### PR TITLE
[codex] Fix extract prompt object store reliability

### DIFF
--- a/src/groundx/extract/prompt/manager.py
+++ b/src/groundx/extract/prompt/manager.py
@@ -212,26 +212,18 @@ class PromptManager:
 
     def cache_workflow(self, file_name: str, workflow_id: str) -> None:
         if workflow_id in self._cache:
-            version: typing.Optional[str] = None
-            try:
-                version = self._config_source.peek(workflow_id)
-            except Exception as e:
-                self.logger.debug_msg(
-                    f"_config_source.peek exception [{e}]",
-                    workflow_id=workflow_id,
-                )
-
-            if not version:
-                self.logger.debug_msg(
-                    f"_config_source.peek failed\ntrying _cache_source [{file_name}.yaml]...",
-                    workflow_id=workflow_id,
-                )
-                version = self._cache_source.peek(file_name)
+            version, peek_failed = self._peek_workflow_version(file_name, workflow_id)
             if (
                 version
                 and workflow_id in self._versions
                 and self._versions.get(workflow_id) == version
             ):
+                return
+            if not version and peek_failed and workflow_id in self._versions:
+                self.logger.debug_msg(
+                    "workflow version peek unavailable; using cached workflow",
+                    workflow_id=workflow_id,
+                )
                 return
             if version and workflow_id in self._versions:
                 self.logger.info_msg(
@@ -263,6 +255,36 @@ class PromptManager:
         self._final_group_metadata[workflow_id] = prepared.final_group_metadata
         self._workflow_group_metadata[workflow_id] = prepared.workflow_group_metadata
         self._versions[workflow_id] = version
+
+    def _peek_workflow_version(
+        self, file_name: str, workflow_id: str
+    ) -> typing.Tuple[typing.Optional[str], bool]:
+        version: typing.Optional[str] = None
+        peek_failed = False
+        try:
+            version = self._config_source.peek(workflow_id)
+        except Exception as e:
+            peek_failed = True
+            self.logger.debug_msg(
+                f"_config_source.peek exception [{e}]",
+                workflow_id=workflow_id,
+            )
+
+        if not version:
+            self.logger.debug_msg(
+                f"_config_source.peek failed\ntrying _cache_source [{file_name}.yaml]...",
+                workflow_id=workflow_id,
+            )
+            try:
+                version = self._cache_source.peek(file_name)
+            except Exception as e:
+                peek_failed = True
+                self.logger.debug_msg(
+                    f"_cache_source.peek exception [{e}]",
+                    workflow_id=workflow_id,
+                )
+
+        return version, peek_failed
 
     def _fetch_workflow_config(
         self, file_name: str, workflow_id: str
@@ -634,25 +656,17 @@ class PromptManager:
     def reload_if_changed(self, workflow_id: typing.Optional[str] = None) -> None:
         workflow_id = self.workflow_id(workflow_id)
 
-        current_version: typing.Optional[str] = None
-        try:
-            current_version = self._config_source.peek(workflow_id)
-        except Exception as e:
+        previous_version = self._versions.get(workflow_id)
+        current_version, peek_failed = self._peek_workflow_version(
+            self.file_name(None), workflow_id
+        )
+
+        if previous_version and not current_version and peek_failed:
             self.logger.debug_msg(
-                f"_config_source.peek exception [{e}]",
+                "workflow version peek unavailable; keeping cached workflow",
                 workflow_id=workflow_id,
             )
-
-        if not current_version:
-            try:
-                current_version = self._cache_source.peek(self.file_name(None))
-            except Exception as e:
-                self.logger.debug_msg(
-                    f"_cache_source.peek exception [{e}]",
-                    workflow_id=workflow_id,
-                )
-
-        previous_version = self._versions.get(workflow_id)
+            return
 
         if not previous_version or current_version != previous_version:
             raw, version = self._fetch_workflow_config(

--- a/src/groundx/extract/services/upload_minio.py
+++ b/src/groundx/extract/services/upload_minio.py
@@ -69,7 +69,10 @@ class MinIOClient:
                 self.parse_url(url),
             )
 
-            return response.read()
+            try:
+                return response.read()
+            finally:
+                self._close_response(response)
         except S3Error as e:
             self.logger.error_msg(
                 f"Failed to get object from [{url}] [{self.parse_url(url)}]: {str(e)}"
@@ -97,7 +100,10 @@ class MinIOClient:
                 self.parse_url(url),
             )
 
-            body = response.read()
+            try:
+                body = response.read()
+            finally:
+                self._close_response(response)
 
             return body, meta
         except S3Error as e:
@@ -184,6 +190,16 @@ class MinIOClient:
         except S3Error as e:
             self.logger.error_msg(f"Failed to put object in [{bucket}/{key}]: {str(e)}")
             raise
+
+    @staticmethod
+    def _close_response(response: typing.Any) -> None:
+        close = getattr(response, "close", None)
+        if callable(close):
+            close()
+
+        release_conn = getattr(response, "release_conn", None)
+        if callable(release_conn):
+            release_conn()
 
     def put_json_stream(
         self,

--- a/src/groundx/extract/services/upload_s3.py
+++ b/src/groundx/extract/services/upload_s3.py
@@ -33,7 +33,7 @@ class S3Client:
 
             response = self.client.get_object(Bucket=s3_bucket, Key=s3_key)
 
-            return response.get("Body").read()
+            return self._read_body(response)
         except Exception as e:
             self.logger.error_msg(f"[{url}] exception: {e}")
             raise
@@ -50,12 +50,9 @@ class S3Client:
 
             response = self.client.get_object(Bucket=s3_bucket, Key=s3_key)
 
-            body = response.get("Body").read()
+            body = self._read_body(response)
 
-            return body, {
-                "ETag": response.get("ETag", ""),
-                "LastModified": str(response.get("LastModified").timestamp()),
-            }
+            return body, self._metadata_from_response(response)
 
         except Exception as e:
             self.logger.error_msg(f"[{url}] exception: {e}")
@@ -71,10 +68,7 @@ class S3Client:
 
             response = self.client.head_object(Bucket=s3_bucket, Key=s3_key)
 
-            return {
-                "ETag": response.get("ETag", ""),
-                "LastModified": str(response.get("LastModified").timestamp()),
-            }
+            return self._metadata_from_response(response)
         except Exception as e:
             self.logger.error_msg(f"[{url}] exception: {e}")
             raise
@@ -108,6 +102,37 @@ class S3Client:
             Body=data,
             ContentType=content_type,
         )
+
+    @staticmethod
+    def _read_body(response: typing.Dict[str, typing.Any]) -> bytes:
+        body = response.get("Body")
+        if body is None:
+            raise Exception("S3 response missing Body")
+
+        try:
+            return typing.cast(bytes, body.read())
+        finally:
+            close = getattr(body, "close", None)
+            if callable(close):
+                close()
+
+    @staticmethod
+    def _metadata_from_response(
+        response: typing.Dict[str, typing.Any]
+    ) -> typing.Dict[str, str]:
+        etag = response.get("ETag", "")
+        metadata: typing.Dict[str, str] = {
+            "ETag": str(etag) if etag is not None else ""
+        }
+
+        last_modified = response.get("LastModified")
+        if last_modified:
+            timestamp = getattr(last_modified, "timestamp", None)
+            metadata["LastModified"] = str(
+                timestamp() if callable(timestamp) else last_modified
+            )
+
+        return metadata
 
     def put_json_stream(
         self,

--- a/tests/extract/prompt/test_manager.py
+++ b/tests/extract/prompt/test_manager.py
@@ -29,6 +29,27 @@ class FailingSource(TestSource):
         return None
 
 
+class FlakyCachedSource(TestSource):
+    def __init__(self, raw: str) -> None:
+        super().__init__(raw)
+        self.fetch_calls = 0
+        self.peek_calls = 0
+        self.fail_fetch = False
+        self.fail_peek = False
+
+    def fetch(self, workflow_id: str) -> typing.Tuple[str, str]:
+        self.fetch_calls += 1
+        if self.fail_fetch:
+            raise Exception(f"fetch unavailable [{workflow_id}]")
+        return super().fetch(workflow_id)
+
+    def peek(self, workflow_id: str) -> typing.Optional[str]:
+        self.peek_calls += 1
+        if self.fail_peek:
+            raise Exception(f"peek unavailable [{workflow_id}]")
+        return super().peek(workflow_id)
+
+
 CUSTOM_WORKFLOW_YAML = """
 workflow:
   template:
@@ -571,6 +592,33 @@ Special Instructions:
             provider.prompt.instructions,
             "Return the updated provider name.",
         )
+
+    def test_cached_workflow_survives_source_peek_failure(self) -> None:
+        source = FlakyCachedSource(SAMPLE_YAML_1)
+        manager = PromptManager(cache_source=source, config_source=source)
+        self.assertEqual(source.fetch_calls, 1)
+
+        source.fail_peek = True
+        source.fail_fetch = True
+
+        fields = manager.get_fields_for_workflow()
+
+        self.assertIn("statement", fields)
+        self.assertEqual(source.fetch_calls, 1)
+
+    def test_reload_if_changed_keeps_cache_when_source_peek_fails(self) -> None:
+        source = FlakyCachedSource(SAMPLE_YAML_1)
+        manager = PromptManager(cache_source=source, config_source=source)
+        self.assertEqual(source.fetch_calls, 1)
+
+        source.fail_peek = True
+        source.fail_fetch = True
+
+        manager.reload_if_changed()
+        fields = manager.get_fields_for_workflow()
+
+        self.assertIn("statement", fields)
+        self.assertEqual(source.fetch_calls, 1)
 
     def test_prepare_extraction_yaml_with_pseudo_groups(self) -> None:
         prepared = prepare_extraction_yaml(SAMPLE_YAML_PSEUDO_GROUPS)

--- a/tests/extract/services/test_upload_minio.py
+++ b/tests/extract/services/test_upload_minio.py
@@ -1,15 +1,49 @@
 import unittest
+import contextlib
+import sys
+import types
+import typing
 
 from groundx.extract.services.logger import Logger
 from groundx.extract.settings.settings import ContainerSettings, ContainerUploadSettings
 from groundx.extract.services.upload_minio import MinIOClient
 
 
-class TestMinIOClient(unittest.TestCase):
-    def test_load_parse_url_1(self) -> None:
-        logger = Logger("parse_url", "debug")
+class FakeMinioResponse:
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+        self.closed = False
+        self.released = False
 
-        cl = MinIOClient(
+    def read(self) -> bytes:
+        return self.body
+
+    def close(self) -> None:
+        self.closed = True
+
+    def release_conn(self) -> None:
+        self.released = True
+
+
+class FakeMinioClient:
+    def __init__(self) -> None:
+        self.response = FakeMinioResponse(b"statement: {}")
+
+    def get_object(self, bucket: str, key: str) -> FakeMinioResponse:
+        return self.response
+
+    def stat_object(self, bucket: str, key: str) -> typing.Any:
+        return type(
+            "Stat",
+            (),
+            {"etag": "etag-1", "last_modified": None},
+        )()
+
+
+class TestMinIOClient(unittest.TestCase):
+    def _client(self) -> MinIOClient:
+        logger = Logger("parse_url", "debug")
+        return MinIOClient(
             settings=ContainerSettings(
                 broker="",
                 service="parse_url",
@@ -23,6 +57,9 @@ class TestMinIOClient(unittest.TestCase):
             ),
             logger=logger,
         )
+
+    def test_load_parse_url_1(self) -> None:
+        cl = self._client()
 
         obj = cl.parse_url("/eyelevel/layout")
         self.assertEqual(obj, "layout")
@@ -46,3 +83,59 @@ class TestMinIOClient(unittest.TestCase):
             obj,
             "layout/raw/prod/db5915cc-69ae-4cea-884e-fa029712cd16/78b97664-47ac-4363-89d9-9004938d8161/1.jpg",
         )
+
+    def test_get_object_closes_response(self) -> None:
+        cl = self._client()
+        fake = FakeMinioClient()
+        cl.client = typing.cast(typing.Any, fake)
+
+        with fake_minio_error_module():
+            body = cl.get_object("s3://eyelevel/workflows/extract/latest.yaml")
+
+        self.assertEqual(body, b"statement: {}")
+        self.assertTrue(fake.response.closed)
+        self.assertTrue(fake.response.released)
+
+    def test_get_object_and_metadata_closes_response(self) -> None:
+        cl = self._client()
+        fake = FakeMinioClient()
+        cl.client = typing.cast(typing.Any, fake)
+
+        with fake_minio_error_module():
+            body, metadata = typing.cast(
+                typing.Tuple[bytes, typing.Dict[str, str]],
+                cl.get_object_and_metadata(
+                    "s3://eyelevel/workflows/extract/latest.yaml"
+                ),
+            )
+
+        self.assertEqual(body, b"statement: {}")
+        self.assertEqual(metadata, {"ETag": "etag-1"})
+        self.assertTrue(fake.response.closed)
+        self.assertTrue(fake.response.released)
+
+
+@contextlib.contextmanager
+def fake_minio_error_module() -> typing.Iterator[None]:
+    previous_minio = sys.modules.get("minio")
+    previous_error = sys.modules.get("minio.error")
+
+    minio_module = types.ModuleType("minio")
+    error_module = types.ModuleType("minio.error")
+    setattr(error_module, "S3Error", Exception)
+    setattr(minio_module, "error", error_module)
+
+    sys.modules["minio"] = minio_module
+    sys.modules["minio.error"] = error_module
+    try:
+        yield
+    finally:
+        if previous_minio is None:
+            sys.modules.pop("minio", None)
+        else:
+            sys.modules["minio"] = previous_minio
+
+        if previous_error is None:
+            sys.modules.pop("minio.error", None)
+        else:
+            sys.modules["minio.error"] = previous_error

--- a/tests/extract/services/test_upload_s3.py
+++ b/tests/extract/services/test_upload_s3.py
@@ -1,0 +1,83 @@
+import typing
+import unittest
+
+from groundx.extract.services.logger import Logger
+from groundx.extract.services.upload_s3 import S3Client
+from groundx.extract.settings.settings import ContainerSettings, ContainerUploadSettings
+
+
+class FakeBody:
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+        self.closed = False
+
+    def read(self) -> bytes:
+        return self.body
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeS3Client:
+    def __init__(self) -> None:
+        self.body = FakeBody(b"statement: {}")
+
+    def get_object(self, Bucket: str, Key: str) -> typing.Dict[str, typing.Any]:
+        return {
+            "Body": self.body,
+            "ETag": '"etag-1"',
+        }
+
+    def head_object(self, Bucket: str, Key: str) -> typing.Dict[str, typing.Any]:
+        return {"ETag": '"etag-1"'}
+
+
+class TestS3Client(unittest.TestCase):
+    def _client(self) -> S3Client:
+        logger = Logger("s3", "debug")
+        return S3Client(
+            settings=ContainerSettings(
+                broker="",
+                service="s3",
+                upload=ContainerUploadSettings(
+                    base_domain="",
+                    bucket="eyelevel",
+                    type="",
+                    url="",
+                ),
+                workers=1,
+            ),
+            logger=logger,
+        )
+
+    def test_get_object_closes_body(self) -> None:
+        cl = self._client()
+        fake = FakeS3Client()
+        cl.client = typing.cast(typing.Any, fake)
+
+        body = cl.get_object("s3://eyelevel/workflows/extract/latest.yaml")
+
+        self.assertEqual(body, b"statement: {}")
+        self.assertTrue(fake.body.closed)
+
+    def test_get_object_and_metadata_handles_missing_last_modified(self) -> None:
+        cl = self._client()
+        fake = FakeS3Client()
+        cl.client = typing.cast(typing.Any, fake)
+
+        body, metadata = typing.cast(
+            typing.Tuple[bytes, typing.Dict[str, str]],
+            cl.get_object_and_metadata("s3://eyelevel/workflows/extract/latest.yaml"),
+        )
+
+        self.assertEqual(body, b"statement: {}")
+        self.assertEqual(metadata, {"ETag": '"etag-1"'})
+        self.assertTrue(fake.body.closed)
+
+    def test_head_object_handles_missing_last_modified(self) -> None:
+        cl = self._client()
+        cl.client = typing.cast(typing.Any, FakeS3Client())
+
+        metadata = cl.head_object("s3://eyelevel/workflows/extract/latest.yaml")
+
+        self.assertEqual(metadata, {"ETag": '"etag-1"'})


### PR DESCRIPTION
## Summary
- keep PromptManager using its in-memory workflow cache when S3/MinIO version peeks fail after a workflow is already loaded
- close and release MinIO responses after object reads
- close S3 response bodies after reads and tolerate missing LastModified metadata
- add regression coverage for flaky prompt metadata checks and S3/MinIO object-store reads

## Root Cause
PromptManager treated transient object-store metadata failures like a cache miss and could fall through to another fetch path. MinIO and S3 reads also left response resources open, and S3 metadata parsing assumed LastModified was always present.

## Validation
- poetry run mypy .
- poetry run pytest -rP -n auto .
- git diff --check