### PR TITLE
Release 3.6.5

### DIFF
--- a/.fern/metadata.json
+++ b/.fern/metadata.json
@@ -125,7 +125,7 @@
   "originGitCommit": "f0151a00df5bafb2bbde7018796ce09eddd719e6",
   "originGitCommitIsDirty": false,
   "invokedBy": "ci",
-  "requestedVersion": "3.6.4",
+  "requestedVersion": "3.6.5",
   "ciProvider": "github",
-  "sdkVersion": "3.6.4"
+  "sdkVersion": "3.6.5"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "groundx"
-version = "3.6.4"
+version = "3.6.5"
 description = ""
 readme = "README.md"
 authors = []


### PR DESCRIPTION
## Summary
- bump groundx package release metadata to 3.6.5
- prepare the merged extraction workflow helper API for PyPI publish

## Validation
- python metadata parse confirmed pyproject and Fern metadata report 3.6.5
- poetry check
- poetry build produced groundx-3.6.5 sdist and wheel
- git diff --check