### PR TITLE
[codex] Consolidate extraction workflow SDK changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,48 @@ client.ingest(
 )
 ```
 
+## Extraction Workflows
+
+Extraction workflow helpers require the extract extra:
+
+```sh
+pip install "groundx[extract]"
+```
+
+Create or update an extraction workflow directly from a YAML file:
+
+```python
+from groundx import GroundX
+
+client = GroundX(api_key="YOUR_API_KEY")
+
+workflow = client.create_extraction_workflow(
+    path="statement.yaml",
+    name="statement extraction",
+)
+
+client.update_extraction_workflow(
+    workflow.workflow.workflow_id,
+    path="statement.yaml",
+    name="statement extraction",
+)
+```
+
+Load an extraction definition when you need to inspect or reuse settings:
+
+```python
+definition = client.load_extraction_definition(path="statement.yaml")
+existing = client.load_extraction_definition(workflow_id="workflow-id")
+```
+
+If `workflow_id` is provided, the SDK loads from that workflow before considering
+YAML inputs. For create/update, pass `path=...` directly for the common case or
+pass `definition=...` when you already loaded one; `definition` takes precedence
+over YAML inputs.
+
+Workflow assignment is still explicit. After creating a workflow, assign it to a
+bucket, group, or account with the normal workflow API.
+
 ## Async Client
 
 The SDK also exports an `async` client so that you can make non-blocking calls to our API.

--- a/openspec/changes/add-extraction-workflow-convenience-methods/design.md
+++ b/openspec/changes/add-extraction-workflow-convenience-methods/design.md
@@ -1,0 +1,352 @@
+# Design: Extraction Workflow Definition Methods
+
+## Selected Approach
+
+Add a hand-written, high-level extraction definition layer in the Python SDK:
+
+- `GroundX.load_extraction_definition(...)`
+- `GroundX.load_extraction_definition_from_yaml(...)`
+- `GroundX.load_extraction_definition_from_workflow(...)`
+- `GroundX.create_extraction_workflow(...)`
+- `GroundX.update_extraction_workflow(...)`
+- async parity on `AsyncGroundX`
+
+The consolidated load method returns an SDK-owned `ExtractionDefinition` object
+from a workflow ID or from one YAML/prepared source. If `workflow_id` is set, it
+takes precedence over lower-priority YAML/prepared inputs. The source-specific
+load methods remain available as explicit aliases. The create and update
+methods accept either an `ExtractionDefinition` or a YAML/prepared source, then
+delegate to the existing generated workflow create/update clients.
+
+The generated Fern workflow client remains available for direct low-level use.
+`prepare_extraction_yaml(...)`, `load_from_yaml(...)`, `load_from_mapping(...)`,
+and mapping-to-`Group` helpers remain available as advanced building blocks, but
+they are not the promoted path for humans, public docs, harnesses, or
+`internal-arcadia-agents`.
+
+## Public SDK Shape
+
+Promoted path from YAML:
+
+```python
+workflow = client.create_extraction_workflow(
+    path="statement.yaml",
+    name="statement extraction",
+)
+
+updated = client.update_extraction_workflow(
+    "workflow-id",
+    path="statement.yaml",
+    name="statement extraction",
+)
+```
+
+Promoted reusable definition path:
+
+```python
+definition = client.load_extraction_definition(path="statement.yaml")
+existing = client.load_extraction_definition(workflow_id="workflow-id")
+```
+
+Explicit alias paths for callers who want source-specific method names:
+
+```python
+definition = client.load_extraction_definition_from_yaml(path="statement.yaml")
+existing = client.load_extraction_definition_from_workflow("workflow-id")
+```
+
+The common YAML source is `path=...`, and public docs should show it directly
+on create/update for the one-shot create or update workflow. Callers use
+`ExtractionDefinition` when they need to inspect, reuse, or copy workflow
+settings, especially from an existing workflow ID. Advanced and test callers may
+pass `yaml_text`, `mapping`, or `prepared` explicitly. For create/update,
+`definition` takes precedence when supplied; otherwise callers pass exactly one
+of these YAML/prepared sources:
+
+- `path`: local filesystem path to read as UTF-8 YAML.
+- `yaml_text`: raw YAML text.
+- `mapping`: an authored YAML-shaped mapping by default. Advanced callers may
+  pass an existing workflow `extract` mapping only with
+  `mapping_kind="workflow_extract"`. Persisted/execution `extract` mappings may
+  load with `prepared=None` when authored YAML metadata is unavailable.
+- `prepared`: an existing `PreparedExtractionYaml`.
+
+Without `definition`, exactly one YAML/prepared source is required for
+create/update. Without `workflow_id`, exactly one YAML/prepared source is
+required for the consolidated loader. This avoids ambiguous behavior where a
+string might be either raw YAML text or a filesystem path.
+
+## Definition Contract
+
+`ExtractionDefinition` is the high-level object humans and agents should hold
+when they need to inspect, reuse, create, or update extraction workflow
+configuration.
+
+Suggested shape:
+
+```python
+@dataclass(frozen=True)
+class ExtractionDefinition:
+    extract: Mapping[str, Any]
+    prepared: PreparedExtractionYaml | None = None
+    template: Mapping[str, str] | None = None
+    custom_steps: Sequence[Mapping[str, Any]] | None = None
+    output_routes: Sequence[Mapping[str, Any]] | None = None
+    leaf_fields: Sequence[Mapping[str, Any]] | None = None
+    chunk_strategy: Any | None = None
+    section_strategy: Any | None = None
+    steps: Any | None = None
+```
+
+The final implementation may add small convenience properties if tests prove
+they are needed. The normal definition-loading path should not expose generated
+Fern classes.
+
+`ExtractionDefinition` normalizes generated workflow response models into plain
+Python data suitable for the generated workflow client. In particular,
+`template` is a string-to-string mapping. Non-string template values are invalid
+for this helper and should raise a clear `ValueError` rather than being coerced
+silently. Placeholder-style keys such as `{{LANGUAGE}}` and
+`{{LANGUAGE_UNKNOWN}}` are plain string keys and must be preserved exactly,
+including an empty string value for `{{LANGUAGE_UNKNOWN}}` when supplied.
+
+`load_extraction_definition(...)` is the promoted loader. When `workflow_id` is
+provided, it dispatches to the workflow loader before considering
+YAML/prepared inputs. Otherwise it accepts exactly one of `path`, `yaml_text`,
+`mapping`, or `prepared` and dispatches to the YAML/prepared loader.
+
+`load_extraction_definition_from_yaml(...)` prepares authored YAML through the
+existing `prepare_extraction_yaml(...)` path, then wraps the prepared result in
+`ExtractionDefinition`. YAML-loaded definitions always have `prepared`.
+When `mapping_kind` is omitted or set to `"authored_yaml"`, `mapping` follows
+the same preparation path as `yaml_text`. When `mapping_kind` is
+`"workflow_extract"`, the loader treats `mapping` as an existing workflow
+`extract` payload, preserves it directly, and only sets `prepared` if the
+persisted extract can be round-tripped through `prepare_extraction_yaml(...)`.
+This explicit selector is required because a simple authored YAML mapping and a
+simple execution-only workflow extract mapping can both be dictionaries whose
+top-level keys are group names.
+
+`load_extraction_definition_from_workflow(workflow_id)` calls the generated
+workflow read/get API with the workflow ID, extracts the workflow's `extract`
+mapping and workflow-level extraction settings, then returns the same
+`ExtractionDefinition` shape. Top-level workflow response fields
+(`template`, `custom_steps`, `output_routes`, `leaf_fields`, `chunk_strategy`,
+`section_strategy`, and `steps`) are authoritative when present. When those
+fields are absent, the loader may fall back to persisted metadata under
+`extract["workflow"]`.
+
+Workflow-loaded definitions only have `prepared` when the persisted extract can
+be round-tripped through `prepare_extraction_yaml(...)`, usually because
+`_groundx_persisted_extract` is present. If the workflow only contains execution
+groups and workflow-level settings, return `prepared=None` instead of inventing
+authored metadata. If the workflow does not contain an extraction `extract`
+mapping, raise a clear exception naming the workflow ID.
+
+## Workflow Kwargs Assembly
+
+Create/update methods consume `ExtractionDefinition` and internally build the
+same workflow settings callers currently write by hand:
+
+- `extract` is `definition.extract`.
+- `template` is copied from `definition.template` when present, after verifying
+  all template values are strings.
+- `custom_steps` is copied from `definition.custom_steps` when present.
+- `output_routes` is copied from `definition.output_routes` when present.
+- `leaf_fields` is copied from `definition.leaf_fields` when present.
+- `name` is included when supplied.
+- `chunk_strategy` defaults to `"element"` for extraction workflow helpers and
+  can be set to `None` to omit it. Workflow-loaded definitions may preserve
+  `definition.chunk_strategy` when the caller does not override it.
+- `section_strategy` is included only when supplied or preserved from a
+  workflow-loaded definition.
+- `steps` is included when supplied or preserved from a workflow-loaded
+  definition.
+
+When custom workflow steps are present and `steps` is not supplied, the
+create/update path must include an empty fixed-step overlay so YAML-authored
+custom steps do not accidentally run alongside fixed default steps. The overlay
+is a `WorkflowSteps` value with every known fixed stage set explicitly to
+`None`: `chunk_instruct`, `chunk_keys`, `chunk_summary`, `doc_keys`,
+`doc_summary`, `sect_instruct`, and `sect_summary`. Serialized requests must
+carry those disabled fixed-step keys in the generated wire shape. Legacy YAML
+without custom workflow steps should not receive that overlay unless the caller
+supplies `steps`.
+
+The kwargs assembly may live in a private helper, for example
+`_workflow_kwargs_from_extraction_definition(...)`. It should not be promoted in
+public docs.
+
+## Optional Extract Dependency Boundary
+
+The exported `GroundX` and `AsyncGroundX` clients live in `src/groundx/ingest.py`,
+which is part of the base SDK import path. That file must not import
+`groundx.extract` or optional extract dependencies at module import time. Instead,
+the extraction definition methods lazy-import the extract workflow module inside
+the method body. If the user installed only `groundx` and calls an extraction
+definition method, raise an actionable error that says to install
+`groundx[extract]`.
+
+Tests must prove:
+
+- `import groundx` and `from groundx import GroundX, AsyncGroundX` still work in
+  an environment without extract optional dependencies;
+- non-extraction client methods remain usable without extract extras;
+- base SDK import does not import `groundx.extract` or representative
+  `groundx[extract]` optional dependencies such as `yaml`, `boto3`, `PIL`,
+  `google`, `gspread`, `minio`, `redis`, `celery`, `fastapi`, `openai`, or
+  `smolagents`;
+- calling extraction definition methods without extract extras fails with the
+  install hint rather than an unrelated import traceback.
+
+New hand-written tests under `tests/custom` must also respect the SDK
+regeneration boundary. Before adding another `tests/custom/...` file, update or
+verify `.fernignore` protects that hand-written test surface so the file is not
+lost on the next Fern SDK release.
+
+## Client Methods
+
+`GroundX.load_extraction_definition(...)` loads an `ExtractionDefinition` from a
+workflow ID or from one YAML/prepared source. `workflow_id` uses the workflow
+loader behavior and takes precedence over `path`, `yaml_text`, `mapping`, or
+`prepared`. If `workflow_id` is absent, passing zero or multiple YAML/prepared
+sources raises a clear `ValueError`.
+
+`GroundX.load_extraction_definition_from_yaml(...)` loads authored YAML into
+`ExtractionDefinition`. It remains available as an explicit alias for YAML,
+mapping, and prepared-object sources.
+
+`GroundX.load_extraction_definition_from_workflow(id, ...)` fetches an existing
+workflow and converts its persisted extraction config into
+`ExtractionDefinition`. It remains available as an explicit alias for workflow
+ID sources.
+
+`GroundX.create_extraction_workflow(...)` resolves an `ExtractionDefinition` or
+one YAML/prepared source into workflow kwargs internally, then forwards them to
+`self.workflows.create(...)`. `definition` takes precedence over
+YAML/prepared inputs.
+
+`GroundX.update_extraction_workflow(id, ...)` resolves an `ExtractionDefinition`
+or one YAML/prepared source into workflow kwargs internally, then forwards them
+to `self.workflows.update(id, ...)`. `definition` takes precedence over
+YAML/prepared inputs.
+
+Sync and async loader/create/update paths should use the same source-selection
+helper so `workflow_id`, `definition`, `path`, `yaml_text`, `mapping`,
+`mapping_kind`, and `prepared` validation cannot drift. `mapping_kind` is valid
+only when `mapping` is the selected source. `request_options` is valid only
+when the selected loader source is `workflow_id`.
+
+Create/update methods return the normal generated `WorkflowResponse`. They do
+not return `PreparedExtractionYaml`; callers who need metadata inspection use
+the definition object. Callers who specifically need authored YAML preparation
+metadata use `definition.prepared` when it is present or the lower-level
+`prepare_extraction_yaml(...)` API when they have authored YAML.
+
+Update is a full workflow settings overlay, not a patch. The docs must state
+that callers should pass the YAML or definition again when updating so custom
+workflow settings are not reset by a name-only update.
+
+## Documentation Contract
+
+The promoted extraction definition and workflow methods are hand-written SDK
+convenience methods like `ingest` and `ingest_directories`. They must be
+documented with the same level of prominence:
+
+- SDK method docstrings in `src/groundx/ingest.py` with parameters, return
+  values, sync examples, async examples where relevant, update semantics, and
+  explicit bucket/account assignment follow-up.
+- Public Fern docs with method-level reference sections for
+  `client.load_extraction_definition(...)`,
+  `client.load_extraction_definition_from_yaml(...)`,
+  `client.load_extraction_definition_from_workflow(...)`,
+  `client.create_extraction_workflow(...)`, and
+  `client.update_extraction_workflow(...)`.
+- Harness and plugin references that list these methods as hand-maintained
+  Python SDK helpers beside `ingest` and `ingest_directories`.
+- Harness public extraction-doc guidance, especially
+  `skills/groundx-extraction-workflows/references/public-docs.md`, must be
+  updated from the old `prepare_extraction_yaml(...)` primary flow to the new
+  helper-backed public flow. The primary create/update examples should pass the
+  YAML path directly to `client.create_extraction_workflow(...)` and
+  `client.update_extraction_workflow(...)`; definition-loading examples should
+  be framed as inspection, reuse, or copy-from-existing-workflow operations.
+  Public prose should stay customer-readable; method names may appear in
+  signatures and code examples, but explanatory copy should prefer "YAML",
+  "workflow settings", and "JSON you want back" over internal jargon when
+  possible.
+- Extraction workflow guides that continue to show
+  `client.workflows.add_to_id(...)` or `client.workflows.add_to_account(...)`
+  after workflow creation because assignment is intentionally not implicit.
+- Harness source-of-truth updates that include the owning skill references,
+  evals, scanner expectations, routing/source manifests if behavior or
+  discoverability changes, generated plugin mirrors, and version/changelog
+  surfaces when required by the harness repo.
+- Web UI or scaffold docs touched by this work must preserve the product UI
+  invariant: the base experience is an authenticated app shell, and onboarding
+  is a configurable overlay/app metadata flow for first-session guidance.
+
+Advanced docs may mention `prepare_extraction_yaml(...)`, `load_from_yaml(...)`,
+and `load_from_mapping(...)`, but primary examples should not teach them as the
+normal workflow-management path.
+
+## Error Handling
+
+- Missing source: raise `ValueError` naming the accepted source arguments.
+- Multiple sources: raise `ValueError` naming the conflicting arguments.
+- `mapping_kind` supplied without `mapping` as the selected source: raise
+  `ValueError`.
+- Missing file path: raise `FileNotFoundError`.
+- Workflow ID not found: surface the generated API error.
+- Workflow exists but lacks extraction config: raise a clear error naming the
+  workflow ID.
+- Workflow exists but lacks authored metadata: return an `ExtractionDefinition`
+  with `prepared=None` when create/update can still preserve the workflow
+  payload, and document that authored metadata inspection is unavailable.
+- Invalid YAML, custom-step metadata, route/leaf mismatch, field-count overload,
+  or template errors: surface the existing `prepare_extraction_yaml(...)` error.
+- Template mappings with non-string values: raise `ValueError` naming the
+  offending template key.
+- Missing `name` on create: raise `ValueError`.
+- Omitted `name` on update: allowed; update should send the full extraction
+  settings and omit only the name.
+
+## Fern/OpenAPI Boundary
+
+This change does not rename generated OpenAPI schemas or generated SDK classes.
+The existing generated names remain part of the low-level workflow API. The new
+definition methods reduce normal user exposure to those names without changing
+the server contract.
+
+If schema naming cleanup is still desired, create a separate OpenSpec plan that
+weighs generated SDK import churn, TypeScript generation, docs updates, and
+backward compatibility.
+
+## Repo Impact
+
+`groundx-python` owns the new SDK methods, `ExtractionDefinition`, tests,
+exports, docstrings, and README or reference documentation for the new
+hand-written methods.
+
+`eyelevel-fern-config` updates public docs to replace the manual
+`prepare_extraction_yaml(...)` plus metadata-copying snippet with
+`client.create_extraction_workflow(path=..., name=...)`, an update example,
+`client.load_extraction_definition(...)` docs for YAML and workflow-ID sources,
+explicit alias docs, and method-level documentation matching the existing
+hand-written SDK helpers.
+
+`groundx-studio-harness` updates runtime/deploy templates to prefer the helper
+methods when installed, keeps `workflow_sdk_kwargs(...)` for offline compile
+output and older SDK fallback, and updates scanners/tests/docs including
+architecture and SDK-surface references that currently list `ingest` and
+`ingest_directories`.
+
+`internal-arcadia-agents` evaluates adopting the definition methods for
+load/create/update calls. If the methods can preserve Arcadia's specialized
+metadata-key sets and custom workflow steps, use them. If not, keep the existing
+explicit calls and record why.
+
+`adp-poc` is scanned for manual workflow create/update snippets and updated only
+where it owns executable docs or scripts. The scan found no owned boilerplate to
+update; the prior whitespace-only local change was removed and the worktree is
+clean.

--- a/openspec/changes/add-extraction-workflow-convenience-methods/execution-plan.md
+++ b/openspec/changes/add-extraction-workflow-convenience-methods/execution-plan.md
@@ -1,0 +1,1850 @@
+# Extraction Workflow Definition Methods Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILLS: Use
+> `superpowers:test-driven-development` for each code task and
+> `superpowers:verification-before-completion` before claiming completion.
+> Historical recipe steps use checkbox (`- [ ]`) syntax. Use `tasks.md` for
+> current completion status and blockers.
+
+## Current Status
+
+The authoritative current status lives in `tasks.md`. The detailed phase
+checklist below is retained as the original execution recipe, not as the current
+completion tracker.
+
+As of 2026-06-14:
+
+- Local SDK, Fern docs, harness, Arcadia, and ADP scan work is implemented.
+- Detached ADP support worktree was removed after scan-only verification.
+- Post-review API correction is complete: common create/update examples are
+  path-first, `load_extraction_definition(...)` uses workflow-ID precedence for
+  inspection/reuse/copy workflows, and create/update use `definition` before
+  YAML/prepared inputs.
+- Remaining gates are SDK publish, fresh published-package verification, and
+  draft-only downstream docs/harness merge gates.
+
+**Goal:** Give humans and automation first-class SDK operations to create or
+update extraction workflows directly from YAML, load an extraction definition
+from YAML or an existing workflow ID when inspection/reuse is needed, and keep
+explicit source-specific loader aliases for advanced callers.
+
+**Architecture:** Add an SDK-owned `ExtractionDefinition` object in the
+hand-written extract surface. Client methods load definitions from YAML or
+workflow responses, then create/update methods assemble generated workflow API
+kwargs internally and delegate to the existing generated workflow client.
+
+**Tech Stack:** Python SDK, Fern-generated workflow client surfaces, PyYAML,
+pytest, mypy/pyright where configured, Fern docs, harness Node/Python scanners.
+
+---
+
+## Ground Rules
+
+- Do not edit generated Fern files by hand.
+- Do not rename OpenAPI schemas in this convenience-method change.
+- Do not remove or change `prepare_extraction_yaml(...)`,
+  `PreparedExtractionYaml`, `load_from_yaml(...)`, or `load_from_mapping(...)`.
+- Do not make base SDK imports depend on the optional `extract` extra. The
+  exported client module must lazy-import extraction helpers inside extraction
+  methods and raise an actionable `pip install groundx[extract]` hint when the
+  extra is missing.
+- Do not promote kwargs-assembly helpers as a public technique. If needed, keep
+  them private/internal, for example `_workflow_kwargs_from_extraction_definition(...)`.
+- Do not remove harness `workflow_sdk_kwargs(...)` until the helper methods
+  exist in a released minimum SDK version and fallback removal is separately
+  approved.
+- Do not touch dirty unrelated worktrees.
+- Run an adversarial review after each repo checkpoint.
+- Publishing and downstream dependency bumps remain blocked by the existing
+  custom-step deployed-path e2e blocker.
+- If GroundX Studio Harness web UI, publish, scaffold, or onboarding docs are
+  touched, preserve the product invariant that the base experience is an
+  authenticated app shell and onboarding is a configurable overlay/app metadata
+  flow.
+
+## Phase 0: OpenSpec Baseline
+
+**Files:**
+
+- Create:
+  `/Users/benjaminfletcher/git/groundx-python/openspec/changes/add-extraction-workflow-convenience-methods/proposal.md`
+- Create:
+  `/Users/benjaminfletcher/git/groundx-python/openspec/changes/add-extraction-workflow-convenience-methods/design.md`
+- Create:
+  `/Users/benjaminfletcher/git/groundx-python/openspec/changes/add-extraction-workflow-convenience-methods/tasks.md`
+- Create:
+  `/Users/benjaminfletcher/git/groundx-python/openspec/changes/add-extraction-workflow-convenience-methods/execution-plan.md`
+- Create:
+  `/Users/benjaminfletcher/git/groundx-python/openspec/changes/add-extraction-workflow-convenience-methods/specs/extraction-workflow-convenience/spec.md`
+
+- [x] Run:
+
+  ```bash
+  OPENSPEC_TELEMETRY=0 npx @fission-ai/openspec@1.3.1 validate add-extraction-workflow-convenience-methods --strict
+  ```
+
+  Expected: `Change 'add-extraction-workflow-convenience-methods' is valid`.
+
+- [ ] Commit or leave the planning files staged according to the user's
+      requested workflow.
+
+## Phase 0.5: Refresh Implementation Branches
+
+**Why:** The implementation worktrees were created before the workflow-template
+closeout work was merged. Starting from stale branches can reintroduce old docs,
+miss `.fernignore` protections, or hide conflicts until PR time.
+
+- [ ] Refresh the SDK implementation branch:
+
+  ```bash
+  cd /Users/benjaminfletcher/git/groundx-python-support-custom-workflow-steps-sdk
+  git fetch origin --prune
+  git status --short --branch
+  test -z "$(git status --porcelain)" || { git status --short; echo "worktree dirty; stop before rebase"; exit 1; }
+  git rebase origin/main
+  poetry run pytest tests/extract/prompt/test_persisted_workflow_extract.py -q
+  git diff --check
+  ```
+
+  Expected: branch is based on current `origin/main`, existing custom-step work
+  still passes its narrow extraction YAML gate, and only intended branch changes
+  remain.
+
+- [ ] Refresh the Fern docs branch:
+
+  ```bash
+  cd /Users/benjaminfletcher/git/eyelevel-fern-config
+  git fetch origin --prune
+  git status --short --branch
+  test -z "$(git status --porcelain)" || { git status --short; echo "worktree dirty; stop before rebase"; exit 1; }
+  git rebase origin/main
+  fern check
+  git diff --check
+  ```
+
+  Expected: branch includes the merged workflow-template docs closeout before
+  the convenience-method docs edits start.
+
+- [ ] Refresh the GroundX Studio Harness branch:
+
+  ```bash
+  cd /Users/benjaminfletcher/git/groundx-studio-harness-support-custom-workflow-steps
+  git fetch origin --prune
+  git status --short --branch
+  test -z "$(git status --porcelain)" || { git status --short; echo "worktree dirty; stop before rebase"; exit 1; }
+  git rebase origin/main
+  python -m pytest skills/groundx-extraction-workflows/templates/test_compile_workflow.py -q
+  node scripts/validate.mjs
+  git diff --check
+  ```
+
+  Expected: branch includes the merged workflow-template closeout and the
+  current plugin validation baseline before helper-preference edits start.
+
+- [ ] Refresh the Arcadia branch before Phase 4 edits:
+
+  ```bash
+  cd /Users/benjaminfletcher/git/internal-arcadia-agents
+  git fetch origin --prune
+  git status --short --branch
+  test -z "$(git status --porcelain)" || { git status --short; echo "worktree dirty; stop before rebase"; exit 1; }
+  UPSTREAM="$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null)" || { echo "no upstream configured; stop and ask for target branch"; exit 1; }
+  git rebase "$UPSTREAM"
+  pytest prompts/test_arcadia_manager.py -q
+  git diff --check
+  ```
+
+  Expected: Arcadia is clean, current with its configured upstream, and the
+  prompt-manager baseline passes before helper-equivalence tests are added.
+
+- [x] Close the detached ADP support worktree before Phase 5 edits:
+
+  ```bash
+  git -C /Users/benjaminfletcher/git/adp-poc worktree list --porcelain
+  test ! -e /Users/benjaminfletcher/git/adp-poc-support-custom-workflow-steps
+  ```
+
+  Expected: detached ADP support worktree is removed if it has no local work.
+  ADP scan work continues only in `/Users/benjaminfletcher/git/adp-poc`.
+
+- [ ] If any rebase conflicts, stop in that worktree, resolve only the conflict,
+      rerun that branch's narrow gate, and record the conflict resolution before
+      continuing to Phase 1.
+- [ ] If any worktree is dirty, stop before rebasing. Identify whether the dirty
+      files are user work, generated output, or previous plan work, then ask for
+      direction before stashing, committing, or editing those files.
+
+## Phase 1: groundx-python SDK
+
+**Repo:** `/Users/benjaminfletcher/git/groundx-python-support-custom-workflow-steps-sdk`
+
+**Files:**
+
+- Create: `src/groundx/extract/workflows.py`
+- Modify: `src/groundx/extract/__init__.py`
+- Modify: `src/groundx/ingest.py`
+- Modify: `.fernignore`
+- Modify: `README.md`
+- Test: `tests/extract/test_extraction_workflow_definitions.py`
+- Test: `tests/extract/test_import_boundaries.py`
+- Test: `tests/custom/test_extraction_workflow_client_exports.py`
+
+### Task 1: Add Failing Definition Loader Tests
+
+- [ ] Create `tests/extract/test_extraction_workflow_definitions.py` with tests
+      for the high-level API:
+
+  ```python
+  from pathlib import Path
+
+  import pytest
+
+  from groundx.extract import ExtractionDefinition, prepare_extraction_yaml
+
+
+  CUSTOM_WORKFLOW_YAML = """
+  workflow:
+    template:
+      "{{LANGUAGE}}": English
+      "{{LANGUAGE_UNKNOWN}}": ""
+    custom_steps:
+      - name: line_item_labels
+        level: chunk
+        kind: keys
+        required_template_keys:
+          - "{{LANGUAGE}}"
+  invoice:
+    fields:
+      invoice_number:
+        prompt:
+          description: Invoice number.
+          type: str
+  line_items:
+    workflow_step: line_item_labels
+    fields:
+      description:
+        workflow_output_key: label
+        prompt:
+          description: Line item description.
+          type: str
+  """
+
+
+  def test_load_extraction_definition_from_yaml_path(tmp_path: Path) -> None:
+      from groundx import GroundX
+
+      yaml_path = tmp_path / "statement.yaml"
+      yaml_path.write_text(CUSTOM_WORKFLOW_YAML, encoding="utf-8")
+      client = GroundX(api_key="test")
+
+      definition = client.load_extraction_definition_from_yaml(path=yaml_path)
+
+      assert isinstance(definition, ExtractionDefinition)
+      assert definition.extract["workflow"]["template"]["{{LANGUAGE}}"]
+      assert definition.custom_steps[0]["name"] == "line_item_labels"
+      assert definition.output_routes
+      assert definition.leaf_fields
+
+
+  def test_load_extraction_definition_from_yaml_requires_one_source(
+      tmp_path: Path,
+  ) -> None:
+      from groundx import GroundX
+
+      yaml_path = tmp_path / "statement.yaml"
+      yaml_path.write_text(CUSTOM_WORKFLOW_YAML, encoding="utf-8")
+      client = GroundX(api_key="test")
+
+      with pytest.raises(ValueError, match="exactly one"):
+          client.load_extraction_definition_from_yaml()
+
+      with pytest.raises(ValueError, match="exactly one"):
+          client.load_extraction_definition_from_yaml(
+              path=yaml_path,
+              yaml_text=CUSTOM_WORKFLOW_YAML,
+          )
+
+
+  def test_load_extraction_definition_from_prepared() -> None:
+      from groundx import GroundX
+
+      client = GroundX(api_key="test")
+      prepared = prepare_extraction_yaml(CUSTOM_WORKFLOW_YAML)
+
+      definition = client.load_extraction_definition_from_yaml(prepared=prepared)
+
+      assert definition.prepared == prepared
+      assert definition.extract == prepared.persisted_workflow_extract
+
+
+  def test_load_extraction_definition_from_authored_yaml_mapping() -> None:
+      import yaml
+      from groundx import GroundX
+
+      client = GroundX(api_key="test")
+      authored_mapping = yaml.safe_load(CUSTOM_WORKFLOW_YAML)
+
+      definition = client.load_extraction_definition_from_yaml(
+          mapping=authored_mapping,
+      )
+
+      assert definition.prepared is not None
+      assert definition.template["{{LANGUAGE}}"] == "English"
+      assert definition.template["{{LANGUAGE_UNKNOWN}}"] == ""
+
+
+  def test_load_extraction_definition_from_persisted_extract_mapping_requires_explicit_kind() -> None:
+      from groundx import GroundX
+
+      client = GroundX(api_key="test")
+      prepared = prepare_extraction_yaml(CUSTOM_WORKFLOW_YAML)
+
+      definition = client.load_extraction_definition_from_yaml(
+          mapping=prepared.persisted_workflow_extract,
+          mapping_kind="workflow_extract",
+      )
+
+      assert definition.extract == prepared.persisted_workflow_extract
+      assert definition.prepared is not None
+
+
+  def test_load_extraction_definition_from_execution_extract_mapping_sets_prepared_none() -> None:
+      from groundx import GroundX
+
+      client = GroundX(api_key="test")
+      execution_extract = {
+          "invoice": {
+              "fields": {
+                  "invoice_number": {
+                      "prompt": {
+                          "description": "Invoice number.",
+                          "type": "str",
+                      }
+                  }
+              }
+          }
+      }
+
+      definition = client.load_extraction_definition_from_yaml(
+          mapping=execution_extract,
+          mapping_kind="workflow_extract",
+      )
+
+      assert definition.extract == execution_extract
+      assert definition.prepared is None
+
+
+  def test_load_extraction_definition_rejects_non_string_template_values() -> None:
+      import yaml
+      from groundx import GroundX
+
+      client = GroundX(api_key="test")
+      authored_mapping = yaml.safe_load(CUSTOM_WORKFLOW_YAML)
+      authored_mapping["workflow"]["template"]["{{LANGUAGE}}"] = 123
+
+      with pytest.raises(ValueError, match="{{LANGUAGE}}"):
+          client.load_extraction_definition_from_yaml(mapping=authored_mapping)
+  ```
+
+- [ ] Add tests for loading from a workflow ID:
+
+  ```python
+  from groundx.types.workflow_detail import WorkflowDetail
+  from groundx.types.workflow_response import WorkflowResponse
+
+
+  class FakeWorkflows:
+      def __init__(self, response):
+          self.response = response
+          self.requested_id = None
+
+      def get(self, id):
+          self.requested_id = id
+          return self.response
+
+
+  def test_load_extraction_definition_from_workflow_id() -> None:
+      from groundx import GroundX
+
+      prepared = prepare_extraction_yaml(CUSTOM_WORKFLOW_YAML)
+      client = GroundX(api_key="test")
+      client._workflows = FakeWorkflows(
+          {"workflow": {"workflow_id": "wf-1", "extract": prepared.persisted_workflow_extract}}
+      )
+
+      definition = client.load_extraction_definition_from_workflow("wf-1")
+
+      assert client.workflows.requested_id == "wf-1"
+      assert definition.extract == prepared.persisted_workflow_extract
+      assert definition.custom_steps[0]["name"] == "line_item_labels"
+
+
+  def test_load_extraction_definition_from_generated_workflow_response_preserves_top_level_settings() -> None:
+      from groundx import GroundX
+
+      prepared = prepare_extraction_yaml(CUSTOM_WORKFLOW_YAML)
+      response = WorkflowResponse(
+          workflow=WorkflowDetail(
+              workflow_id="wf-1",
+              extract=prepared.persisted_workflow_extract,
+              template={"{{LANGUAGE}}": "French", "{{LANGUAGE_UNKNOWN}}": ""},
+              custom_steps=[
+                  {
+                      "name": "top_level_labels",
+                      "level": "chunk",
+                      "kind": "keys",
+                      "required_template_keys": ["{{LANGUAGE}}"],
+                  }
+              ],
+              output_routes=prepared.persisted_workflow_extract["workflow"][
+                  "output_routes"
+              ],
+              leaf_fields=prepared.persisted_workflow_extract["workflow"][
+                  "leaf_fields"
+              ],
+              chunk_strategy="element",
+          )
+      )
+      client = GroundX(api_key="test")
+      client._workflows = FakeWorkflows(response)
+
+      definition = client.load_extraction_definition_from_workflow("wf-1")
+
+      assert definition.template == {"{{LANGUAGE}}": "French", "{{LANGUAGE_UNKNOWN}}": ""}
+      assert definition.custom_steps[0]["name"] == "top_level_labels"
+      assert definition.output_routes
+      assert definition.leaf_fields
+      assert definition.chunk_strategy == "element"
+
+
+  def test_load_extraction_definition_from_workflow_without_authored_metadata_sets_prepared_none() -> None:
+      from groundx import GroundX
+
+      execution_extract = {
+          "invoice": {
+              "fields": {
+                  "invoice_number": {
+                      "prompt": {
+                          "description": "Invoice number.",
+                          "type": "str",
+                      }
+                  }
+              }
+          }
+      }
+      client = GroundX(api_key="test")
+      client._workflows = FakeWorkflows(
+          WorkflowResponse(
+              workflow=WorkflowDetail(workflow_id="wf-1", extract=execution_extract)
+          )
+      )
+
+      definition = client.load_extraction_definition_from_workflow("wf-1")
+
+      assert definition.extract == execution_extract
+      assert definition.prepared is None
+
+
+  def test_load_extraction_definition_from_workflow_requires_extract() -> None:
+      from groundx import GroundX
+
+      client = GroundX(api_key="test")
+      client._workflows = FakeWorkflows({"workflow": {"workflow_id": "wf-1"}})
+
+      with pytest.raises(Exception, match="wf-1"):
+          client.load_extraction_definition_from_workflow("wf-1")
+  ```
+
+- [ ] Add concrete async loader parity tests. Use `asyncio.run(...)` so the
+      tests do not depend on a pytest async plugin:
+
+  ```python
+  import asyncio
+
+
+  class AsyncFakeWorkflows:
+      def __init__(self, response):
+          self.response = response
+          self.requested_id = None
+
+      async def get(self, id):
+          self.requested_id = id
+          return self.response
+
+
+  def test_async_load_extraction_definition_from_yaml_text() -> None:
+      from groundx import AsyncGroundX
+
+      async def run() -> None:
+          client = AsyncGroundX(api_key="test")
+
+          definition = await client.load_extraction_definition_from_yaml(
+              yaml_text=CUSTOM_WORKFLOW_YAML,
+          )
+
+          assert definition.prepared is not None
+          assert definition.template["{{LANGUAGE}}"] == "English"
+          assert definition.template["{{LANGUAGE_UNKNOWN}}"] == ""
+
+      asyncio.run(run())
+
+
+  def test_async_load_extraction_definition_from_workflow_id() -> None:
+      from groundx import AsyncGroundX
+
+      async def run() -> None:
+          prepared = prepare_extraction_yaml(CUSTOM_WORKFLOW_YAML)
+          client = AsyncGroundX(api_key="test")
+          client._workflows = AsyncFakeWorkflows(
+              WorkflowResponse(
+                  workflow=WorkflowDetail(
+                      workflow_id="wf-1",
+                      extract=prepared.persisted_workflow_extract,
+                  )
+              )
+          )
+
+          definition = await client.load_extraction_definition_from_workflow("wf-1")
+
+          assert client.workflows.requested_id == "wf-1"
+          assert definition.extract == prepared.persisted_workflow_extract
+          assert definition.custom_steps[0]["name"] == "line_item_labels"
+
+      asyncio.run(run())
+
+
+  def test_async_load_extraction_definition_requires_one_source() -> None:
+      from groundx import AsyncGroundX
+
+      async def run() -> None:
+          client = AsyncGroundX(api_key="test")
+
+          with pytest.raises(ValueError, match="exactly one"):
+              await client.load_extraction_definition_from_yaml()
+
+          with pytest.raises(ValueError, match="exactly one"):
+              await client.load_extraction_definition_from_yaml(
+                  yaml_text=CUSTOM_WORKFLOW_YAML,
+                  prepared=prepare_extraction_yaml(CUSTOM_WORKFLOW_YAML),
+              )
+
+      asyncio.run(run())
+  ```
+
+- [ ] Run:
+
+  ```bash
+  poetry run pytest tests/extract/test_extraction_workflow_definitions.py -q
+  ```
+
+  Expected before implementation: import or attribute failures for
+  `ExtractionDefinition` and loader methods.
+
+- [ ] Create `tests/custom/test_extraction_workflow_client_exports.py` with
+      import-boundary tests for the exported SDK client:
+
+  Before creating this file, update `.fernignore` to protect the hand-written
+  custom-test surface:
+
+  ```text
+  tests/custom
+  ```
+
+  Verify the entry exists with:
+
+  ```bash
+  rg -n "^tests/custom$" .fernignore
+  ```
+
+  This is required because `.fernignore` is the SDK's hand-written boundary,
+  and the test must survive Fern regeneration.
+
+  ```python
+  import builtins
+  import subprocess
+  import sys
+  import textwrap
+
+
+  def _run_script(script: str) -> subprocess.CompletedProcess[str]:
+      return subprocess.run(
+          [sys.executable, "-c", textwrap.dedent(script).strip()],
+          text=True,
+          capture_output=True,
+          check=False,
+      )
+
+
+  def test_base_groundx_import_does_not_import_extract_module() -> None:
+      result = _run_script(
+          """
+          import builtins
+          import sys
+
+          extract_optional_roots = {
+              "boto3",
+              "celery",
+              "dateparser",
+              "fastapi",
+              "google",
+              "googleapiclient",
+              "gspread",
+              "minio",
+              "openai",
+              "PIL",
+              "redis",
+              "smolagents",
+              "yaml",
+          }
+
+          original_import = builtins.__import__
+
+          def guarded_import(name, *args, **kwargs):
+              root = name.split(".", 1)[0]
+              if name.startswith("groundx.extract") or root in extract_optional_roots:
+                  raise AssertionError(
+                      f"base SDK import must not import optional extract dependency {name}"
+                  )
+              return original_import(name, *args, **kwargs)
+
+          builtins.__import__ = guarded_import
+
+          import groundx
+          from groundx import AsyncGroundX, GroundX
+
+          assert GroundX
+          assert AsyncGroundX
+          assert "groundx.extract" not in sys.modules
+          assert not (extract_optional_roots & set(sys.modules))
+          """
+      )
+
+      assert result.returncode == 0, result.stderr
+
+
+  def test_extraction_methods_without_extract_extra_raise_install_hint() -> None:
+      result = _run_script(
+          """
+          import builtins
+
+          extract_optional_roots = {
+              "boto3",
+              "celery",
+              "dateparser",
+              "fastapi",
+              "google",
+              "googleapiclient",
+              "gspread",
+              "minio",
+              "openai",
+              "PIL",
+              "redis",
+              "smolagents",
+              "yaml",
+          }
+
+          original_import = builtins.__import__
+
+          def guarded_import(name, *args, **kwargs):
+              root = name.split(".", 1)[0]
+              if name.startswith("groundx.extract") or root in extract_optional_roots:
+                  raise ImportError("No module named yaml")
+              return original_import(name, *args, **kwargs)
+
+          builtins.__import__ = guarded_import
+
+          from groundx import GroundX
+
+          client = GroundX(api_key="test")
+          try:
+              client.load_extraction_definition_from_yaml(path="statement.yaml")
+          except ImportError as exc:
+              assert "groundx[extract]" in str(exc)
+          else:
+              raise AssertionError("expected missing extract extra hint")
+          """
+      )
+
+      assert result.returncode == 0, result.stderr
+  ```
+
+  The subprocess wrapper is intentional: it prevents previous tests from hiding
+  a module-time `groundx.extract` import through `sys.modules` cache state.
+
+- [ ] Run:
+
+  ```bash
+  poetry run pytest tests/custom/test_extraction_workflow_client_exports.py -q
+  ```
+
+  Expected before implementation: the first test should pass only if the base
+  client import is already clean; the second should fail until the lazy import
+  wrapper raises the install hint.
+
+### Task 2: Implement ExtractionDefinition And Loaders
+
+- [ ] Create `src/groundx/extract/workflows.py` with:
+
+  - `ExtractionDefinition` dataclass.
+  - `_definition_from_prepared(prepared: PreparedExtractionYaml)`.
+  - `_definition_from_workflow_detail(workflow: Any)`.
+  - `_definition_from_extract_mapping(mapping: Mapping[str, Any])`.
+  - `_load_definition_from_one_source(path=..., yaml_text=..., mapping=..., mapping_kind="authored_yaml", prepared=...)`.
+
+- [ ] Implement source validation:
+
+  ```python
+  selected = [
+      name
+      for name, value in {
+          "path": path,
+          "yaml_text": yaml_text,
+          "mapping": mapping,
+          "prepared": prepared,
+      }.items()
+      if value is not None
+  ]
+  if len(selected) != 1:
+      raise ValueError(
+          "provide exactly one extraction definition source: "
+          "path, yaml_text, mapping, or prepared"
+      )
+  ```
+
+- [ ] Implement explicit mapping-kind validation:
+
+  ```python
+  allowed_mapping_kinds = {"authored_yaml", "workflow_extract"}
+  if mapping_kind not in allowed_mapping_kinds:
+      raise ValueError(
+          "mapping_kind must be 'authored_yaml' or 'workflow_extract'"
+      )
+  if mapping is None and mapping_kind != "authored_yaml":
+      raise ValueError("mapping_kind is only valid with mapping")
+  if mapping is not None and mapping_kind == "workflow_extract":
+      return _definition_from_extract_mapping(mapping)
+  ```
+
+  With `mapping_kind="authored_yaml"` or omitted, `mapping` must follow the
+  same preparation path as `yaml_text`. Do not infer `workflow_extract` by
+  inspecting dict keys; authored YAML and execution-only workflow extract
+  mappings can be structurally identical.
+
+- [ ] Export `ExtractionDefinition` from `src/groundx/extract/__init__.py`.
+
+- [ ] Add `GroundX.load_extraction_definition_from_yaml(...)` in
+      `src/groundx/ingest.py`. It should lazy-import the extract workflow
+      module inside the method body, call the extract module loader, and return
+      `ExtractionDefinition`.
+
+- [ ] Add `GroundX.load_extraction_definition_from_workflow(...)` in
+      `src/groundx/ingest.py`. It should lazy-import the extract workflow
+      module, call `self.workflows.get(id=workflow_id)`, extract the generated
+      response's `workflow`, and return `ExtractionDefinition`.
+
+- [ ] Define `ExtractionDefinition.prepared` as optional. YAML-loaded
+      definitions set it to the `PreparedExtractionYaml`. Workflow-loaded
+      definitions set it only when the workflow extract can be round-tripped
+      through `prepare_extraction_yaml(...)`, usually because
+      `_groundx_persisted_extract` is present. Workflow-loaded definitions that
+      only have execution groups and top-level workflow settings must set
+      `prepared=None`.
+
+- [ ] For workflow-loaded definitions, preserve generated `WorkflowDetail`
+      top-level settings (`template`, `custom_steps`, `output_routes`,
+      `leaf_fields`, `chunk_strategy`, `section_strategy`, and `steps`) ahead of
+      fallback metadata under `extract["workflow"]`.
+
+- [ ] Add a small lazy-import helper in `src/groundx/ingest.py`, for example
+      `_import_extraction_workflows()`, that catches missing optional extract
+      dependencies and raises an actionable `ImportError` mentioning
+      `pip install groundx[extract]`. Do not import `groundx.extract` at module
+      import time.
+
+- [ ] Add async parity on `AsyncGroundX`. YAML loading can reuse the same local
+      parser. Workflow-ID loading must await the generated workflow get call.
+
+- [ ] Run:
+
+  ```bash
+  poetry run pytest tests/extract/test_extraction_workflow_definitions.py tests/custom/test_extraction_workflow_client_exports.py -q
+  ```
+
+  Expected: loader tests pass; create/update tests will be added next.
+
+### Task 3: Add Failing Create/Update Tests
+
+- [ ] Extend `tests/extract/test_extraction_workflow_definitions.py` with sync
+      create/update forwarding tests:
+
+  ```python
+  class CreateUpdateWorkflows:
+      def __init__(self) -> None:
+          self.created = None
+          self.updated = None
+
+      def create(self, **kwargs):
+          self.created = kwargs
+          return {"workflow": {"workflow_id": "created"}}
+
+      def update(self, id, **kwargs):
+          self.updated = (id, kwargs)
+          return {"workflow": {"workflow_id": id}}
+
+
+  FIXED_STAGE_ATTRS = (
+      "chunk_instruct",
+      "chunk_keys",
+      "chunk_summary",
+      "doc_keys",
+      "doc_summary",
+      "sect_instruct",
+      "sect_summary",
+  )
+
+
+  FIXED_STAGE_WIRE_KEYS = (
+      "chunk-instruct",
+      "chunk-keys",
+      "chunk-summary",
+      "doc-keys",
+      "doc-summary",
+      "sect-instruct",
+      "sect-summary",
+  )
+
+
+  def _step_value(steps, attr):
+      if isinstance(steps, dict):
+          return steps.get(attr, steps.get(attr.replace("_", "-")))
+      return getattr(steps, attr)
+
+
+  def test_create_extraction_workflow_accepts_definition(tmp_path: Path) -> None:
+      from groundx import GroundX
+
+      yaml_path = tmp_path / "statement.yaml"
+      yaml_path.write_text(CUSTOM_WORKFLOW_YAML, encoding="utf-8")
+      client = GroundX(api_key="test")
+      definition = client.load_extraction_definition_from_yaml(path=yaml_path)
+      client._workflows = CreateUpdateWorkflows()
+      request_options = {"timeout_in_seconds": 30}
+
+      response = client.create_extraction_workflow(
+          definition=definition,
+          name="statement extraction",
+          request_options=request_options,
+      )
+
+      assert response == {"workflow": {"workflow_id": "created"}}
+      assert client.workflows.created["request_options"] == request_options
+      assert client.workflows.created["extract"]["workflow"]["custom_steps"]
+      assert client.workflows.created["custom_steps"][0]["name"] == "line_item_labels"
+      steps = client.workflows.created["steps"]
+      for attr in FIXED_STAGE_ATTRS:
+          assert _step_value(steps, attr) is None
+
+
+  def test_update_extraction_workflow_accepts_definition(tmp_path: Path) -> None:
+      from groundx import GroundX
+
+      yaml_path = tmp_path / "statement.yaml"
+      yaml_path.write_text(CUSTOM_WORKFLOW_YAML, encoding="utf-8")
+      client = GroundX(api_key="test")
+      definition = client.load_extraction_definition_from_yaml(path=yaml_path)
+      client._workflows = CreateUpdateWorkflows()
+      request_options = {"timeout_in_seconds": 31}
+
+      response = client.update_extraction_workflow(
+          "wf-1",
+          definition=definition,
+          name="statement extraction",
+          request_options=request_options,
+      )
+
+      assert response == {"workflow": {"workflow_id": "wf-1"}}
+      assert client.workflows.updated[0] == "wf-1"
+      assert client.workflows.updated[1]["request_options"] == request_options
+      assert client.workflows.updated[1]["custom_steps"]
+      steps = client.workflows.updated[1]["steps"]
+      for attr in FIXED_STAGE_ATTRS:
+          assert _step_value(steps, attr) is None
+
+
+  LEGACY_YAML = """
+  invoice:
+    fields:
+      invoice_number:
+        prompt:
+          description: Invoice number.
+          type: str
+  """
+
+
+  def test_create_extraction_workflow_legacy_yaml_does_not_disable_fixed_defaults(
+      tmp_path: Path,
+  ) -> None:
+      from groundx import GroundX
+
+      yaml_path = tmp_path / "legacy.yaml"
+      yaml_path.write_text(LEGACY_YAML, encoding="utf-8")
+      client = GroundX(api_key="test")
+      client._workflows = CreateUpdateWorkflows()
+
+      client.create_extraction_workflow(
+          path=yaml_path,
+          name="statement extraction",
+      )
+
+      assert "steps" not in client.workflows.created
+  ```
+
+- [ ] Add source one-of tests for create/update:
+
+  ```python
+  def test_create_extraction_workflow_uses_definition_before_yaml_sources(tmp_path: Path) -> None:
+      from groundx import GroundX
+
+      yaml_path = tmp_path / "statement.yaml"
+      yaml_path.write_text(CUSTOM_WORKFLOW_YAML, encoding="utf-8")
+      client = GroundX(api_key="test")
+      definition = client.load_extraction_definition_from_yaml(path=yaml_path)
+
+      client.create_extraction_workflow(
+          definition=definition,
+          yaml_text="not: [valid",
+          name="statement extraction",
+      )
+      assert client.workflows.created["extract"] == definition.extract
+
+      with pytest.raises(ValueError, match="exactly one"):
+          client.create_extraction_workflow(name="statement extraction")
+
+      with pytest.raises(ValueError, match="exactly one"):
+          client.create_extraction_workflow(
+              path=yaml_path,
+              yaml_text=CUSTOM_WORKFLOW_YAML,
+              name="statement extraction",
+          )
+
+
+  def test_update_extraction_workflow_uses_definition_before_yaml_sources(tmp_path: Path) -> None:
+      from groundx import GroundX
+
+      yaml_path = tmp_path / "statement.yaml"
+      yaml_path.write_text(CUSTOM_WORKFLOW_YAML, encoding="utf-8")
+      client = GroundX(api_key="test")
+      definition = client.load_extraction_definition_from_yaml(path=yaml_path)
+
+      client.update_extraction_workflow(
+          "wf-1",
+          definition=definition,
+          yaml_text="not: [valid",
+          name="statement extraction",
+      )
+      assert client.workflows.updated[1]["extract"] == definition.extract
+
+      with pytest.raises(ValueError, match="exactly one"):
+          client.update_extraction_workflow("wf-1", name="statement extraction")
+
+      with pytest.raises(ValueError, match="exactly one"):
+          client.update_extraction_workflow(
+              "wf-1",
+              path=yaml_path,
+              prepared=definition.prepared,
+              name="statement extraction",
+          )
+  ```
+
+- [ ] Add async create/update tests using async fake workflow clients:
+
+  ```python
+  class AsyncCreateUpdateWorkflows:
+      def __init__(self) -> None:
+          self.created = None
+          self.updated = None
+
+      async def create(self, **kwargs):
+          self.created = kwargs
+          return {"workflow": {"workflow_id": "created"}}
+
+      async def update(self, id, **kwargs):
+          self.updated = (id, kwargs)
+          return {"workflow": {"workflow_id": id}}
+
+
+  def test_async_create_and_update_extraction_workflow_accept_definition(
+      tmp_path: Path,
+  ) -> None:
+      from groundx import AsyncGroundX
+
+      async def run() -> None:
+          yaml_path = tmp_path / "statement.yaml"
+          yaml_path.write_text(CUSTOM_WORKFLOW_YAML, encoding="utf-8")
+          client = AsyncGroundX(api_key="test")
+          definition = await client.load_extraction_definition_from_yaml(
+              path=yaml_path,
+          )
+          client._workflows = AsyncCreateUpdateWorkflows()
+          create_request_options = {"timeout_in_seconds": 30}
+          update_request_options = {"timeout_in_seconds": 31}
+
+          create_response = await client.create_extraction_workflow(
+              definition=definition,
+              name="statement extraction",
+              request_options=create_request_options,
+          )
+          update_response = await client.update_extraction_workflow(
+              "wf-1",
+              definition=definition,
+              name="statement extraction",
+              request_options=update_request_options,
+          )
+
+          assert create_response == {"workflow": {"workflow_id": "created"}}
+          assert update_response == {"workflow": {"workflow_id": "wf-1"}}
+          assert client.workflows.created["request_options"] == create_request_options
+          assert client.workflows.updated[1]["request_options"] == update_request_options
+          assert client.workflows.created["custom_steps"][0]["name"] == (
+              "line_item_labels"
+          )
+          assert client.workflows.updated[1]["custom_steps"][0]["name"] == (
+              "line_item_labels"
+          )
+          for attr in FIXED_STAGE_ATTRS:
+              assert _step_value(client.workflows.created["steps"], attr) is None
+              assert _step_value(client.workflows.updated[1]["steps"], attr) is None
+
+      asyncio.run(run())
+
+
+  def test_async_create_extraction_workflow_uses_definition_before_yaml_sources(
+      tmp_path: Path,
+  ) -> None:
+      from groundx import AsyncGroundX
+
+      async def run() -> None:
+          yaml_path = tmp_path / "statement.yaml"
+          yaml_path.write_text(CUSTOM_WORKFLOW_YAML, encoding="utf-8")
+          client = AsyncGroundX(api_key="test")
+          definition = await client.load_extraction_definition_from_yaml(
+              path=yaml_path,
+          )
+
+          with pytest.raises(ValueError, match="exactly one"):
+              await client.create_extraction_workflow(name="statement extraction")
+
+          await client.create_extraction_workflow(
+              definition=definition,
+              yaml_text="not: [valid",
+              name="statement extraction",
+          )
+          assert client.workflows.created["extract"] == definition.extract
+
+      asyncio.run(run())
+  ```
+
+- [ ] Add generated workflow-client serialization tests that send the helper
+      output through the real generated `WorkflowsClient`, using the existing
+      recording-client pattern from `tests/custom/test_client.py`:
+
+  ```python
+  import typing
+
+  from groundx.core.http_client import get_request_body
+  from groundx.workflows.client import WorkflowsClient
+
+
+  class _DummyWorkflowResponse:
+      status_code = 200
+      headers: typing.Dict[str, str] = {}
+      text = ""
+
+      def json(self) -> typing.Dict[str, typing.Any]:
+          return {"workflow": {"workflowId": "created"}}
+
+
+  class _RecordingHttpClient:
+      def __init__(self) -> None:
+          self.calls: typing.List[typing.Tuple[str, typing.Dict[str, typing.Any]]] = []
+
+      def request(self, path: str, **kwargs: typing.Any) -> _DummyWorkflowResponse:
+          json_body, data_body = get_request_body(
+              json=kwargs.get("json"),
+              data=kwargs.get("data"),
+              request_options=kwargs.get("request_options"),
+              omit=kwargs.get("omit"),
+          )
+          encoded_kwargs = dict(kwargs)
+          encoded_kwargs["json"] = json_body
+          encoded_kwargs["data"] = data_body
+          self.calls.append((path, encoded_kwargs))
+          return _DummyWorkflowResponse()
+
+
+  class _RecordingWrapper:
+      def __init__(self, http_client: _RecordingHttpClient) -> None:
+          self.httpx_client = http_client
+
+
+  def test_create_extraction_workflow_serializes_generated_wire_keys(
+      tmp_path: Path,
+  ) -> None:
+      from groundx import GroundX
+
+      yaml_path = tmp_path / "statement.yaml"
+      yaml_path.write_text(CUSTOM_WORKFLOW_YAML, encoding="utf-8")
+      http_client = _RecordingHttpClient()
+      client = GroundX(api_key="test")
+      client._workflows = WorkflowsClient(
+          client_wrapper=typing.cast(typing.Any, _RecordingWrapper(http_client))
+      )
+      request_options = {"additional_headers": {"X-Test": "1"}}
+
+      client.create_extraction_workflow(
+          path=yaml_path,
+          name="statement extraction",
+          request_options=request_options,
+      )
+
+      assert http_client.calls[0][0] == "v1/workflow"
+      assert http_client.calls[0][1]["method"] == "POST"
+      assert http_client.calls[0][1]["request_options"] == request_options
+      body = http_client.calls[0][1]["json"]
+      assert body["customSteps"][0]["requiredTemplateKeys"] == [
+          "{{LANGUAGE}}",
+          "{{LANGUAGE_UNKNOWN}}",
+      ]
+      assert body["outputRoutes"][0]["workflowGroup"] == "line_items"
+      assert body["leafFields"][0]["finalPath"] == "/line_items/*/description"
+      for key in FIXED_STAGE_WIRE_KEYS:
+          assert key in body["steps"]
+          assert body["steps"][key] is None
+      assert "search-query" not in body["steps"]
+      assert "sect-keys" not in body["steps"]
+      assert "custom_steps" not in body
+      assert "output_routes" not in body
+      assert "leaf_fields" not in body
+
+
+  def test_update_extraction_workflow_serializes_generated_wire_keys(
+      tmp_path: Path,
+  ) -> None:
+      from groundx import GroundX
+
+      yaml_path = tmp_path / "statement.yaml"
+      yaml_path.write_text(CUSTOM_WORKFLOW_YAML, encoding="utf-8")
+      http_client = _RecordingHttpClient()
+      client = GroundX(api_key="test")
+      client._workflows = WorkflowsClient(
+          client_wrapper=typing.cast(typing.Any, _RecordingWrapper(http_client))
+      )
+      request_options = {"timeout_in_seconds": 22}
+
+      client.update_extraction_workflow(
+          "wf-1",
+          path=yaml_path,
+          name="statement extraction",
+          request_options=request_options,
+      )
+
+      assert http_client.calls[0][0] == "v1/workflow/wf-1"
+      assert http_client.calls[0][1]["method"] == "PUT"
+      assert http_client.calls[0][1]["request_options"] == request_options
+      body = http_client.calls[0][1]["json"]
+      assert body["customSteps"][0]["name"] == "line_item_labels"
+      for key in FIXED_STAGE_WIRE_KEYS:
+          assert key in body["steps"]
+          assert body["steps"][key] is None
+  ```
+
+- [ ] Run:
+
+  ```bash
+  poetry run pytest tests/extract/test_extraction_workflow_definitions.py -q
+  ```
+
+  Expected before implementation: create/update method failures.
+
+### Task 4: Implement Create/Update Methods
+
+- [ ] Add private/internal kwargs assembly from `ExtractionDefinition`, for
+      example `_workflow_kwargs_from_extraction_definition(...)`. Behavior:
+
+  - copy `extract` from `definition.extract`;
+  - copy `template`, `custom_steps`, `output_routes`, and `leaf_fields` when
+    present;
+  - include `name` when supplied;
+  - default `chunk_strategy` to `"element"` for YAML-loaded definitions and omit
+    it only when caller passes `None`;
+  - preserve `definition.chunk_strategy` for workflow-loaded definitions when
+    the caller does not override it;
+  - include `section_strategy` when supplied or preserved from the definition;
+  - include caller-supplied `steps` when supplied, otherwise preserve
+    `definition.steps` when present;
+  - if custom workflow steps exist and `steps` is omitted, include the same
+    empty fixed-step overlay used by the harness custom-workflow path:
+    `WorkflowSteps(chunk_instruct=None, chunk_keys=None, chunk_summary=None,
+    doc_keys=None, doc_summary=None, sect_instruct=None, sect_summary=None)`.
+    Do not add `search_query` or `sect_keys` to this overlay in this plan; the
+    current harness compiler intentionally preserves the legacy seven-key wire
+    shape;
+  - keep this helper private/internal and absent from promoted docs.
+
+- [ ] Add `GroundX.create_extraction_workflow(...)` in `src/groundx/ingest.py`.
+      It should use `definition` before YAML/prepared sources, assemble kwargs
+      internally, pass optional `request_options`, and return
+      `self.workflows.create(**kwargs)`.
+
+- [ ] Add `GroundX.update_extraction_workflow(...)` in `src/groundx/ingest.py`.
+      It should use `definition` before YAML/prepared sources, assemble kwargs
+      internally, pass optional `request_options`, and return
+      `self.workflows.update(id, **kwargs)`.
+
+- [ ] Use one shared source-selection helper for sync and async create/update.
+      It must use `definition` first; when `definition` is absent, it must
+      validate exactly one of `path`, `yaml_text`, `mapping`, or `prepared`, and
+      reject `mapping_kind` unless `mapping` is the selected source.
+
+- [ ] Add equivalent async methods on `AsyncGroundX`:
+
+  - `async def load_extraction_definition_from_yaml(...)` returns
+    `ExtractionDefinition` and may call the same local parser as sync.
+  - `async def load_extraction_definition_from_workflow(...)` awaits
+    `self.workflows.get(id=workflow_id)`.
+  - `async def create_extraction_workflow(...)` awaits
+    `self.workflows.create(**kwargs)`.
+  - `async def update_extraction_workflow(...)` awaits
+    `self.workflows.update(id, **kwargs)`.
+
+  Do not implement async methods as sync wrappers that call generated async
+  workflow methods without `await`; the async tests above must fail if the
+  generated async workflow client is not awaited.
+
+- [ ] Add docstrings for all promoted client methods:
+
+  - sync and async consolidated loaders;
+  - sync and async YAML loader aliases;
+  - sync and async workflow-ID loader aliases;
+  - sync and async create helpers;
+  - sync and async update helpers.
+
+  Docstrings must include parameters, return values, sync examples, async
+  examples where relevant, update semantics, and explicit workflow assignment
+  after create. They must also state that extraction definition methods require
+  `groundx[extract]`, while base SDK import and non-extraction calls do not.
+
+- [ ] Update import-boundary tests so `from groundx.extract import
+      ExtractionDefinition` works.
+
+- [ ] Update `README.md` or the repo's hand-written SDK reference section so
+      the promoted extraction workflow methods are listed beside `ingest` and
+      `ingest_directories`.
+
+- [ ] Run:
+
+  ```bash
+  poetry run pytest tests/extract/test_extraction_workflow_definitions.py tests/extract/test_import_boundaries.py -q
+  poetry run pytest tests/custom/test_extraction_workflow_client_exports.py -q
+  ```
+
+  Expected: all convenience helper and import tests pass.
+
+### Task 5: SDK Regression Gates
+
+- [ ] Run:
+
+  ```bash
+  poetry run pytest tests/extract/prompt/test_manager.py tests/extract/prompt/test_persisted_workflow_extract.py -q
+  poetry run pytest tests/custom/test_client.py -q
+  poetry run pytest tests/custom/test_extraction_workflow_client_exports.py -q
+  poetry run pytest tests/extract/test_extraction_workflow_definitions.py -q
+  poetry run pytest -rP -n auto tests/custom tests/extract
+  poetry run mypy .
+  poetry install --extras extract --extras aiohttp
+  poetry run pytest -rP -n auto -m aiohttp .
+  git diff --check
+  ```
+
+  Expected: all pass. If `mypy` is not configured or fails for unrelated known
+  issues, record exact output and run the narrow type gate that the repo uses for
+  SDK closeout.
+
+- [ ] Adversarial review:
+
+  - Confirm generated files are untouched.
+  - Confirm `import groundx` and `from groundx import GroundX, AsyncGroundX` do
+    not import optional extract dependencies.
+  - Confirm extraction definition methods fail with an actionable
+    `groundx[extract]` install hint when extract dependencies are unavailable.
+  - Confirm `prepare_extraction_yaml(...)` still returns `PreparedExtractionYaml`.
+  - Confirm `load_from_yaml(...)` and `load_from_mapping(...)` still behave as
+    low-level conversion helpers.
+  - Confirm `mapping` defaults to authored YAML semantics and existing workflow
+    `extract` mappings require `mapping_kind="workflow_extract"`.
+  - Confirm template values are validated as strings, and `{{LANGUAGE}}` plus
+    `{{LANGUAGE_UNKNOWN}}` placeholder keys survive exactly, including empty
+    string values.
+  - Confirm workflow-loaded definitions preserve generated `WorkflowDetail`
+    top-level settings and use `prepared=None` when authored metadata is absent.
+  - Confirm no promoted doc or example teaches a kwargs-prep helper.
+  - Confirm helper-produced kwargs match generated `workflows.create/update`
+    parameter names.
+  - Confirm helper-produced kwargs serialize through the generated workflow
+    client to public camelCase JSON names.
+  - Confirm update sends full extraction settings and does not teach name-only
+    update.
+  - Confirm method docstrings and README/reference docs match the standard for
+    hand-written SDK helpers.
+  - Confirm custom workflow YAML disables the exact seven fixed defaults
+    `chunk_instruct`, `chunk_keys`, `chunk_summary`, `doc_keys`, `doc_summary`,
+    `sect_instruct`, and `sect_summary` by default, while legacy YAML does not.
+
+## Phase 1.5: SDK Publish And Fresh-Install Gate
+
+**Why:** Public docs and harness helper-preference changes should not merge
+until the helper methods are available from a released Python SDK. Draft PRs are
+allowed before this gate; public merge is not.
+
+- [ ] Confirm the custom-step deployed-path blocker is resolved. The SDK
+      implementation PR may be reviewed before this, but release and downstream
+      dependency bumps remain blocked until custom workflow steps work on the
+      deployed path.
+
+- [ ] Merge the SDK implementation PR only after Phase 1 gates pass and the
+      deployed-path blocker is resolved.
+
+- [ ] Have a maintainer publish the Python SDK release through the repo's normal
+      tag-based release flow.
+
+- [ ] Verify the released package from a fresh environment:
+
+  ```bash
+  SMOKE_DIR="$(mktemp -d /tmp/groundx-extraction-workflow-methods.XXXXXX)"
+  python -m venv "$SMOKE_DIR"
+  "$SMOKE_DIR/bin/python" -m pip install --upgrade pip
+  "$SMOKE_DIR/bin/python" -m pip install --upgrade "groundx[extract]"
+  "$SMOKE_DIR/bin/python" - <<'PY'
+  from groundx import AsyncGroundX, GroundX
+
+  for client_cls in (GroundX, AsyncGroundX):
+      for name in (
+          "load_extraction_definition",
+          "load_extraction_definition_from_yaml",
+          "load_extraction_definition_from_workflow",
+          "create_extraction_workflow",
+          "update_extraction_workflow",
+      ):
+          assert callable(getattr(client_cls, name, None)), (client_cls, name)
+
+  client = GroundX(api_key="test")
+  definition = client.load_extraction_definition(
+      yaml_text="""
+  invoice:
+    fields:
+      invoice_number:
+        prompt:
+          description: Invoice number.
+          type: str
+  """
+  )
+  assert definition.extract
+  assert definition.prepared is not None
+  PY
+  ```
+
+  Expected: the latest published `groundx[extract]` exposes the promoted helper
+  methods and can load authored YAML without a local checkout.
+
+- [ ] Record the published SDK version in the OpenSpec closeout notes before
+      merging public docs or harness helper-preference PRs.
+
+## Phase 2: Public Docs
+
+**Repo:** `/Users/benjaminfletcher/git/eyelevel-fern-config`
+
+**Files:**
+
+- Modify: `fern/pages/extract-data-from-documents.mdx`
+- Modify any Fern docs navigation or SDK helper reference pages needed to make
+  the methods discoverable like `ingest` and `ingest_directories`.
+- Test/validate: repo docs checks and OpenSpec validation for any touched
+  OpenSpec files.
+
+- [ ] Before opening the docs PR, check Phase 1.5. If the SDK has not been
+      published and verified from a fresh install, open the docs PR as draft and
+      keep it draft-only until the gate is complete.
+
+- [ ] Replace the manual workflow settings block with:
+
+  ```python
+  import os
+
+  from groundx import GroundX
+
+  client = GroundX(api_key=os.environ["GROUNDX_API_KEY"])
+
+  workflow_response = client.create_extraction_workflow(
+      path="statement.yaml",
+      name="statement extraction",
+  )
+
+  workflow_id = workflow_response.workflow.workflow_id
+  if workflow_id is None:
+      raise RuntimeError("GroundX did not return a workflow ID")
+
+  client.workflows.add_to_id(id=bucket_id, workflow_id=workflow_id)
+  ```
+
+- [ ] Add the matching update example:
+
+  ```python
+  client.update_extraction_workflow(
+      workflow_id,
+      path="statement.yaml",
+      name="statement extraction",
+  )
+  ```
+
+- [ ] Add the workflow-ID load example:
+
+  ```python
+  definition = client.load_extraction_definition(workflow_id=workflow_id)
+  ```
+
+- [ ] Keep an advanced note that `prepare_extraction_yaml(...)` returns
+      `PreparedExtractionYaml` for callers that need final groups, workflow
+      groups, route metadata, or custom metadata inspection from authored YAML.
+      Also note that definitions loaded from an existing workflow may have
+      `definition.prepared is None` when the workflow does not preserve authored
+      YAML metadata.
+
+- [ ] Add method-level public documentation for the promoted helper methods with
+      signatures, accepted source arguments, return values, sync examples, async
+      examples, update semantics, explicit `groundx[extract]` dependency
+      guidance, and explicit workflow assignment after create.
+
+- [ ] Do not change `fern/openapi.yml` schema names in this plan.
+
+- [ ] Run the repo's docs validation commands, including:
+
+  ```bash
+  fern check
+  git diff --check
+  ```
+
+  Expected: docs validate and no whitespace errors.
+
+- [ ] Adversarial review:
+
+  - Confirm docs no longer teach manual metadata copying as the primary path.
+  - Confirm docs do not claim a released helper before the SDK release gate is
+    satisfied.
+  - Confirm docs keep explicit bucket/account assignment after workflow create.
+  - Confirm docs explain `groundx[extract]` without implying the base SDK import
+    requires extract dependencies.
+  - Confirm docs do not imply workflow-loaded definitions always have authored
+    YAML metadata.
+  - Confirm the promoted helper methods are discoverable as first-class SDK
+    helpers, not only mentioned inside one extraction walkthrough.
+  - Confirm generated schema names remain untouched.
+
+## Phase 3: Harness Templates And Skills
+
+**Repo:** `/Users/benjaminfletcher/git/groundx-studio-harness-support-custom-workflow-steps`
+
+**Files:**
+
+- Modify: `skills/groundx-extraction-workflows/templates/deploy_workflow.py`
+- Modify: `skills/groundx-extraction-workflows/templates/run_extraction.py`
+- Modify: `skills/groundx-extraction-workflows/templates/batch_extraction.py`
+- Modify: `skills/groundx-extraction-workflows/templates/prompt_manager.py`
+- Modify: `skills/groundx-extraction-workflows/templates/compile_workflow.py`
+- Modify: `skills/groundx-extraction-workflows/templates/test_compile_workflow.py`
+- Modify: `scripts/tests/test-groundx-extraction-workflows.mjs`
+- Modify: `scripts/tests/test-extraction-deploy-workflow.mjs`
+- Modify: `skills/groundx-python/references/02-core-sdk.md`
+- Modify as needed: `skills/groundx-python/evals/evals.json`
+- Modify as needed: `skills/groundx-extraction-workflows/SKILL.md`
+- Modify as needed: `skills/groundx-extraction-workflows/evals/evals.json`
+- Modify architecture/API-surface references that enumerate hand-written Python
+  SDK helpers, including `skills/groundx-architecture/references/api-surface.md`.
+- Modify: `skills/groundx-extraction-workflows/references/public-docs.md`
+- Modify references under `skills/groundx-extraction-workflows/references/`
+- Modify scanner fixtures or expectations if existing checks encode the old
+  manual workflow path.
+- Modify routing/source manifests only if discoverability or first-entry
+  ownership changes.
+- Modify changelog/version surfaces if harness packaging rules require a
+  version bump for changed plugin payload.
+- Do not list or edit `plugins/` mirror files as source files. If source changes
+  alter plugin payload, refresh mirrors with `node scripts/sync-plugin.mjs`,
+  review the generated diff, rerun `node scripts/sync-plugin.mjs --check`, and
+  rerun `node scripts/validate.mjs` after the generated-output refresh.
+
+- [ ] Before opening the harness PR, check Phase 1.5. If the SDK has not been
+      published and verified from a fresh install, open the harness PR as draft
+      and keep it draft-only until the gate is complete. If the harness minimum
+      supported SDK version is not bumped, the older-SDK fallback must remain
+      covered by tests.
+
+- [ ] Add compatibility detection:
+
+  ```python
+  def _client_has_extraction_workflow_helpers(gx: typing.Any) -> bool:
+      return all(
+          callable(getattr(gx, name, None))
+          for name in (
+              "load_extraction_definition_from_yaml",
+              "load_extraction_definition",
+              "create_extraction_workflow",
+              "update_extraction_workflow",
+          )
+      )
+  ```
+
+- [ ] Keep deploy/run/batch compile steps in place before any API call:
+
+  ```python
+  workflow, extraction_metadata = build_workflow_artifacts(yaml_path, name=workflow_name)
+  errors = validate_workflow(workflow)
+  if errors:
+      raise SystemExit("workflow validation failed:\n  - " + "\n  - ".join(errors))
+  _write_workflow_artifacts(workflow, extraction_metadata)
+  ```
+
+  Existing helper-backed paths must still write `workflow.json` and
+  `extraction_workflow_metadata_v1.json`. The helper methods may be used for the
+  API call only after these artifacts are produced and validated.
+
+- [ ] In create paths, prefer:
+
+  ```python
+  workflow, metadata = build_workflow_artifacts(yaml_path, workflow_name)
+  _validate_and_write_artifacts(workflow, metadata)
+  if _client_has_extraction_workflow_helpers(gx):
+      response = gx.create_extraction_workflow(
+          path=yaml_path,
+          name=workflow_name,
+      )
+  else:
+      response = gx.workflows.create(**workflow_sdk_kwargs(workflow))
+  ```
+
+- [ ] In update paths, prefer:
+
+  ```python
+  workflow, metadata = build_workflow_artifacts(yaml_path, workflow_name)
+  _validate_and_write_artifacts(workflow, metadata)
+  if _client_has_extraction_workflow_helpers(gx):
+      response = gx.update_extraction_workflow(
+          workflow_id,
+          path=yaml_path,
+          name=workflow_name,
+      )
+  else:
+      response = gx.workflows.update(workflow_id, **workflow_sdk_kwargs(workflow))
+  ```
+
+- [ ] Keep `compile_workflow.py` building offline workflow JSON and
+      `workflow_sdk_kwargs(...)` for fallback. Do not delete either in this
+      plan.
+
+- [ ] Update harness references so path-first create/update is preferred,
+      definition loading is the reuse/inspection path, and
+      `workflow_sdk_kwargs(...)` is compatibility/offline support.
+
+- [ ] Update `skills/groundx-extraction-workflows/references/public-docs.md`:
+
+  - replace the old primary flow that says to use
+    `prepare_extraction_yaml(...)` and pass prepared workflow groups;
+  - show the helper-backed public flow for creating and updating workflows
+    directly from a YAML path;
+  - allow method names such as
+    `load_extraction_definition(...)` and explicit loader aliases in code and
+    method references;
+  - keep explanatory prose customer-readable by preferring "YAML",
+    "workflow settings", and "JSON you want back" over internal jargon.
+
+- [ ] Update harness GroundX API, GroundX Python, and architecture references
+      that currently list `ingest` and `ingest_directories` as hand-written
+      Python SDK helpers so they also list the promoted extraction workflow
+      methods.
+
+- [ ] Update harness evals and scanners so repeated invariants are machine
+      checked where the repo already has a relevant gate:
+
+  - SDK-helper discoverability should be represented in `groundx-python` or
+    architecture evals when those files already test hand-written helper
+    routing.
+  - Extraction workflow template scanners should accept path-first
+    create/update as preferred while keeping `workflow_sdk_kwargs(...)` as
+    compatibility/offline support.
+  - Generated plugin mirrors must be refreshed with `node scripts/sync-plugin.mjs`
+    after source files change; do not edit `plugins/` directly. After any sync,
+    rerun `node scripts/sync-plugin.mjs --check` and `node scripts/validate.mjs`.
+
+- [ ] If any `harness-web-ui`, `harness-publish`, scaffold, or onboarding
+      reference is changed during the scan, preserve these invariants:
+
+  - authenticated product UI is the base product experience;
+  - onboarding is a configurable overlay/app metadata flow;
+  - onboarding does not become a separate anonymous base app or replacement for
+    the authenticated shell.
+
+- [ ] Run:
+
+  ```bash
+  python -m pytest skills/groundx-extraction-workflows/templates/test_compile_workflow.py skills/groundx-extraction-workflows/templates/test_imports.py -q
+  node scripts/tests/test-groundx-extraction-workflows.mjs
+  node scripts/tests/test-extraction-deploy-workflow.mjs
+  node scripts/tests/test-evals.mjs
+  node scripts/tests/test-harness-web-ui.mjs  # only if web-ui, scaffold, or onboarding references changed
+  node scripts/sync-plugin.mjs --check
+  node scripts/scans/scan-version-bump.mjs
+  node scripts/validate.mjs
+  git diff --check
+  ```
+
+  Expected: all pass. If plugin mirror sync reports expected generated diffs,
+  run `node scripts/sync-plugin.mjs`, review the generated changes, rerun
+  `node scripts/sync-plugin.mjs --check`, then rerun `node scripts/validate.mjs`
+  before proceeding.
+
+- [ ] Adversarial review:
+
+  - Confirm fallback still works with older SDKs.
+  - Confirm helper-backed deploy paths still write and validate offline compile
+    artifacts before API calls.
+  - Confirm scanners no longer require the old manual `workflow_sdk_kwargs`
+    deployment path as the preferred path.
+  - Confirm SDK-surface references document the promoted extraction workflow
+    methods like `ingest` and `ingest_directories`.
+  - Confirm source-of-truth surfaces, evals/scanners, generated plugin mirrors,
+    and version/changelog surfaces are consistent with the harness contributor
+    contract.
+  - Confirm any touched web UI, scaffold, or onboarding references preserve the
+    authenticated-base/onboarding-overlay model.
+  - Confirm docs do not promise helper availability before SDK release.
+
+## Phase 4: internal-arcadia-agents
+
+**Repo:** `/Users/benjaminfletcher/git/internal-arcadia-agents`
+
+**Files:**
+
+- Modify conditionally: `prompts/arcadia_manager.py`
+- Test: `prompts/test_arcadia_manager.py`
+- Modify docs or OpenSpec notes only if helper adoption is not behaviorally
+  equivalent.
+
+- [ ] Add tests that use the existing `test_policy_metadata` fixture and compare
+      first-class-method payloads to the current explicit workflow payloads.
+      Equivalence means all of the following match:
+
+  - `extract`, including `_groundx_persisted_extract`;
+  - serialized `steps`;
+  - `chunk_strategy`;
+  - `section_strategy` for `update_prompts(...)`;
+  - workflow `name`;
+  - workflow `id` for update/repair paths.
+
+  Add helper assertions in `prompts/test_arcadia_manager.py`:
+
+  ```python
+  def _plain(value):
+      if hasattr(value, "model_dump"):
+          return value.model_dump(by_alias=True)
+      if hasattr(value, "dict"):
+          return value.dict(by_alias=True)
+      return value
+
+
+  def _assert_arcadia_payload_equivalent(actual, expected):
+      assert actual["extract"] == expected["extract"]
+      assert _plain(actual["steps"]) == _plain(expected["steps"])
+      assert actual.get("chunk_strategy") == expected.get("chunk_strategy")
+      assert actual.get("section_strategy") == expected.get("section_strategy")
+      assert actual.get("name") == expected.get("name")
+      assert actual.get("id") == expected.get("id")
+  ```
+
+  Add a create equivalence test:
+
+  ```python
+  def test_create_extraction_workflow_helper_matches_arcadia_create_payload():
+      man = TestManager(
+          file_name="test_policy_metadata",
+          workflow_id="test_policy_metadata",
+      )
+      expected = {
+          "chunk_strategy": "element",
+          "name": "test",
+          "steps": man.workflow_steps(
+              file_name="test_policy_metadata",
+              workflow_id="test_policy_metadata",
+          ),
+          "extract": man.persisted_workflow_extract_dict(
+              file_name="test_policy_metadata",
+              workflow_id="test_policy_metadata",
+          ),
+      }
+      prepared = prepare_arcadia_extraction_yaml(expected["extract"])
+      definition = man.gx_client.load_extraction_definition_from_yaml(
+          prepared=prepared,
+      )
+      calls = {}
+
+      def create(**kwargs):
+          calls["create"] = kwargs
+          return types.SimpleNamespace(
+              workflow=types.SimpleNamespace(workflow_id="created")
+          )
+
+      man.gx_client.workflows.create = create
+
+      man.gx_client.create_extraction_workflow(
+          definition=definition,
+          name="test",
+          steps=expected["steps"],
+      )
+
+      _assert_arcadia_payload_equivalent(calls["create"], expected)
+      assert calls["create"]["extract"]["_groundx_persisted_extract"][
+          "charges"
+      ]["match_attrs"] == ["custom_match"]
+  ```
+
+  Add an update equivalence test:
+
+  ```python
+  def test_update_extraction_workflow_helper_matches_arcadia_update_payload():
+      man = TestManager(
+          file_name="test_policy_metadata",
+          workflow_id="test_policy_metadata",
+      )
+      expected = {
+          "id": "test_policy_metadata",
+          "chunk_strategy": "element",
+          "section_strategy": "page",
+          "name": "test",
+          "steps": man.workflow_steps(
+              file_name="test_policy_metadata",
+              workflow_id="test_policy_metadata",
+          ),
+          "extract": man.persisted_workflow_extract_dict(
+              file_name="test_policy_metadata",
+              workflow_id="test_policy_metadata",
+          ),
+      }
+      prepared = prepare_arcadia_extraction_yaml(expected["extract"])
+      definition = man.gx_client.load_extraction_definition_from_yaml(
+          prepared=prepared,
+      )
+      calls = {}
+
+      def update(id, **kwargs):
+          calls["update"] = {"id": id, **kwargs}
+          return types.SimpleNamespace(
+              workflow=types.SimpleNamespace(workflow_id=id)
+          )
+
+      man.gx_client.workflows.update = update
+
+      man.gx_client.update_extraction_workflow(
+          "test_policy_metadata",
+          definition=definition,
+          name="test",
+          section_strategy="page",
+          steps=expected["steps"],
+      )
+
+      _assert_arcadia_payload_equivalent(calls["update"], expected)
+      assert calls["update"]["extract"]["_groundx_persisted_extract"][
+          "meters"
+      ]["required_attrs"] == ["meter_number"]
+  ```
+
+- [ ] If the methods preserve Arcadia's metadata-key behavior, update
+      `init_prompts`, `repair_prompts`, and `update_prompts` to call the
+      first-class methods while still passing Arcadia's explicit
+      `steps=self.workflow_steps(...)`.
+
+- [ ] If the methods cannot preserve equivalent behavior, leave the existing
+      explicit calls in place and add a short OpenSpec note explaining that
+      Arcadia remains on the lower-level path because it owns specialized
+      metadata-key handling.
+
+- [ ] Run:
+
+  ```bash
+  pytest prompts/test_arcadia_manager.py -q
+  pytest classes/test_extraction_reassembly.py -q
+  git diff --check
+  ```
+
+  Expected: existing Arcadia prompt-manager and reassembly behavior remains
+  unchanged except for the helper-backed create/update implementation if
+  adopted.
+
+- [ ] Adversarial review:
+
+  - Confirm `qa_charges` and future `reconcile_fields`/`qa_fields`/`save_fields`
+    planning remains untouched.
+  - Confirm create/update payloads still include Arcadia workflow steps.
+  - Confirm metadata-key behavior matches current tests.
+
+## Phase 5: ADP And Related Repos Scan
+
+**Repos:**
+
+- `/Users/benjaminfletcher/git/adp-poc`
+
+`groundx-agent-harness` is out of scope because it is generated from GroundX
+Studio Harness. Phase 3 covers generated mirrors through source edits plus
+plugin sync and sync checks.
+
+- [ ] Inspect Phase 5 worktree status before scanning, and again before any
+      edit:
+
+  ```bash
+  git -C /Users/benjaminfletcher/git/adp-poc status --short --branch
+  ```
+
+  Expected: scans can remain read-only, but do not edit any dirty Phase 5 repo
+  without explicit direction.
+
+- [ ] Before editing any Phase 5 repo, run the matching guard:
+
+  ```bash
+  # ADP repos: any dirty file blocks edits.
+  test -z "$(git -C /Users/benjaminfletcher/git/adp-poc status --porcelain)" || {
+    git -C /Users/benjaminfletcher/git/adp-poc status --short
+    echo "/Users/benjaminfletcher/git/adp-poc is dirty; stop before editing"
+    exit 1
+  }
+  ```
+
+- [ ] Scan:
+
+  ```bash
+  PATTERN="prepare_extraction_yaml|workflow_sdk_kwargs|workflows\\.create|workflows\\.update|load_extraction_definition|create_extraction_workflow|update_extraction_workflow"
+
+  rg -n "$PATTERN" \
+    /Users/benjaminfletcher/git/adp-poc \
+    --glob '!plugins/**' \
+    --glob '!.agents/plugins/**' || true
+  ```
+
+- [ ] Update owned examples or scripts that still teach manual metadata copying.
+      Before any edit, require that the target repo has no dirty non-generated
+      source files, or stop and ask for direction.
+
+- [x] Restore the whitespace-only ADP `prompt.yaml` local change before marking
+      ADP scan complete.
+
+- [ ] Run the narrow validation commands for any repo touched by this scan.
+
+- [ ] Adversarial review:
+
+  - Confirm no customer YAML content changed accidentally.

--- a/openspec/changes/add-extraction-workflow-convenience-methods/proposal.md
+++ b/openspec/changes/add-extraction-workflow-convenience-methods/proposal.md
@@ -1,0 +1,158 @@
+# Change: Add Extraction Workflow Convenience Methods
+
+Status: proposed, planning-only
+
+This change adds a small SDK-owned convenience layer over the existing workflow
+create/update/get API. It is intentionally separate from
+`support-custom-workflow-steps`: that change owns the low-level API/runtime
+contract, while this change owns the caller ergonomics for loading extraction
+definitions from YAML or existing workflows, then creating and updating
+extraction workflows from those definitions.
+
+## Problem
+
+The current public Python examples require callers who want to create or update
+an extraction workflow from YAML to:
+
+1. read a YAML file into text,
+2. call `prepare_extraction_yaml(...)`,
+3. pull out `prepared.persisted_workflow_extract`,
+4. inspect `workflow_extract["workflow"]`,
+5. manually copy `template`, `custom_steps`, `output_routes`, and
+   `leaf_fields`, and
+6. call `client.workflows.create(...)` or `client.workflows.update(...)`.
+
+That is too much ceremony for the common path. It also exposes generated
+workflow schema details and teaches users to reproduce fragile metadata-copying
+logic that the SDK can own.
+
+There is also no promoted high-level way to load an extraction definition from
+an existing workflow ID. That leaves humans and automation such as
+`internal-arcadia-agents` choosing between low-level workflow responses,
+`PreparedExtractionYaml`, and hand-built dictionaries even when their job is
+simply "load the extraction definition I should inspect or reuse."
+
+## Goals
+
+- Add `GroundX.create_extraction_workflow(...)` and
+  `GroundX.update_extraction_workflow(...)` in the hand-written Python SDK
+  surface.
+- Add `GroundX.load_extraction_definition(...)` for loading an extraction
+  definition from a workflow ID or from one YAML/prepared source. When
+  `workflow_id` is provided, it takes precedence over YAML/prepared inputs.
+- Keep explicit alias methods
+  `GroundX.load_extraction_definition_from_yaml(...)` and
+  `GroundX.load_extraction_definition_from_workflow(...)` for callers who want
+  source-specific names.
+- Add async parity on `AsyncGroundX`.
+- Document the promoted create, update, and load-definition methods as
+  first-class hand-written SDK helpers, matching the treatment of `ingest` and
+  `ingest_directories` rather than only showing them in a walkthrough snippet.
+- Make the promoted create/update path path-first: public docs and harness
+  examples should pass `path="statement.yaml"` directly to create/update. The
+  `ExtractionDefinition` object is for inspection, reuse, copying settings
+  from an existing workflow, and advanced callers.
+- Treat `mapping` input as authored YAML-shaped by default. Persisted or
+  execution workflow `extract` mappings require an explicit advanced
+  `mapping_kind="workflow_extract"` argument so the SDK never guesses between
+  two dict shapes that can look identical.
+- Validate workflow template values as strings. Template keys and values must
+  preserve the existing API contract, including placeholder-style keys such as
+  `{{LANGUAGE}}` and `{{LANGUAGE_UNKNOWN}}`, including empty-string values.
+- Preserve the base SDK experience for users who installed `groundx` without
+  the `extract` extra. The exported `GroundX` client must remain importable and
+  non-extraction methods must keep working; extraction definition methods may
+  lazy-import extract dependencies and raise a clear install hint when
+  `groundx[extract]` is missing.
+- Keep `prepare_extraction_yaml(...)` and `PreparedExtractionYaml` as the
+  lower-level API because `PromptManager`, Arcadia, and tests use the richer
+  prepared metadata surfaces.
+- Keep `load_from_yaml(...)`, `load_from_mapping(...)`, and
+  `group_from_mapping(...)` available as low-level conversion helpers, but do
+  not promote them as the recommended extraction workflow API.
+- Keep workflow-create/update kwargs assembly as private implementation detail
+  or advanced-only plumbing, not as a promoted public technique.
+- Hide generated `CustomWorkflowStep*`, route, and leaf-field classes from the
+  normal extraction workflow creation path.
+- Update public docs and harness templates so they teach the one-call path
+  and promoted load-definition operations for reuse/inspection instead of
+  manual workflow metadata assembly.
+- Update the harness public extraction-doc source of truth so it no longer
+  teaches `prepare_extraction_yaml(...)` as the primary public create/update
+  path.
+- Preserve old direct generated-client access for advanced users.
+
+## Non-Goals
+
+- Do not rename Fern/OpenAPI schemas such as `CustomWorkflowStepConfig` in this
+  change. Renaming generated schemas would churn public SDK imports and should be
+  a separate contract-cleanup plan if desired.
+- Do not add a new server endpoint. The helper delegates to existing workflow
+  create/update API calls.
+- Do not publish a new SDK or public docs before the custom workflow-step
+  runtime/API e2e blocker is resolved.
+- Do not remove `workflow_sdk_kwargs(...)` from the harness until the minimum
+  released SDK version includes the new convenience methods.
+- Do not force `internal-arcadia-agents` to replace specialized metadata-key
+  preparation where the helper cannot preserve equivalent behavior.
+- Do not implicitly assign created workflows to buckets or accounts. Bucket and
+  account assignment remain explicit workflow API calls.
+- Do not make workflow execution/testing part of this convenience API. Running
+  extraction remains a separate runtime operation after a workflow exists and is
+  assigned.
+- Do not change the GroundX Studio web UI base experience. Authenticated product
+  UI remains the default scaffold shape; onboarding is a configurable overlay on
+  top of that authenticated experience, not a separate base app architecture.
+
+## Repositories
+
+Primary OpenSpec planning repo:
+
+- `/Users/benjaminfletcher/git/groundx-python`
+
+Implementation and documentation repos:
+
+- `/Users/benjaminfletcher/git/groundx-python-support-custom-workflow-steps-sdk`
+- `/Users/benjaminfletcher/git/eyelevel-fern-config`
+- `/Users/benjaminfletcher/git/groundx-studio-harness-support-custom-workflow-steps`
+- `/Users/benjaminfletcher/git/internal-arcadia-agents`
+
+Scan-only or conditional repos:
+
+- `/Users/benjaminfletcher/git/adp-poc`
+- `/Users/benjaminfletcher/git/groundx-studio-harness`
+- `/Users/benjaminfletcher/git/cashbot-go`
+
+Out of scope:
+
+- `/Users/benjaminfletcher/git/groundx-agent-harness` is generated from GroundX
+  Studio Harness and must not be edited directly for this plan.
+
+`cashbot-go` is expected to need no change because this convenience layer does
+not alter the runtime or public HTTP contract. If implementation reveals a
+missing runtime/API behavior, stop and route that through the existing
+`support-custom-workflow-steps` blocker instead of patching it here.
+
+## Dependencies And Blockers
+
+- Local SDK/harness/docs changes may be planned and implemented against the
+  current custom workflow-step branches.
+- Before implementation starts, refresh each implementation branch against its
+  current target branch. The existing support-custom-workflow-step branches were
+  created before the template closeout PRs merged, so the convenience-method
+  work must not proceed from stale branch assumptions. This freshness gate
+  includes SDK, Fern docs, GroundX Studio Harness, Arcadia, and ADP before it is
+  edited.
+- Publishing and downstream dependency bumps remain blocked until the existing
+  `support-custom-workflow-steps` deployed-path validation blocker is resolved:
+  the deployed API must reject oversized or spoofed custom-step workflows.
+- Public docs and harness helper-preference changes may be prepared as draft
+  PRs, but they must not merge until the Python SDK helpers have been merged,
+  published, and verified from the published package in a fresh environment.
+- GroundX Studio Harness updates must follow the harness source-of-truth model:
+  update owning skill references, evals, scanner expectations, routing/source
+  manifests, generated mirrors, and version surfaces when the change touches
+  those contracts. Do not rely on prose-only guidance for repeated invariants.
+- New hand-written SDK tests under `tests/custom` must be protected by the SDK
+  regeneration boundary before they are added. `.fernignore` is the authoritative
+  boundary for files that must survive Fern releases.

--- a/openspec/changes/add-extraction-workflow-convenience-methods/specs/extraction-workflow-convenience/spec.md
+++ b/openspec/changes/add-extraction-workflow-convenience-methods/specs/extraction-workflow-convenience/spec.md
@@ -1,0 +1,350 @@
+## ADDED Requirements
+
+### Requirement: Python SDK exposes first-class extraction definition loaders
+
+The Python SDK SHALL expose hand-written methods for loading extraction
+definitions from authored YAML and from existing workflow IDs without requiring
+callers to work with generated workflow response internals.
+
+#### Scenario: Load extraction definition from YAML path
+
+- **GIVEN** a local extraction YAML file
+- **WHEN** a caller invokes `GroundX.load_extraction_definition(path=...)`
+- **THEN** the SDK reads the file as UTF-8 YAML
+- **AND** prepares it through the same extraction YAML preparation path as
+  `prepare_extraction_yaml(...)`
+- **AND** returns an `ExtractionDefinition`
+- **AND** the returned definition exposes the persisted `extract` payload,
+  workflow template, custom steps, output routes, leaf fields, and underlying
+  prepared metadata for advanced inspection
+- **AND** the base SDK package remains importable without loading optional
+  extraction dependencies until this method is called
+- **AND** `GroundX.load_extraction_definition_from_yaml(path=...)` remains
+  available as an explicit source-specific alias
+
+#### Scenario: Load extraction definition from explicit YAML text or mapping
+
+- **GIVEN** in-memory extraction YAML or a YAML-shaped mapping
+- **WHEN** a caller invokes `GroundX.load_extraction_definition(...)`
+  with exactly one YAML/prepared source argument and no `workflow_id`
+- **THEN** the SDK returns the same `ExtractionDefinition` shape
+- **AND** passing zero or multiple YAML/prepared sources fails with a clear
+  `ValueError`
+- **AND** raw string YAML is passed through `yaml_text`, not ambiguously through
+  a bare positional string
+- **AND** `mapping` defaults to authored YAML-shaped semantics
+
+#### Scenario: Load extraction definition from explicit workflow extract mapping
+
+- **GIVEN** a persisted or execution-only workflow `extract` mapping
+- **WHEN** a caller invokes `GroundX.load_extraction_definition(...)`
+  with `mapping=...` and `mapping_kind="workflow_extract"`
+- **THEN** the SDK treats the mapping as an existing workflow extract payload
+- **AND** preserves the extract mapping exactly
+- **AND** sets `prepared=None` when authored YAML metadata is unavailable
+- **AND** does not guess `workflow_extract` from dict keys because simple
+  authored YAML mappings and simple execution-only extract mappings can look
+  identical
+
+#### Scenario: Workflow template values are string-preserving
+
+- **GIVEN** authored YAML whose workflow template contains placeholder-style
+  keys such as `{{LANGUAGE}}` and `{{LANGUAGE_UNKNOWN}}`
+- **WHEN** the SDK loads the extraction definition
+- **THEN** the placeholder keys are preserved exactly as string keys
+- **AND** an empty-string value for `{{LANGUAGE_UNKNOWN}}` is preserved
+- **AND** non-string template values fail with a clear `ValueError` naming the
+  offending template key
+
+#### Scenario: Load extraction definition from workflow ID
+
+- **GIVEN** an existing GroundX workflow ID whose workflow contains extraction
+  config
+- **WHEN** a caller invokes `GroundX.load_extraction_definition(workflow_id=...)`
+- **THEN** the SDK fetches the workflow through the generated workflow client
+- **AND** extracts the workflow `extract` mapping and workflow-level extraction
+  settings
+- **AND** returns an `ExtractionDefinition` compatible with create/update
+  helpers
+- **AND** preserves top-level workflow response fields such as `template`,
+  `custom_steps`, `output_routes`, `leaf_fields`, `chunk_strategy`,
+  `section_strategy`, and `steps` when present
+- **AND** falls back to persisted workflow metadata under `extract["workflow"]`
+  only when the corresponding top-level workflow response field is absent
+- **AND** if the workflow has no extraction config, the SDK raises a clear error
+  naming the workflow ID
+- **AND** `GroundX.load_extraction_definition_from_workflow(workflow_id)`
+  remains available as an explicit source-specific alias
+
+#### Scenario: Consolidated loader applies workflow-ID precedence
+
+- **GIVEN** a caller wants to load an extraction definition
+- **WHEN** they provide `workflow_id` plus any YAML/prepared source such as
+  `path`, `yaml_text`, `mapping`, or `prepared`
+- **THEN** `GroundX.load_extraction_definition(...)` loads from `workflow_id`
+- **AND** the SDK does not read or validate the lower-priority YAML/prepared
+  source
+- **AND** if `workflow_id` is absent, passing zero or multiple YAML/prepared
+  sources fails with a clear `ValueError`
+- **AND** `mapping_kind` is valid only when `mapping` is the selected
+  YAML/prepared source
+- **AND** `request_options` is valid only when `workflow_id` is the selected
+  source
+
+#### Scenario: Workflow-loaded definition does not fake authored metadata
+
+- **GIVEN** an existing GroundX workflow whose `extract` mapping does not
+  contain `_groundx_persisted_extract`
+- **WHEN** a caller invokes
+  `GroundX.load_extraction_definition_from_workflow(workflow_id)`
+- **THEN** the SDK returns an `ExtractionDefinition` that preserves create/update
+  payload fields
+- **AND** the definition has `prepared=None`
+- **AND** docs state that authored YAML inspection metadata is unavailable for
+  such workflow-loaded definitions
+
+#### Scenario: Base SDK import does not require extract extras
+
+- **GIVEN** a Python environment with `groundx` installed without the `extract`
+  extra
+- **WHEN** a caller imports `groundx`, `GroundX`, or `AsyncGroundX`
+- **THEN** the import succeeds
+- **AND** non-extraction client methods remain usable
+- **AND** base imports do not import `groundx.extract` or representative
+  `groundx[extract]` optional dependency modules
+- **AND** calling an extraction definition method fails with an actionable
+  install hint such as `pip install groundx[extract]`
+
+#### Scenario: Hand-written custom tests survive SDK regeneration
+
+- **GIVEN** the SDK repo uses `.fernignore` as the hand-written boundary
+- **WHEN** this change adds a new hand-written test under `tests/custom`
+- **THEN** `.fernignore` protects the `tests/custom` test surface before the
+  test is added
+- **AND** the plan does not rely on unprotected hand-written files surviving
+  Fern regeneration by accident
+
+#### Scenario: Async definition loaders have parity
+
+- **GIVEN** an async GroundX client
+- **WHEN** a caller invokes
+  `AsyncGroundX.load_extraction_definition(...)`,
+  `AsyncGroundX.load_extraction_definition_from_yaml(...)`, or
+  `AsyncGroundX.load_extraction_definition_from_workflow(...)`
+- **THEN** the async methods accept the same source arguments as the sync
+  methods
+- **AND** workflow-ID loading awaits the generated async workflow call
+- **AND** both methods return `ExtractionDefinition`
+
+### Requirement: Python SDK exposes extraction workflow create/update helpers
+
+The Python SDK SHALL expose hand-written convenience helpers that create and
+update extraction workflows from `ExtractionDefinition` or authored extraction
+YAML without requiring callers to manually copy persisted workflow metadata into
+generated workflow client kwargs.
+
+#### Scenario: Workflow create accepts an extraction definition
+
+- **GIVEN** an `ExtractionDefinition`
+- **WHEN** a caller invokes
+  `GroundX.create_extraction_workflow(definition=..., name=...)`
+- **THEN** the SDK sends `extract` from the definition
+- **AND** copies workflow-level `template`, `custom_steps`, `output_routes`,
+  and `leaf_fields` into generated workflow create kwargs when present
+- **AND** returns the generated `WorkflowResponse`
+- **AND** workflow assignment to a bucket or account remains an explicit
+  follow-up call such as `client.workflows.add_to_id(...)` or
+  `client.workflows.add_to_account(...)`
+
+#### Scenario: Workflow create accepts a YAML shortcut
+
+- **GIVEN** a local extraction YAML file
+- **WHEN** a caller invokes `GroundX.create_extraction_workflow(path=..., name=...)`
+- **THEN** the SDK internally loads an `ExtractionDefinition` from the YAML
+- **AND** performs the same create behavior as the definition-based path
+
+#### Scenario: Workflow update accepts an extraction definition
+
+- **GIVEN** an existing workflow ID and an `ExtractionDefinition`
+- **WHEN** a caller invokes
+  `GroundX.update_extraction_workflow(id, definition=..., name=...)`
+- **THEN** the SDK sends a full workflow settings overlay to generated
+  `workflows.update(...)`
+- **AND** does not teach or perform name-only metadata updates for extraction
+  workflows
+- **AND** returns the generated `WorkflowResponse`
+
+#### Scenario: Workflow update accepts a YAML shortcut
+
+- **GIVEN** an existing workflow ID and a local extraction YAML file
+- **WHEN** a caller invokes
+  `GroundX.update_extraction_workflow(id, path=..., name=...)`
+- **THEN** the SDK internally loads an `ExtractionDefinition` from the YAML
+- **AND** performs the same update behavior as the definition-based path
+
+#### Scenario: Create/update source selection applies definition precedence
+
+- **GIVEN** a caller wants to create or update an extraction workflow
+- **WHEN** they provide source input
+- **THEN** `definition` takes precedence over `path`, `yaml_text`, `mapping`,
+  and `prepared`
+- **AND** if `definition` is absent, exactly one YAML/prepared source is
+  required
+- **AND** if `definition` is absent, passing zero or multiple YAML/prepared
+  sources fails clearly
+- **AND** `mapping_kind` is valid only when `mapping` is the selected
+  YAML/prepared source
+- **AND** generated workflow kwargs assembly remains internal SDK plumbing, not
+  the promoted public technique
+
+#### Scenario: Prepared extraction YAML remains the advanced surface
+
+- **GIVEN** a caller needs final groups, workflow groups, pseudo groups, route
+  maps, or separated metadata
+- **WHEN** they call `prepare_extraction_yaml(...)`
+- **THEN** the SDK still returns `PreparedExtractionYaml`
+- **AND** the first-class methods do not remove, rename, or repurpose that
+  lower-level API
+- **AND** callers may load an `ExtractionDefinition` from an existing
+  `PreparedExtractionYaml`
+- **AND** callers must tolerate `definition.prepared is None` when the
+  definition was loaded from a workflow that lacks authored metadata
+
+#### Scenario: Custom workflow steps do not accidentally run fixed defaults
+
+- **GIVEN** an extraction definition with `workflow.custom_steps`
+- **WHEN** workflow create/update kwargs are produced and no explicit `steps`
+  override is provided
+- **THEN** the SDK includes an empty fixed-step overlay equivalent to the
+  harness custom-workflow path for exactly these seven stage attributes:
+  `chunk_instruct`, `chunk_keys`, `chunk_summary`, `doc_keys`, `doc_summary`,
+  `sect_instruct`, and `sect_summary`
+- **AND** the generated workflow request serializes the corresponding disabled
+  wire keys: `chunk-instruct`, `chunk-keys`, `chunk-summary`, `doc-keys`,
+  `doc-summary`, `sect-instruct`, and `sect-summary`
+- **AND** the SDK does not add `search_query` or `sect_keys` to that default
+  overlay in this plan
+- **AND** authored custom steps are not run alongside omitted fixed-step
+  defaults
+- **AND** legacy YAML without custom workflow steps preserves the old default
+  behavior unless the caller supplies explicit `steps`
+
+#### Scenario: Async workflow create/update has parity
+
+- **GIVEN** an async GroundX client
+- **WHEN** a caller invokes `AsyncGroundX.create_extraction_workflow(...)` or
+  `AsyncGroundX.update_extraction_workflow(...)`
+- **THEN** the methods accept the same definition and source arguments as the
+  sync client
+- **AND** they await the generated async workflow create/update calls
+- **AND** they return the generated async `WorkflowResponse`
+
+### Requirement: Docs and harnesses prefer path-first create/update
+
+Public documentation and harness templates SHALL teach first-class workflow
+helpers as the primary SDK path once the SDK implementation exists. The common
+create/update flow passes a YAML path directly to create/update. Definition
+loading is promoted for inspection, reuse, and copying settings from an existing
+workflow while preserving fallback paths for older SDKs and offline workflow
+JSON compilation.
+
+#### Scenario: Methods are documented as hand-written SDK helpers
+
+- **GIVEN** the Python SDK ships hand-written helpers such as `ingest` and
+  `ingest_directories`
+- **WHEN** extraction definition and workflow helpers are added
+- **THEN** `load_extraction_definition`,
+  `load_extraction_definition_from_yaml`,
+  `load_extraction_definition_from_workflow`, `create_extraction_workflow`, and
+  `update_extraction_workflow` are documented with comparable method-level
+  coverage
+- **AND** SDK docstrings include parameters, return values, examples, and update
+  semantics
+- **AND** public docs and harness references list them as hand-written Python
+  SDK helpers rather than generated Fern endpoints
+- **AND** architecture or API-surface references that enumerate hand-written SDK
+  helpers are updated
+- **AND** SDK docs make the `groundx[extract]` dependency boundary explicit
+- **AND** harness public extraction-doc guidance is updated so
+  `prepare_extraction_yaml(...)` is not the primary public create/update path
+
+#### Scenario: Public docs replace manual metadata copying
+
+- **GIVEN** public extraction workflow docs
+- **WHEN** they show how to create or update a workflow from YAML
+- **THEN** the primary example uses
+  `client.create_extraction_workflow(path=..., name=...)`
+- **AND** update examples use
+  `client.update_extraction_workflow(id, path=..., name=...)`
+- **AND** definition examples use `client.load_extraction_definition(...)` only
+  when the caller needs to inspect, reuse, or copy workflow settings
+- **AND** create examples keep the explicit workflow ID extraction and
+  bucket/account assignment step
+- **AND** manual extraction of `persisted_workflow_extract["workflow"]` and
+  manual copying of `template`, `custom_steps`, `output_routes`, and
+  `leaf_fields` is not the primary path
+
+#### Scenario: Harness keeps fallback until SDK minimum moves
+
+- **GIVEN** harness templates that may run with older SDK versions
+- **WHEN** the installed client has extraction definition and workflow helpers
+- **THEN** deploy/run/batch/prompt-manager paths use the helper methods
+- **AND** when the helpers are absent, the templates fall back to existing
+  `build_workflow_artifacts(...)` and `workflow_sdk_kwargs(...)`
+- **AND** offline compile output remains available
+- **AND** helper-backed deploy paths still write and validate the same
+  reproducible `workflow.json` and `extraction_workflow_metadata_v1.json`
+  artifacts before making API calls
+- **AND** source-of-truth surfaces such as `SKILL.md`, reference docs, evals,
+  scanners, routing/source manifests, generated plugin mirrors, and version or
+  changelog files are updated when their contracts are touched
+
+#### Scenario: Public docs and harness helper preference wait for released SDK
+
+- **GIVEN** the SDK helper implementation has not yet been published and
+  verified from a fresh `groundx[extract]` install
+- **WHEN** public docs or harness helper-preference PRs are prepared
+- **THEN** those PRs remain draft-only or blocked from merge
+- **AND** public docs do not claim the helpers are available until the release
+  gate is complete
+- **AND** harness templates keep the older-SDK fallback covered when the
+  minimum supported SDK version has not been bumped
+
+#### Scenario: Web UI guidance preserves authenticated base experience
+
+- **GIVEN** this plan touches GroundX Studio Harness web UI, publish, scaffold,
+  or onboarding references
+- **WHEN** those docs or tests are updated
+- **THEN** they continue to describe the base product experience as an
+  authenticated app shell
+- **AND** onboarding remains a configurable overlay/app metadata flow for
+  first-session guidance
+- **AND** no docs or templates introduce an anonymous onboarding-first base app
+  unless a separate approved web UI plan explicitly changes that behavior
+
+#### Scenario: Arcadia adoption is equivalence-gated
+
+- **GIVEN** Arcadia prompt management uses specialized extraction metadata keys
+- **WHEN** helper adoption is considered
+- **THEN** tests compare first-class-method behavior with the existing explicit
+  Arcadia workflow kwargs
+- **AND** equivalence includes `extract`, `_groundx_persisted_extract`,
+  serialized `steps`, `chunk_strategy`, `section_strategy`, workflow `name`, and
+  update `id`
+- **AND** Arcadia adopts the methods only if behavior is equivalent
+- **AND** otherwise Arcadia records a no-op decision and keeps its lower-level
+  explicit path
+
+### Requirement: Convenience helpers do not change Fern schema names
+
+This change SHALL NOT rename generated OpenAPI/Fern schemas or generated SDK
+classes.
+
+#### Scenario: Generated schema imports remain stable
+
+- **GIVEN** generated types such as `CustomWorkflowStepConfig`
+- **WHEN** this convenience-method change is implemented
+- **THEN** those generated schema names remain unchanged
+- **AND** normal extraction workflow callers no longer need to import them for
+  YAML-based workflow load/create/update
+- **AND** any future schema-name cleanup is handled by a separate approved plan

--- a/openspec/changes/add-extraction-workflow-convenience-methods/tasks.md
+++ b/openspec/changes/add-extraction-workflow-convenience-methods/tasks.md
@@ -1,0 +1,275 @@
+# Add Extraction Workflow Definition Methods Tasks
+
+## Working State
+
+- Central planning repo: `/Users/benjaminfletcher/git/groundx-python`
+- Central planning branch: `codex/support-custom-workflow-steps-plan`
+- SDK implementation worktree:
+  `/Users/benjaminfletcher/git/groundx-python-support-custom-workflow-steps-sdk`
+  on `codex/support-custom-workflow-steps-sdk`
+- Harness implementation worktree:
+  `/Users/benjaminfletcher/git/groundx-studio-harness-support-custom-workflow-steps`
+  on `codex/support-custom-workflow-steps-harness`
+- Public docs repo:
+  `/Users/benjaminfletcher/git/eyelevel-fern-config` on
+  `codex/support-custom-workflow-steps-fern`
+- Arcadia repo:
+  `/Users/benjaminfletcher/git/internal-arcadia-agents` on
+  `codex/extraction-reassembly-metadata`
+- ADP repo:
+  `/Users/benjaminfletcher/git/adp-poc` on
+  `codex/support-custom-workflow-steps-adp`
+
+## Tasks
+
+- [x] Validate this OpenSpec change in the central planning repo.
+- [x] Refresh every implementation branch against its current target branch
+      before coding. At minimum refresh the SDK branch against current
+      `origin/main`, the Fern docs branch against current `origin/main`, and the
+      harness branch against current `origin/main`; refresh Arcadia against its
+      configured upstream before any Arcadia edits. Then rerun the narrow
+      baseline checks for any branch that already contains custom-step work.
+      Stop before rebasing if a worktree is dirty; do not stash, commit, or
+      overwrite dirty files without explicit direction.
+- [x] In `groundx-python`, add failing tests for the public high-level API:
+      `ExtractionDefinition`,
+      `client.load_extraction_definition(...)`,
+      `client.load_extraction_definition_from_yaml(...)`,
+      `client.load_extraction_definition_from_workflow(...)`,
+      `client.create_extraction_workflow(...)`, and
+      `client.update_extraction_workflow(...)`.
+- [x] Add concrete async parity tests for the same client methods on
+      `AsyncGroundX`, including awaited YAML loading, workflow-ID loading,
+      create, update, and one-source validation failures.
+- [x] Add tests proving create/update use `definition` before YAML/prepared
+      sources, and reject ambiguous YAML/prepared sources when `definition` is
+      absent. Include cases where `mapping_kind` is provided without `mapping`
+      as the selected source.
+- [x] Add tests proving `mapping` source handling is explicit for all supported
+      shapes: authored YAML-shaped mapping by default, persisted workflow
+      `extract` mapping with authored metadata only when
+      `mapping_kind="workflow_extract"`, and execution-only workflow `extract`
+      mapping that loads with `prepared=None` only when
+      `mapping_kind="workflow_extract"`.
+- [x] Add tests proving workflow template values must be strings and that
+      placeholder-style template keys such as `{{LANGUAGE}}` and
+      `{{LANGUAGE_UNKNOWN}}` are preserved exactly, including an empty-string
+      value for `{{LANGUAGE_UNKNOWN}}`.
+- [x] Add tests proving workflow-ID loading fetches an existing workflow,
+      extracts the persisted extraction config, and fails clearly for workflows
+      without extraction config.
+- [x] Add tests using real generated `WorkflowResponse` / `WorkflowDetail`
+      models proving workflow-ID loading preserves top-level `template`,
+      `custom_steps`, `output_routes`, `leaf_fields`, `chunk_strategy`,
+      `section_strategy`, and `steps`, with persisted `extract["workflow"]`
+      used only as fallback.
+- [x] Add tests proving workflow-loaded definitions with no
+      `_groundx_persisted_extract` return `prepared=None` while still preserving
+      create/update payload fields.
+- [x] Add import-boundary tests proving `import groundx` and
+      `from groundx import GroundX, AsyncGroundX` do not import optional extract
+      dependencies at module import time, and extraction methods raise a clear
+      `pip install groundx[extract]` hint when those dependencies are missing.
+- [x] Before adding any new hand-written test under `tests/custom`, update or
+      verify `.fernignore` protects `tests/custom` so the test survives SDK
+      regeneration.
+- [x] Add tests proving custom metadata copying, generated workflow-client wire
+      serialization, and custom-step fixed-default disabling. The fixed-default
+      disabling tests must assert the exact disabled `WorkflowSteps` overlay:
+      `chunk_instruct`, `chunk_keys`, `chunk_summary`, `doc_keys`,
+      `doc_summary`, `sect_instruct`, and `sect_summary` are present and set to
+      `None` before serialization, and the generated JSON body carries the
+      corresponding disabled fixed-step keys.
+- [x] Add sync and async tests proving `request_options` passed to
+      `create_extraction_workflow(...)` and `update_extraction_workflow(...)`
+      reaches the generated workflow create/update calls.
+- [x] Implement `ExtractionDefinition` in a focused hand-written extract module
+      and export it from `groundx.extract`.
+- [x] Implement private/internal workflow kwargs assembly from
+      `ExtractionDefinition`. Do not promote this as a public method or docs
+      technique.
+- [x] Implement `GroundX.load_extraction_definition_from_yaml(...)` and
+      `GroundX.load_extraction_definition_from_workflow(...)` in the
+      hand-written SDK client subclass, not in generated Fern files.
+- [x] Implement `GroundX.load_extraction_definition(...)` as the promoted
+      consolidated loader. It must use `workflow_id` before YAML/prepared
+      sources; when `workflow_id` is absent, it must accept exactly one of
+      `path`, `yaml_text`, `mapping`, or `prepared`.
+- [x] Use lazy imports from `src/groundx/ingest.py` into the extract workflow
+      module so the base SDK remains usable without the `extract` extra.
+- [x] Implement `GroundX.create_extraction_workflow(...)` and
+      `GroundX.update_extraction_workflow(...)` so they accept an
+      `ExtractionDefinition` or YAML shortcut source and delegate to generated
+      workflow create/update calls.
+- [x] Implement async parity on `AsyncGroundX`.
+- [x] Document the promoted loader/create/update methods in the SDK with method
+      docstrings and README or reference coverage comparable to `ingest` and
+      `ingest_directories`. Public examples should show path-first
+      create/update; definition loading is for inspection, reuse, or copying
+      settings.
+- [x] Document that extraction definition methods require `groundx[extract]`,
+      while importing and using the base SDK does not.
+- [x] Verify `prepare_extraction_yaml(...)`, `PreparedExtractionYaml`,
+      `load_from_yaml(...)`, and `load_from_mapping(...)` remain available and
+      unchanged for lower-level callers, but are not promoted as the normal
+      workflow-management path.
+- [x] Run SDK narrow tests for the new methods, generated workflow-client wire
+      serialization, and existing extract YAML custom workflow tests.
+- [x] Run SDK type checks and broader custom/extract tests.
+- [x] Run SDK CI-equivalent async coverage, including the aiohttp-marked test
+      gate after installing the aiohttp extra.
+- [ ] After SDK implementation passes local gates, merge and publish the Python
+      SDK only after the custom-step deployed-path blocker is resolved. Then
+      verify the published package in a fresh environment before allowing public
+      docs or harness helper-preference PRs to merge.
+- [x] In `eyelevel-fern-config`, update
+      `fern/pages/extract-data-from-documents.mdx` so the primary workflow
+      create and update examples pass a YAML path directly to the new
+      create/update helpers.
+- [x] Add method-level public docs for
+      `client.load_extraction_definition(...)`,
+      `client.load_extraction_definition_from_yaml(...)`,
+      `client.load_extraction_definition_from_workflow(...)`,
+      `client.create_extraction_workflow(...)`, and
+      `client.update_extraction_workflow(...)`, including explicit workflow
+      assignment after create and the exact-one-source rule for the loader.
+- [x] Keep Fern/OpenAPI schema names unchanged unless a separate schema-naming
+      plan is created and approved.
+- [x] Validate Fern docs with the repo's docs checks.
+- [ ] Keep the Fern docs PR draft-only until the published Python SDK helper
+      methods are verified from the released package.
+- [x] In `groundx-studio-harness`, update deploy/run/batch/prompt-manager
+      templates to prefer the first-class loader/create/update methods when
+      installed.
+- [x] Keep `workflow_sdk_kwargs(...)` for offline compile artifacts and fallback
+      until the minimum supported SDK version includes the helper methods.
+- [x] Update harness scanners, references, evals, and source surfaces so they
+      teach path-first create/update as the preferred SDK path and definition
+      loading as the reuse/inspection path; refresh generated plugin mirrors
+      only through the repo-approved sync command.
+- [x] Update harness API-surface and Python SDK references that list
+      hand-written methods so the promoted extraction workflow methods appear
+      beside `ingest` and `ingest_directories`.
+- [x] Update `skills/groundx-extraction-workflows/references/public-docs.md`
+      so its public-doc flow prefers the new helper methods and no longer
+      teaches `prepare_extraction_yaml(...)` as the primary public path.
+- [x] Check/update harness source-of-truth surfaces when touched:
+      `skills/routing.manifest.json`, owning `SKILL.md` files,
+      `references/README.md`, skill `evals/evals.json`, scanner fixtures or
+      expectations, generated plugin mirror sync output, changelog/version
+      surfaces, and README generator output. Do not edit or scan `plugins/`
+      mirror files directly unless the task is plugin packaging.
+- [x] If any `harness-web-ui`, `harness-publish`, scaffold, or onboarding
+      reference is touched, preserve the product invariant that the base
+      experience is an authenticated app shell and onboarding is a configurable
+      overlay/app metadata flow.
+- [x] Run harness Python template tests, Node scanner/eval tests, plugin sync
+      checks, and full validation.
+- [ ] Keep harness helper-preference changes draft-only until the published
+      Python SDK helper methods are verified and the minimum supported SDK
+      version is updated or fallback behavior is proven.
+- [x] In `internal-arcadia-agents`, add tests using the existing
+      `test_policy_metadata` fixture that compare first-class-method behavior
+      to the existing explicit workflow calls. The comparison must cover
+      `extract`, `_groundx_persisted_extract`, serialized `steps`,
+      `chunk_strategy`, `section_strategy`, workflow `name`, and update `id`.
+- [x] Adopt the methods in Arcadia only if tests prove equivalent behavior;
+      otherwise record a no-op decision and leave existing explicit workflow
+      calls in place.
+- [x] Scan `adp-poc` for manual workflow create/update
+      boilerplate. Exclude generated plugin mirror directories from the scan,
+      inspect worktree status first, and update only clean, owned examples or
+      scripts. `groundx-agent-harness` is out of scope because it is generated
+      from GroundX Studio Harness.
+- [x] Run OpenSpec validation in every repo whose OpenSpec changes are touched.
+- [x] Run an adversarial review after each repo checkpoint before starting the
+      next repo.
+- [ ] Keep SDK/docs publishing and downstream dependency bumps blocked until the
+      existing custom-step deployed-path e2e blocker is resolved.
+
+## Execution Evidence And Open Blockers
+
+Updated 2026-06-14.
+
+Completed local implementation and verification:
+
+- SDK worktree `/Users/benjaminfletcher/git/groundx-python-support-custom-workflow-steps-sdk`:
+  implemented `ExtractionDefinition`, sync/async load/create/update helpers,
+  lazy extract imports, request-options propagation, explicit mapping-kind
+  handling, workflow-ID load, fixed-step disabling, and README/docstring
+  coverage. Verification run:
+  `poetry run pytest -q`,
+  `poetry run pyright`,
+  `poetry run ruff check ...touched files...`,
+  `poetry install --extras aiohttp`,
+  `poetry run pytest -q -rs -m aiohttp .`,
+  `git diff --check`.
+- Fern docs repo `/Users/benjaminfletcher/git/eyelevel-fern-config`:
+  updated `fern/pages/extract-data-from-documents.mdx` to teach
+  path-first `create_extraction_workflow` and `update_extraction_workflow`,
+  plus `load_extraction_definition`, explicit YAML/workflow loader aliases, and
+  method-level public docs covering parameters, returns, examples, extract
+  extra requirements, exact-one-source validation, explicit workflow assignment
+  after create, and full-update semantics. Verification run: `fern check`,
+  `git diff --check`.
+- Harness repo
+  `/Users/benjaminfletcher/git/groundx-studio-harness-support-custom-workflow-steps`:
+  updated deploy/run/batch/prompt-manager templates to prefer helper methods
+  with `workflow_sdk_kwargs(...)` fallback, updated public docs/reference/API
+  surfaces, updated scanner expectations, and synced generated plugin mirrors
+  through `node scripts/sync-plugin.mjs`. Verification run:
+  `node scripts/tests/test-extraction-deploy-workflow.mjs`,
+  `node scripts/tests/test-groundx-extraction-workflows.mjs`,
+  `python -m pytest skills/groundx-extraction-workflows/templates/test_compile_workflow.py skills/groundx-extraction-workflows/templates/test_imports.py -q`,
+  `node scripts/sync-plugin.mjs --check`,
+  `node scripts/validate.mjs`,
+  `git diff --check`.
+- Arcadia repo `/Users/benjaminfletcher/git/internal-arcadia-agents`:
+  added helper-backed create/update path with old-SDK fallback, kept explicit
+  Arcadia `steps`, and added payload equivalence tests for persisted extract,
+  `_groundx_persisted_extract`, steps, chunk/section strategy, name, and update
+  ID. Verification run:
+  `PYTHONPATH=$PWD pytest prompts/test_arcadia_manager.py -q`,
+  `PYTHONPATH=$PWD pytest classes/test_extraction_reassembly.py -q`,
+  `git diff --check`.
+
+Post-review fixes applied 2026-06-14:
+
+- Plan, SDK, docs, and harness guidance now promote
+  `client.create_extraction_workflow(path=...)` and
+  `client.update_extraction_workflow(id, path=...)` for the common YAML flow.
+  `client.load_extraction_definition(...)` is promoted for inspection, reuse,
+  and copying existing workflow settings, with explicit YAML/workflow aliases
+  retained for source-specific callers.
+- Arcadia now prefers `load_extraction_definition(prepared=...)` when the SDK
+  exposes it and falls back to `load_extraction_definition_from_yaml(prepared=...)`
+  for older SDKs.
+- Harness `run_extraction.py --reuse-workflow` now loads the existing extraction
+  definition when the SDK helper is available, so X-Ray fallback keeps the
+  workflow extract metadata and output routes.
+- Harness `prompt_manager.py` old-SDK fallback now uses the generated workflow
+  client's `id` argument for `workflows.update(...)` and `workflows.get(...)`.
+- Arcadia repair prompt tests now cover the helper-backed workflow update path.
+- Harness deploy template tests now cover helper-backed create/update and keep
+  old-SDK fallback coverage on the corrected `yaml_path` function contract.
+- SDK helper docstrings now include method-level parameter, return, example,
+  and update-semantics coverage, with a regression test enforcing those
+  sections for the promoted helper methods.
+- Fern public docs now include method-level helper reference sections for the
+  promoted extraction workflow helpers instead of only guide snippets.
+- `execution-plan.md` now states that its detailed checkboxes are the original
+  execution recipe and that this file is the authoritative current tracker.
+
+Open blockers / not yet executable:
+
+- SDK publish and downstream merge gates remain blocked until the custom-step
+  deployed-path e2e blocker is resolved and the released SDK package is verified
+  from a fresh environment.
+- `groundx-agent-harness` is out of scope because it is generated from GroundX
+  Studio Harness; do not edit it directly for this plan.
+- ADP scan complete: `/Users/benjaminfletcher/git/adp-poc` had only
+  whitespace-only local changes in `workflows/adp_401k_v1/prompt.yaml`; those
+  no-op changes were removed and the worktree is clean. The ADP scan found no
+  manual extraction workflow helper boilerplate to update.
+- The detached `adp-poc-support-custom-workflow-steps` worktree had no local
+  work and was removed after scan-only verification.

--- a/openspec/changes/support-custom-workflow-steps-sdk/adversarial-review.md
+++ b/openspec/changes/support-custom-workflow-steps-sdk/adversarial-review.md
@@ -1,0 +1,54 @@
+# Adversarial Review
+
+## Scope
+
+Fresh review of the SDK implementation after generated models, extract YAML
+metadata, persisted metadata reload, and custom X-Ray/readback parsing were
+implemented.
+
+## Findings
+
+### Fixed: Reserved route template tokens were treated as user template values
+
+The first generated-client and YAML tests used `CUSTOM_WORKFLOW_*` values in
+`workflow.template`. That contradicted the cashbot runtime, where those tokens
+are reserved and injected per output route. The tests now use a normal user
+template key, `BILLING_HINT`, while the SDK keeps `CUSTOM_WORKFLOW_*` reserved.
+
+### Fixed: Authored repeated list paths dropped the list field name
+
+The initial authored YAML traversal emitted `/invoice/*/description` for a list
+field `invoice.charges[].description`. The correct schema pointer is
+`/invoice/charges/*/description`. A regression test now covers this case and
+the traversal keeps the list field name while omitting `*` from the
+`workflow_field` value.
+
+### Fixed: Custom steps without output routes were accepted
+
+The initial authored metadata path allowed `workflow.custom_steps` without any
+field-level `workflow_output_key`, producing metadata the runtime would reject.
+The SDK now fails early for authored and persisted custom metadata that defines
+custom steps without matching output routes and leaf fields.
+
+### Fixed: Workflow create/update calls were not directly covered
+
+The generated type tests covered `WorkflowRequest` and `WorkflowDetail`, but not
+the actual workflow create/update call bodies. The tests now record the raw
+workflow client request body after the same HTTP encoding path used by the SDK
+and assert `template`, `customSteps`, `outputRoutes`, and `leafFields` survive
+both POST and PUT calls.
+
+### Fixed: Duplicate custom output destinations were accepted
+
+The route/leaf one-to-one check did not reject two fields that targeted the same
+custom step output destination, such as `line_item_labels.label`. The SDK now
+fails these duplicate destinations during authored and persisted metadata
+validation.
+
+## Residual Risk
+
+- Local generated SDK output was produced from Fern/OpenAPI with
+  `fern generate --group python-sdk --local --version 3.6.4
+  --no-require-env-vars`; it is verification evidence, not a public release.
+- End-to-end SDK publishing remains a later publish-last gate; downstream
+  dependency movement should wait for a published-artifact e2e.

--- a/openspec/changes/support-custom-workflow-steps-sdk/execution-plan.md
+++ b/openspec/changes/support-custom-workflow-steps-sdk/execution-plan.md
@@ -1,0 +1,127 @@
+# groundx-python SDK Execution Plan
+
+## Scope
+
+This repo owns generated Python SDK surfaces after the approved Fern/OpenAPI
+generation path and the handwritten `groundx.extract` YAML, persistence, and
+readback behavior. The central
+`openspec/changes/support-custom-workflow-steps/` folder remains a cross-repo
+coordination artifact; this folder is the repo-owned SDK implementation plan.
+
+## Files
+
+- Generated from approved Fern/OpenAPI path only:
+  `src/groundx/types/workflow_request.py`,
+  `src/groundx/types/workflow_detail.py`,
+  `src/groundx/types/workflow_steps.py`,
+  `src/groundx/types/workflow_step.py`,
+  `src/groundx/types/workflow_step_config.py`,
+  `src/groundx/types/__init__.py`,
+  `src/groundx/workflows/client.py`, and
+  `src/groundx/workflows/raw_client.py`.
+- Handwritten extract files:
+  `src/groundx/extract/prompt/utility.py`,
+  `src/groundx/extract/prompt/manager.py`,
+  `src/groundx/extract/classes/groundx.py`,
+  `src/groundx/extract/classes/document.py`,
+  `src/groundx/extract/__init__.py`, and
+  `src/groundx/extract/prompt/__init__.py`.
+- Tests:
+  `tests/custom/test_client.py`,
+  `tests/extract/prompt/test_manager.py`,
+  `tests/extract/prompt/test_persisted_workflow_extract.py`,
+  `tests/extract/classes/test_groundx.py`, and
+  `tests/extract/classes/test_document.py`.
+
+## Generated Boundaries
+
+- Generated SDK files must come from the upstream Fern/OpenAPI source and the
+  approved generation or release path.
+- Local generated output may be used for verification before public publishing.
+- Handwritten SDK commits must not directly edit generated files outside the
+  approved generation path.
+
+## Expected Failing Tests
+
+- `tests/custom/test_client.py::test_workflow_request_serializes_template_and_custom_steps`
+  fails before generation because `WorkflowRequest` cannot serialize
+  `template`, `customSteps`, `outputRoutes`, `leafFields`, or
+  `requiredTemplateKeys`.
+- `tests/custom/test_client.py::test_workflow_detail_deserializes_custom_routes_and_outputs`
+  fails before generation because `WorkflowDetail` cannot deserialize route,
+  leaf, and custom output map fields.
+- `tests/extract/prompt/test_manager.py::test_prepare_extraction_yaml_accepts_custom_workflow_steps`
+  fails before handwritten implementation because `workflow:` and
+  `workflow_step` custom metadata are not prepared.
+- `tests/extract/prompt/test_manager.py::test_prepare_extraction_yaml_rejects_slot_and_workflow_step_conflict`
+  fails before handwritten implementation because conflict validation is absent.
+- `tests/extract/prompt/test_manager.py::test_prepare_extraction_yaml_rejects_reserved_workflow_final_group`
+  fails before handwritten implementation because reserved `workflow:` behavior
+  is not enforced for custom authoring metadata.
+- `tests/extract/prompt/test_manager.py::test_prepare_extraction_yaml_rejects_invalid_custom_step_identity`
+  fails before handwritten implementation because custom step identity rules are
+  absent.
+- `tests/extract/prompt/test_manager.py::test_prepare_extraction_yaml_rejects_missing_required_template_keys`
+  fails before handwritten implementation because `required_template_keys` are
+  not validated against workflow-level `workflow.template`.
+- `tests/extract/prompt/test_manager.py::test_prepare_extraction_yaml_rejects_custom_step_over_20_fields`
+  fails before handwritten implementation because SDK-side mirrored field-load
+  validation is absent.
+- `tests/extract/prompt/test_persisted_workflow_extract.py::test_persisted_custom_workflow_extract_round_trips_routes_and_leaf_fields`
+  fails before handwritten implementation because custom route and leaf metadata
+  are not persisted.
+- `tests/extract/prompt/test_persisted_workflow_extract.py::test_persisted_custom_workflow_extract_rejects_unknown_version`
+  fails before handwritten implementation because unknown custom metadata
+  versions are not fail-closed.
+- `tests/extract/prompt/test_persisted_workflow_extract.py::test_persisted_custom_workflow_extract_rejects_route_leaf_mismatch`
+  fails before handwritten implementation because one-to-one route/leaf
+  validation is absent.
+- `tests/extract/prompt/test_persisted_workflow_extract.py::test_persisted_custom_workflow_extract_hash_is_deterministic`
+  fails before handwritten implementation because canonical hash sorting is
+  absent.
+- `tests/extract/classes/test_groundx.py::test_xray_loads_custom_output_maps`
+  fails before readback implementation because custom output maps are not
+  exposed.
+- `tests/extract/classes/test_document.py::test_document_preserves_fixed_and_custom_readback_fields`
+  fails before readback implementation because fixed and custom readback fields
+  are not modeled together.
+
+## Implementation Steps
+
+1. Add the expected failing tests listed above without changing production code.
+2. Consume generated SDK surfaces from the approved Fern/OpenAPI branch or
+   approved local generation output.
+3. Add handwritten YAML parsing for `workflow.template`, custom step
+   definitions, `workflow_step`, `workflow_output_key`, and explicit output
+   route metadata.
+4. Add persisted extract metadata with `workflow.metadata_version: 1`,
+   `custom_steps`, `output_routes`, `leaf_fields`, optional `field_counts`, and
+   optional `schema_hash`.
+5. Enforce custom step identity, reserved metadata names, `slot` /
+   `workflow_step` conflict rejection, required template keys, route/leaf
+   one-to-one integrity, repeated item wildcard paths, deterministic hash
+   sorting, and the 20-field mirrored validation rule.
+6. Preserve legacy YAML and persisted extract behavior when custom workflow
+   metadata is absent.
+7. Add readback parsing for `customChunkOutputs`, `customSectionOutputs`, and
+   `customDocumentOutputs` without changing fixed readback field names.
+8. Commit generated files separately from handwritten extract changes.
+
+## Verification Commands
+
+- `git status --short --branch`
+- `poetry run pytest tests/custom/test_client.py tests/extract/prompt/test_manager.py tests/extract/prompt/test_persisted_workflow_extract.py -q`
+- `poetry run pytest tests/extract/classes/test_groundx.py tests/extract/classes/test_document.py -q`
+- `poetry run pytest tests/extract -q`
+- `poetry run pytest -rP -n auto tests/custom tests/extract`
+- `poetry run mypy .`
+- `poetry run pytest -rP -n auto .`
+- `OPENSPEC_TELEMETRY=0 npx @fission-ai/openspec@1.3.1 validate support-custom-workflow-steps-sdk --strict`
+
+## Publish-Last Gate
+
+Do not publish the Python SDK until Fern/OpenAPI, cashbot-go runtime/API,
+handwritten extract behavior, harness compile/readback, and TypeScript
+generation smoke have passed. If the final e2e requires a published SDK, publish
+only as the final prerequisite and do not allow downstream dependency bumps
+until that published-artifact e2e passes.

--- a/openspec/changes/support-custom-workflow-steps-sdk/proposal.md
+++ b/openspec/changes/support-custom-workflow-steps-sdk/proposal.md
@@ -1,0 +1,34 @@
+# Support Custom Workflow Steps SDK
+
+## Why
+
+The shared custom workflow-step contract needs a repo-owned Python SDK plan that
+can be validated and archived independently from the central cross-repo
+coordination plan. The SDK owns generated Python workflow client surfaces after
+the approved Fern/OpenAPI path and handwritten `groundx.extract` YAML,
+persistence, and X-Ray/readback behavior.
+
+## What Changes
+
+- Add generated-client coverage for workflow-level `template`, `customSteps`,
+  `outputRoutes`, `leafFields`, `requiredTemplateKeys`, custom output maps, and
+  field-count metadata once the Fern/OpenAPI contract is generated into this
+  repo.
+- Add handwritten extraction YAML support for `workflow:` authoring metadata,
+  custom workflow steps, `workflow_step`, `workflow_output_key`, persisted
+  `workflow.extract.workflow` metadata, route/leaf integrity, and 20-field
+  mirrored validation.
+- Add SDK readback support for `customChunkOutputs`,
+  `customSectionOutputs`, and `customDocumentOutputs` while preserving fixed
+  fields such as `chunkKeywords`, `sectionSummary`, and `fileSummary`.
+- Keep generated files separate from handwritten extract implementation and
+  publish the SDK only after upstream runtime/API, schema, harness, and
+  TypeScript generation gates pass.
+
+## Impact
+
+- The existing central `support-custom-workflow-steps` change remains a
+  coordination artifact and is not the archiveable SDK implementation plan.
+- This change is the repo-owned, archiveable Python SDK implementation plan.
+- No SDK implementation begins until a clean implementation branch/worktree is
+  selected and the generated-file source path is confirmed.

--- a/openspec/changes/support-custom-workflow-steps-sdk/specs/custom-output-readback/spec.md
+++ b/openspec/changes/support-custom-workflow-steps-sdk/specs/custom-output-readback/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: SDK readback exposes custom output maps
+
+The SDK SHALL parse and expose custom chunk, section, and document output maps
+from X-Ray/readback responses while preserving legacy fixed readback fields.
+
+#### Scenario: Custom output maps load from X-Ray
+
+- **GIVEN** an X-Ray/readback response with `customChunkOutputs`,
+  `customSectionOutputs`, and `customDocumentOutputs`
+- **WHEN** the SDK loads the response into extract classes
+- **THEN** chunk-level custom values are readable from `customChunkOutputs`
+- **AND** section-level custom values are readable from `customSectionOutputs`
+- **AND** document-level custom values are readable from
+  `customDocumentOutputs`
+- **AND** matching page-level chunk paths are parsed when X-Ray includes
+  `documentPages[].chunks[]`
+
+#### Scenario: Fixed readback fields remain stable
+
+- **GIVEN** an old X-Ray/readback response that contains fixed outputs only
+- **WHEN** the SDK loads the response
+- **THEN** `chunkKeywords`, `sectionSummary`, and `fileSummary` remain readable
+- **AND** missing custom output maps are treated as absent or empty
+- **AND** old documents do not require a backfill migration before SDK readback
+
+#### Scenario: Document custom output is not fileSummary
+
+- **GIVEN** a custom document-level output
+- **WHEN** the SDK loads X-Ray/readback data
+- **THEN** the value is read from top-level `customDocumentOutputs`
+- **AND** it is not read from legacy top-level or per-chunk `fileSummary`

--- a/openspec/changes/support-custom-workflow-steps-sdk/specs/extract-yaml/spec.md
+++ b/openspec/changes/support-custom-workflow-steps-sdk/specs/extract-yaml/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Extraction YAML can author custom workflow steps
+
+The SDK SHALL parse top-level `workflow:` authoring metadata for custom
+workflow steps while preserving final JSON group names.
+
+#### Scenario: Custom workflow steps prepare into persisted metadata
+
+- **GIVEN** extraction YAML with `workflow.custom_steps`, workflow-level
+  `workflow.template`, final groups, group-level `workflow_step`, and
+  field-level `workflow_output_key`
+- **WHEN** `prepare_extraction_yaml(...)` prepares the YAML
+- **THEN** final groups remain the final JSON shape
+- **AND** custom step definitions are persisted under
+  `workflow.extract.workflow.custom_steps`
+- **AND** route metadata is persisted under
+  `workflow.extract.workflow.output_routes`
+- **AND** leaf metadata is persisted under
+  `workflow.extract.workflow.leaf_fields`
+- **AND** the final JSON does not contain the authoring-only `workflow`,
+  `workflow_step`, or `workflow_output_key` metadata keys
+
+#### Scenario: Workflow is always reserved
+
+- **GIVEN** YAML with a top-level `workflow:` mapping
+- **WHEN** `prepare_extraction_yaml(...)` prepares the YAML
+- **THEN** the mapping is parsed only as workflow authoring metadata
+- **AND** a final output group named `workflow` is rejected with a clear
+  migration error
+
+#### Scenario: Legacy slot remains compatibility-only
+
+- **GIVEN** legacy YAML that uses `slot:` metadata and no custom step
+  definitions
+- **WHEN** `prepare_extraction_yaml(...)` prepares the YAML
+- **THEN** existing fixed-step behavior remains unchanged
+- **AND** new YAML may use `workflow_step:` for fixed or custom step names
+- **AND** a group that declares both `slot` and `workflow_step` fails clearly
+
+#### Scenario: Custom step identity is canonical
+
+- **GIVEN** YAML custom step definitions
+- **WHEN** the SDK prepares workflow metadata
+- **THEN** custom step names match `^[a-z][a-z0-9_]{0,63}$`
+- **AND** names are globally unique across custom steps
+- **AND** names do not collide with fixed workflow step names or reserved
+  metadata names
+- **AND** uppercase, hyphenated, dotted, spaced, leading-underscore, empty, or
+  overlength names fail clearly
+
+#### Scenario: Field load is mirrored before workflow submission
+
+- **GIVEN** prepared YAML that assigns more than 20 prompted leaf fields to one
+  executable workflow step
+- **WHEN** the SDK prepares or submits the workflow
+- **THEN** the SDK raises an error naming the overloaded step
+- **AND** the error states that one executable workflow step may own at most 20
+  fields
+- **AND** public API/runtime validation remains authoritative for direct API
+  callers
+
+### Requirement: Persisted workflow extract keeps custom metadata round trippable
+
+The SDK SHALL persist enough canonical metadata under
+`workflow.extract.workflow` to reload authored custom workflow steps and derive
+or verify executable-step field counts.
+
+#### Scenario: Custom workflow extract round trips
+
+- **GIVEN** prepared YAML with custom steps, output routes, leaf fields,
+  repeated item paths, and workflow-level template values
+- **WHEN** the SDK serializes and reloads
+  `PreparedExtractionYaml.persisted_workflow_extract`
+- **THEN** `workflow.metadata_version: 1` is preserved
+- **AND** `custom_steps`, `output_routes`, and `leaf_fields` are preserved
+- **AND** each route has exactly one matching leaf field on `final_path`,
+  `workflow_group`, `workflow_field`, `step_name`, `level`, and `output_key`
+- **AND** repeated item leaf paths use a literal `*` RFC 6901 path segment
+- **AND** deterministic `schema_hash` calculation excludes prompt prose,
+  examples, model parameters, and template values
+
+#### Scenario: Unknown custom metadata versions fail closed
+
+- **GIVEN** a persisted workflow extract payload with custom workflow metadata
+- **AND** its metadata version is missing, unknown, future, non-integer, or
+  unsupported
+- **WHEN** the SDK reloads the mapping
+- **THEN** reload fails clearly
+- **AND** the SDK does not silently drop custom step assignments

--- a/openspec/changes/support-custom-workflow-steps-sdk/specs/release-governance/spec.md
+++ b/openspec/changes/support-custom-workflow-steps-sdk/specs/release-governance/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Python SDK release follows publish-last gates
+
+The Python SDK SHALL be published only after local/runtime/schema/SDK/harness
+verification is complete and immediately before any final e2e path that
+requires a published SDK artifact.
+
+#### Scenario: Local generated output is verification, not release
+
+- **GIVEN** local generated Python SDK output is used to test custom workflow
+  steps before public publication
+- **WHEN** verification is reviewed
+- **THEN** the local generated output is identified as non-release evidence
+- **AND** downstream dependency bumps do not depend on that local output
+
+#### Scenario: Published SDK is final e2e prerequisite
+
+- **GIVEN** Fern/OpenAPI, cashbot-go runtime/API, SDK extract behavior, harness
+  compile/readback, and TypeScript generation smoke have passed
+- **WHEN** the final e2e path requires a published SDK
+- **THEN** publishing the SDK is allowed as the final prerequisite
+- **AND** downstream repos use a lower-bound dependency such as
+  `groundx-python >= <released version>` only after the published-artifact e2e
+  passes
+
+#### Scenario: Published-artifact e2e failure blocks downstream movement
+
+- **GIVEN** the SDK has been published as the final e2e prerequisite
+- **WHEN** the published-artifact e2e path fails
+- **THEN** the release is recorded as failed
+- **AND** downstream dependency bumps and customer-facing closeout remain
+  blocked until a corrective publication or approved replacement path passes

--- a/openspec/changes/support-custom-workflow-steps-sdk/specs/workflow-client/spec.md
+++ b/openspec/changes/support-custom-workflow-steps-sdk/specs/workflow-client/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Generated workflow clients expose custom workflow config
+
+The generated Python SDK workflow request and response models SHALL represent
+the public Fern/OpenAPI custom workflow-step contract after the approved
+generation path.
+
+#### Scenario: Workflow request serializes custom config
+
+- **GIVEN** SDK code builds a workflow create or update request
+- **WHEN** the request includes workflow-level `template`, `customSteps`,
+  `outputRoutes`, `leafFields`, and `requiredTemplateKeys`
+- **THEN** the generated request model serializes those fields with the public
+  JSON names
+- **AND** legacy fixed `steps` fields remain serializable
+- **AND** custom step `config` can carry existing element-targeted prompt,
+  engine, and include settings while omitting or nulling legacy fixed-output
+  `field`
+
+#### Scenario: Workflow detail deserializes custom metadata
+
+- **GIVEN** the workflow API returns persisted custom workflow-step metadata
+- **WHEN** the generated SDK deserializes workflow detail
+- **THEN** it exposes `customSteps`, `outputRoutes`, `leafFields`, `template`,
+  field-count metadata, and custom output map schemas without dropping fields
+- **AND** fixed workflow details still deserialize with existing fields
+
+#### Scenario: Generated files come from the approved source path
+
+- **GIVEN** generated SDK files change for custom workflow steps
+- **WHEN** the SDK change is reviewed
+- **THEN** the generated files came from the upstream Fern/OpenAPI source and
+  approved generation or release path
+- **AND** handwritten extract implementation did not directly edit generated
+  files outside that path

--- a/openspec/changes/support-custom-workflow-steps-sdk/tasks.md
+++ b/openspec/changes/support-custom-workflow-steps-sdk/tasks.md
@@ -1,0 +1,75 @@
+# Support Custom Workflow Steps SDK Tasks
+
+## Working State
+
+- Repo scan branch: `codex/support-custom-workflow-steps-plan`.
+- Repo scan dirty state: untracked central OpenSpec change folder
+  `openspec/changes/support-custom-workflow-steps/` and this repo-owned SDK
+  OpenSpec change folder.
+- Implementation branch/worktree: create or confirm clean branch
+  `codex/support-custom-workflow-steps-sdk` from `origin/main` before code
+  changes.
+- Commit checkpoints:
+  1. failing generated-client serialization and extract YAML tests;
+  2. approved generated SDK surfaces;
+  3. handwritten extract YAML and persisted metadata;
+  4. X-Ray/readback parsing and full SDK verification.
+
+## Tasks
+
+- [ ] Create or select clean branch `codex/support-custom-workflow-steps-sdk`
+      from `origin/main`.
+- [ ] Confirm clean implementation state with `git status --short --branch`.
+- [ ] Add failing generated-client serialization tests in
+      `tests/custom/test_client.py` named
+      `test_workflow_request_serializes_template_and_custom_steps` and
+      `test_workflow_detail_deserializes_custom_routes_and_outputs`.
+      Expected before generated update: `WorkflowRequest` and `WorkflowDetail`
+      cannot represent the new fields or reject them as unknown extras.
+- [ ] Add failing extraction YAML tests in
+      `tests/extract/prompt/test_manager.py` named
+      `test_prepare_extraction_yaml_accepts_custom_workflow_steps`,
+      `test_prepare_extraction_yaml_rejects_slot_and_workflow_step_conflict`,
+      `test_prepare_extraction_yaml_rejects_reserved_workflow_final_group`,
+      `test_prepare_extraction_yaml_rejects_invalid_custom_step_identity`,
+      `test_prepare_extraction_yaml_rejects_missing_required_template_keys`,
+      and `test_prepare_extraction_yaml_rejects_custom_step_over_20_fields`.
+      Expected before implementation: preparation treats `workflow:` as an
+      ordinary group, rejects unknown metadata, or drops custom metadata.
+- [ ] Add failing persisted extract tests in
+      `tests/extract/prompt/test_persisted_workflow_extract.py` named
+      `test_persisted_custom_workflow_extract_round_trips_routes_and_leaf_fields`,
+      `test_persisted_custom_workflow_extract_rejects_unknown_version`,
+      `test_persisted_custom_workflow_extract_rejects_route_leaf_mismatch`,
+      and `test_persisted_custom_workflow_extract_hash_is_deterministic`.
+      Expected before implementation: custom workflow metadata is not preserved
+      or is silently ignored.
+- [ ] Add failing readback tests in `tests/extract/classes/test_groundx.py`
+      named `test_xray_loads_custom_output_maps` and in
+      `tests/extract/classes/test_document.py` named
+      `test_document_preserves_fixed_and_custom_readback_fields`.
+      Expected before implementation: custom output maps are unavailable while
+      fixed fields still load.
+- [ ] Consume generated SDK surfaces from the approved Fern/OpenAPI source path;
+      do not hand-edit generated files outside that path.
+- [ ] Implement extraction YAML parsing for workflow-level `workflow.template`,
+      custom step definitions, `workflow_step`, and `workflow_output_key`.
+- [ ] Implement persisted `workflow.extract.workflow` metadata for
+      `metadata_version`, `custom_steps`, `output_routes`, `leaf_fields`,
+      optional `field_counts`, and optional `schema_hash`.
+- [ ] Enforce custom step identity, route/leaf one-to-one integrity, repeated
+      item wildcard path semantics, deterministic hash sorting, and mirrored
+      20-field validation before sending workflows.
+- [ ] Preserve legacy `slot:` behavior for existing YAML and fail when `slot`
+      and `workflow_step` appear on the same group.
+- [ ] Add X-Ray/readback parsing for `customChunkOutputs`,
+      `customSectionOutputs`, and `customDocumentOutputs`.
+- [ ] Run `poetry run pytest tests/custom/test_client.py tests/extract/prompt/test_manager.py tests/extract/prompt/test_persisted_workflow_extract.py -q`.
+- [ ] Run `poetry run pytest tests/extract/classes/test_groundx.py tests/extract/classes/test_document.py -q`.
+- [ ] Run `poetry run pytest tests/extract -q`.
+- [ ] Run `poetry run pytest -rP -n auto tests/custom tests/extract`.
+- [ ] Run `poetry run mypy .`.
+- [ ] Run `poetry run pytest -rP -n auto .` before release readiness.
+- [ ] Commit generated files separately from handwritten extract changes.
+- [ ] Adversarial review: confirm fixed workflows, old persisted extracts, and
+      old X-Ray/readback fields still work and custom behavior is additive.

--- a/openspec/changes/support-custom-workflow-steps/chunk-keywords-trace.md
+++ b/openspec/changes/support-custom-workflow-steps/chunk-keywords-trace.md
@@ -1,0 +1,326 @@
+# Fixed Output Trace
+
+This trace is the anchor for the custom step plan. `chunk-keys` is the closest
+current analogue for a custom chunk-level output, but the final design must also
+cover representative section-level and document-level outputs.
+
+## Chunk-Level Name Changes
+
+| Layer | Name |
+| --- | --- |
+| Workflow step key | `chunk-keys` |
+| Python SDK `WorkflowSteps` attr | `chunk_keys` |
+| Python SDK `WorkflowStepConfig.field` value | `chunk-keys` |
+| Go step enum | `summarizer.ChunkKeys` |
+| Go field enum | `summarizer.ChunkKeysF` |
+| Go chunk storage | `layout.Chunk.MoleKeysD` / `layout.Chunk.MoleKeys` |
+| Go setter | `layout.Chunk.SetChunkKeys(...)` |
+| Go X-Ray field | `chunkKeywords` |
+| Python extract X-Ray model | `Chunk.chunkKeywords` |
+| Python document loader | parses `chunk.chunkKeywords` as JSON |
+| Harness X-Ray helper | reads `chunk["chunkKeywords"]` |
+| Arcadia runtime metadata tests | include `chunkKeywords` as a readable X-Ray field |
+
+## Section-Level Name Changes
+
+| Layer | Name |
+| --- | --- |
+| Workflow step key | `sect-summary` |
+| Python SDK `WorkflowSteps` attr | `sect_summary` |
+| Python SDK `WorkflowStepConfig.field` value | `sect-sum` |
+| Go step enum | `summarizer.SectSummary` |
+| Go field enum | `summarizer.SectSumF` |
+| Go storage | `layout.Chunk.SectionMeta.Search` |
+| Go setter/getter | `layout.Chunk.SetSectionSummary(...)` / `GetSectionSummary()` |
+| Go X-Ray field | `sectionSummary` |
+| Python extract X-Ray model | `Chunk.sectionSummary` |
+| Python document loader | parses `chunk.sectionSummary` as JSON |
+| Harness X-Ray helper | reads `sectionSummary` for statement scalar fields |
+| Arcadia runtime metadata | `XRAY_REASSEMBLY_OUTPUT_ATTRS` includes `sectionSummary` |
+
+## Document-Level Name Changes
+
+| Layer | Name |
+| --- | --- |
+| Workflow step key | `doc-summary` |
+| Python SDK `WorkflowSteps` attr | `doc_summary` |
+| Python SDK `WorkflowStepConfig.field` value | `doc-sum` |
+| Go step enum | `summarizer.DocSummary` |
+| Go field enum | `summarizer.DocSumF` |
+| Go storage | `layout.Chunk.DocumentMeta.Search` |
+| Go setter/getter | `layout.Chunk.SetDocumentSummary(...)` / `GetDocumentSummary()` |
+| Go X-Ray field | top-level JSON `fileSummary` (`XRay.Summary`) when one document summary applies; per-chunk JSON `fileSummary` (`XRayChunk.FileSummary`) only when chunk summaries diverge |
+| Python extract X-Ray model | `XRayDocument.fileSummary` and `Chunk.fileSummary` |
+| Python document loader | currently parses `Chunk.fileSummary` as JSON but does not parse top-level `XRayDocument.fileSummary` |
+| Harness X-Ray helper | does not currently aggregate `fileSummary` |
+| Arcadia runtime metadata | `XRAY_REASSEMBLY_OUTPUT_ATTRS` includes chunk-level `fileSummary`; `Statement.load_xray` iterates chunks, not top-level X-Ray metadata |
+
+## Current Code Points
+
+### eyelevel-fern-config
+
+- `fern/openapi.yml` defines `WorkflowStepConfig.field` enum values, including
+  `chunk-keys`.
+- `fern/openapi.yml` defines fixed `WorkflowSteps` properties, including
+  `chunk-keys`.
+- `fern/openapi.yml` defines `WorkflowSteps` properties for `sect-summary` and
+  `doc-summary`, and `WorkflowStepConfig.field` enum values for `sect-sum` and
+  `doc-sum`.
+- `fern/openapi.yml` exposes `WorkflowRequest`/`WorkflowDetail` fields for
+  `chunkStrategy`, `name`, `extract`, `sectionStrategy`, and `steps`; it does
+  not expose `template`.
+- `fern/generators.yml` generates both Python and TypeScript SDKs from the
+  shared OpenAPI contract.
+
+### groundx-python
+
+- `src/groundx/types/workflow_steps.py` exposes `chunk_keys`.
+- `src/groundx/types/workflow_step_config_field.py` includes literal
+  `chunk-keys`, `sect-sum`, and `doc-sum`.
+- `src/groundx/extract/classes/groundx.py` has fixed X-Ray fields
+  `chunkKeywords`, `fileKeywords`, `fileSummary`, `sectionKeywords`,
+  `sectionSummary`, and `suggestedText`; it has no generic custom output map.
+- `src/groundx/extract/classes/document.py` parses `chunk.sectionSummary`,
+  `chunk.suggestedText`, `chunk.chunkKeywords`, `chunk.sectionKeywords`,
+  `chunk.fileKeywords`, and `chunk.fileSummary` as JSON.
+- `src/groundx/extract/classes/document.py` does not currently parse
+  `XRayDocument.fileSummary`, even though `XRayDocument` has that field.
+- `src/groundx/extract/prompt/utility.py` currently reserves `_defs`,
+  `_pseudo_groups`, and `_groundx_persisted_extract`; it does not treat
+  top-level `workflow:` as a special authoring section.
+- `src/groundx/extract/prompt/manager.py` persists workflow route metadata
+  through `workflow_field_paths`, `persisted_workflow_extract`, and related
+  metadata accessors.
+- `tests/extract/classes/test_groundx.py` asserts `chunkKeywords` is parsed.
+- The SDK X-Ray/readback trace must be expanded to include custom section and
+  document output maps after the public output shape is chosen.
+- The SDK YAML trace must include reserved top-level authoring keys and legacy
+  final groups named `workflow`.
+
+### cashbot-go
+
+- `pkg/model/summarizer/step_type.go` maps `chunk-keys` to `ChunkKeys`.
+- `pkg/model/summarizer/step_type.go` accepts only fixed step names in
+  `UnmarshalText`, so arbitrary custom step names cannot enter the current
+  `Steps` map.
+- `pkg/model/summarizer/field_type.go` maps `chunk-keys` to `ChunkKeysF`.
+- `pkg/model/summarizer/field_type.go` accepts only fixed field names in
+  `UnmarshalText`, so custom output fields need a separate model or expanded
+  validation contract.
+- `pkg/model/summarizer/process.go` maps `ChunkKeys` to `ChunkKeysF`.
+- `pkg/model/summarizer/process.go` maps `SectSummary` to `SectSumF` and
+  `DocSummary` to `DocSumF`.
+- `pkg/model/summarizer/process.go` writes `ChunkKeysF` through
+  `cnk.SetChunkKeys(...)`.
+- `pkg/model/summarizer/process.go` writes `SectSumF` through
+  `cnk.SetSectionSummary(...)` and `DocSumF` through
+  `cnk.SetDocumentSummary(...)`.
+- `pkg/model/summarizer/process.go` already carries
+  `Template *map[string]string`, and `Process.Copy()` preserves it.
+- `pkg/processor/summarizer/chunks.go` runs `Summarizer.ChunkKeywords(...)`.
+- `pkg/processor/summarizer/sections.go`, `document.go`, `request.go`,
+  `execute.go`, `util.go`, and `processor.go` participate in section/document
+  summary execution and prompt rendering.
+- `pkg/model/layout/chunk.go` stores chunk keywords as `MoleKeysD`/`MoleKeys`,
+  section summaries as `SectionMeta.Search`, and document summaries as
+  `DocumentMeta.Search`.
+- `pkg/model/layout/xray.go` emits document summary differently depending on
+  document consistency: a single consistent summary becomes top-level
+  `XRay.Summary` / JSON `fileSummary`; divergent document summaries become
+  per-chunk `FileSummary` / JSON `fileSummary`.
+- `pkg/model/layout/document.go`, `search_meta.go`, `custom_meta.go`, and
+  related tests may be needed if custom section/document outputs cannot live on
+  fixed chunk fields.
+- `pkg/model/layout/xray.go` emits `ChunkKeywords` with JSON tag
+  `chunkKeywords`, `SectionSummary` with JSON tag `sectionSummary`, and
+  `FileSummary` with JSON tag `fileSummary`.
+- `pkg/model/layout/xray_test.go` covers X-Ray `ChunkKeywords`.
+- `pkg/model/completions/eyelevel/process.go` loads `Process.Template` into
+  prompt templates via `gpt.InitTemplates(...)`.
+- `pkg/model/prompt/templates.go` initializes and expands template values for
+  prompt rendering.
+- `pkg/partner/workflow.go` top-level create/update compatibility paths copy
+  `ChunkStrategy`, `Extract`, and `Steps`, but not `Template`; the existing
+  `APIRequest.Template` field is a different partner template type, not the
+  workflow `*map[string]string` template config.
+
+### internal-arcadia-agents
+
+- `classes/statement.py` includes `chunkKeywords` in the X-Ray output fields
+  used by routed reassembly.
+- `classes/statement.py` also includes `sectionSummary` and `fileSummary` in
+  `XRAY_REASSEMBLY_OUTPUT_ATTRS`.
+- `classes/statement.py` builds workflow output by iterating `xray.chunks` and
+  the allowlisted chunk attributes; it does not currently route top-level
+  `XRayDocument.fileSummary`.
+- `classes/extraction_reassembly.py` routes workflow output by
+  `workflow_field_paths` and fails preflight on missing groups, invalid route
+  maps, or duplicate final paths.
+- `tasks/download.py`, `tasks/agent.py`, `tasks/save.py`, and
+  `classes/arcadia_agent_request.py` currently implement a hardcoded request
+  type graph for reconcile/QA/save operations.
+- `classes/test_extraction_reassembly.py` includes a parametrized test that
+  verifies metadata can read `chunkKeywords`.
+- Runtime metadata must be traced from custom X-Ray/readback output path back to
+  final JSON path.
+
+### groundx-studio-harness
+
+- `skills/groundx-extraction-workflows/templates/compile_workflow.py` maps
+  `slot: chunk-keys` to SDK attr `chunk_keys`.
+- `skills/groundx-extraction-workflows/templates/compile_workflow.py` currently
+  exposes a fixed `SLOT_MENU` of `chunk-instruct`, `chunk-keys`, and
+  `chunk-summary`; it does not expose custom step arrays or custom output maps.
+- `skills/groundx-extraction-workflows/templates/xray_to_extract.py` reads
+  `chunkKeywords` for charges, `chunkSummary`/`suggestedText` for meters, and
+  `sectionSummary` for statement fields.
+- `skills/groundx-extraction-workflows/templates/validate_workflow_json.py`,
+  `SKILL.md`, `SKILL.public.md`, `references/*`, `evals/evals.json`,
+  examples, changelog entries, and scanner tests enforce or describe the old
+  fixed-slot model.
+- `skills/groundx-extraction-workflows/references/2_schema_design.md` documents
+  `chunk-keys` -> `chunkKeywords`.
+- `scripts/tests/test-groundx-extraction-workflows.mjs` validates the old
+  three-slot menu and must be updated when custom steps are supported.
+
+## Custom Step Serialization Survival Points
+
+Custom step identity must survive these boundaries without case, kebab, camel,
+or enum-name normalization:
+
+- authored extraction YAML: `workflow.custom_steps.<level>[].name`, final group
+  `workflow_step`, and field-level `workflow_output_key`
+- SDK prepared state: custom step definitions, workflow group assignments,
+  canonical route metadata, and `leaf_fields`
+- persisted workflow extract metadata: `workflow.metadata_version`, `custom_steps`,
+  `output_routes`, `leaf_fields`, optional `field_counts`, and optional
+  `schema_hash`
+- public workflow config: `customSteps[].name`, `customSteps[].level`,
+  `customSteps[].kind`, optional `customSteps[].config`,
+  `customSteps[].requiredTemplateKeys`, workflow-level `outputRoutes[]`,
+  workflow-level `leafFields[]`, route `outputKey` values, and leaf
+  `isRepeated`/`repetitionScope` values for direct non-YAML callers
+- cashbot-go model/runtime: custom step names must use a custom-step model path
+  rather than the fixed `StepType` enum path, while fixed step names keep the
+  existing enum behavior
+- runtime storage and X-Ray/readback: custom output maps are keyed by
+  `<step_name>/<output_key>` through `customChunkOutputs`,
+  `customSectionOutputs`, and `customDocumentOutputs`
+- SDK, harness, and Arcadia reassembly: route metadata must map the exact custom
+  readback path back to the final JSON path without exposing custom workflow
+  group names as final groups
+
+The fixed-output trace follows real runtime paths for the representative chunk,
+section, and document outputs: workflow config enters fixed Go step/field enums,
+processors write fixed layout fields, X-Ray emits fixed JSON names, and SDK,
+harness, or Arcadia read those emitted names. The custom-step plan therefore
+adds separate custom-step metadata and custom output maps instead of overloading
+the fixed fields or aliases.
+
+## Repo-Plan Verification Questions
+
+Resolved by the locked central contract:
+
+- Custom X-Ray/readback uses `customChunkOutputs`, `customSectionOutputs`, and
+  `customDocumentOutputs`.
+- Custom document outputs use `customDocumentOutputs`, not legacy top-level or
+  per-chunk `fileSummary`.
+- Public workflow `template` follows cashbot-go workflow/process
+  `Process.Template *map[string]string`; the top-level partner template object
+  is not reused.
+- One executable workflow step may own at most 20 fields, with public
+  API/runtime hard-fail validation mirrored by SDK, harness, and ADP validation.
+- Top-level YAML `workflow:` is always reserved for authoring metadata.
+- Arcadia keeps `agent` and `save_agents` internal behind the default
+  compatibility adapter, treats `qa_charges` as dead legacy, and defers
+  `reconcile_fields`, `qa_fields`, and `save_fields` to a follow-on plan.
+- SDK/docs publishing is allowed only late, after local verification, as the
+  final prerequisite before the e2e path that requires published artifacts.
+- Route metadata records `workflow_group`, `workflow_field`, `final_path`,
+  `step_name`, `level`, `output_map`, `output_key`, and `readback_path`.
+- Public workflow config carries route records as workflow-level `outputRoutes`;
+  persisted metadata stores them as `output_routes`.
+- Public workflow config carries leaf-field records as workflow-level
+  `leafFields`; persisted metadata stores them as `leaf_fields`.
+- Public `outputRoutes` and `leafFields` must match one-to-one on final path,
+  workflow group/field, custom step, level, and output key before hashing or
+  execution.
+- YAML explicit output keys use field-level `workflow_output_key`; persisted
+  metadata uses `output_key`; public JSON route records use `outputKey`.
+- Public `customSteps[]` records contain `name`, `level`, `kind`, optional
+  `config`, and optional `requiredTemplateKeys`; custom step `config` reuses the
+  existing element-targeted workflow step shape and omits or nulls the legacy
+  fixed-output `field`.
+- Custom step names are lower snake case (`^[a-z][a-z0-9_]{0,63}$`), globally
+  unique, and never auto-normalized from case/kebab/camel variants.
+- Custom output `output_key` values follow the same lower-snake-case rule.
+- `workflow.metadata_version: 1` is current; unknown/future custom workflow
+  metadata versions fail closed.
+- Public API/runtime field counts are server-recomputed from canonical
+  `workflow.extract.workflow.output_routes` and
+  `workflow.extract.workflow.leaf_fields`.
+- Leaf-field repetition uses `is_repeated` and `repetition_scope` in persisted
+  metadata, and `isRepeated` and `repetitionScope` in public JSON.
+- Repeated item leaves use a literal `*` RFC 6901 path segment as a schema
+  wildcard, such as `/fees/*/amount`, and count once per prompted schema leaf.
+- Template config is `map[string]string`, allows extra keys, blocks reserved
+  names and invalid types/sizes, stores YAML-authored values at workflow-level
+  `workflow.template`, declares required keys through step metadata, validates
+  required keys with the same normalization/rules as template keys, and keeps
+  existing fixed-prompt optional placeholder behavior.
+- Reserved workflow metadata template key names are enumerated by the
+  workflow-config contract and apply equally to `template` and
+  `requiredTemplateKeys`.
+- TypeScript smoke coverage uses `fern generate --group ts-sdk`.
+
+- The repo-owned `cashbot-go` plan now records the exact storage persistence
+  boundary: `layout.CustomMeta` document (`docM`), molecule (`moleM`), and
+  section (`sectionM`) maps, with `CustomMeta.Scan`/`Value` as the DB
+  serialization boundary and nil/absent metadata treated as empty custom output
+  maps for old rows.
+- The repo-owned `cashbot-go` plan now records the public workflow create/update
+  validation path: `WorkflowHandler.createWorkflow` and
+  `WorkflowHandler.updateWorkflow` call `Workflow.ValidateCreate` and
+  `Workflow.ValidateEdit`; custom-step, route/leaf, schema-hash, and 20-field
+  validation must be reached from both methods.
+- The current `internal-arcadia-agents` gate is only a deferral stub. The
+  follow-on plan, created after central cleanup/closeout, must define input
+  payload, output payload, retry/idempotency, and failure propagation contracts
+  for `reconcile_fields`, `qa_fields`, and `save_fields`.
+
+## Trace Commands To Rerun Before Implementation
+
+```bash
+rg -n "chunk-keys|chunkKeys|ChunkKeys|chunkKeywords|ChunkKeywords|MoleKeys|SetChunkKeys" \
+  /Users/benjaminfletcher/git/eyelevel-fern-config \
+  /Users/benjaminfletcher/git/groundx-python \
+  /Users/benjaminfletcher/git/cashbot-go \
+  /Users/benjaminfletcher/git/internal-arcadia-agents \
+  /Users/benjaminfletcher/git/groundx-studio-harness
+```
+
+```bash
+rg -n "sect-summary|sect-sum|SectSummary|SectionSummary|sectionSummary|SetSectionSummary|doc-summary|doc-sum|DocSummary|DocumentSummary|fileSummary|FileSummary|XRayDocument|SetDocumentSummary|GetDocumentSummary|XRay\\.Summary|XRayChunk\\.FileSummary" \
+  /Users/benjaminfletcher/git/eyelevel-fern-config \
+  /Users/benjaminfletcher/git/groundx-python \
+  /Users/benjaminfletcher/git/cashbot-go \
+  /Users/benjaminfletcher/git/internal-arcadia-agents \
+  /Users/benjaminfletcher/git/groundx-studio-harness
+```
+
+```bash
+rg -n "qa_charges|qa_meters|qa_statement|reconcile_charges|reconcile_meters|reconcile_statement|save_charges|save_meters|save_statement|allowed_request_types|next_agent|save_agents|def agent" \
+  /Users/benjaminfletcher/git/internal-arcadia-agents
+```
+
+```bash
+rg -n "Template \\*map\\[string\\]string|template,omitempty|Templates\\(\\)|process.Templates" \
+  /Users/benjaminfletcher/git/cashbot-go
+```
+
+```bash
+rg -n "workflow:|RESERVED_TOP_LEVEL_KEYS|top_level_metadata|workflow_group_metadata|_groundx_persisted_extract|workflow_field_paths|final_field_paths" \
+  /Users/benjaminfletcher/git/groundx-python \
+  /Users/benjaminfletcher/git/internal-arcadia-agents \
+  /Users/benjaminfletcher/git/groundx-studio-harness
+```

--- a/openspec/changes/support-custom-workflow-steps/design.md
+++ b/openspec/changes/support-custom-workflow-steps/design.md
@@ -1,0 +1,763 @@
+# Design: Support Custom Workflow Steps
+
+## Current Findings
+
+### ADP POC
+
+`/Users/benjaminfletcher/git/adp-poc/workflows/adp_401k_v1/prompt.yaml` has 11
+top-level final sections. All 11 declare `slot: chunk-instruct`. The conversion
+report records `workflow_load_exceptions.slot_field_counts["chunk-instruct"]`
+as 159 fields and marks runtime prompt-load reduction as unresolved.
+
+This means the ADP issue is not just bad slot assignment. The current workflow
+model does not provide enough independent chunk-level output slots for a large
+schema.
+
+### Fern and Python SDK
+
+`eyelevel-fern-config/fern/openapi.yml` defines `WorkflowSteps` as a fixed object
+with named properties:
+
+- `chunk-instruct`
+- `chunk-keys`
+- `chunk-summary`
+- `doc-keys`
+- `doc-summary`
+- `search-query`
+- `sect-instruct`
+- `sect-keys`
+- `sect-summary`
+
+The generated Python SDK mirrors that in
+`src/groundx/types/workflow_steps.py`. The Pydantic model allows extra fields,
+but that is not enough for a supported feature because the public API schema,
+Go runtime, X-Ray, docs, and Arcadia code do not define how those extra fields
+are processed.
+
+`WorkflowStepConfig.field` is a separate vocabulary from the step name. Current
+allowed output fields are:
+
+- `doc-sum`
+- `doc-keys`
+- `sect-sum`
+- `sect-keys`
+- `chunk-sum`
+- `chunk-keys`
+- `chunk-instruct`
+- `text`
+
+The existing distinction between step name and output field must stay explicit.
+
+`eyelevel-fern-config/fern/generators.yml` also generates the TypeScript SDK
+from the same OpenAPI contract. This feature is Python-centered, but Fern
+schema changes must pass a TypeScript generation smoke check. TypeScript
+feature documentation and examples may be deferred, but generator compatibility
+cannot be treated as out of scope because the shared schema feeds both SDKs.
+
+### cashbot-go
+
+`cashbot-go/pkg/model/summarizer/process.go` already has:
+
+- `Steps *map[StepType]map[molecule.Type]*Step`
+- `Template *map[string]string`
+
+`Template` is copied, overwritten, and passed into prompt rendering through
+`process.Templates()`, but it is not exposed through Fern/OpenAPI/Python SDK
+workflow config. The partner workflow create/update compatibility path also
+does not copy top-level template config into `Process`, and the existing
+`APIRequest.Template` field is a different partner template type. The locked
+contract exposes public `template` as workflow/process config matching
+`Process.Template *map[string]string`; it does not reuse the top-level partner
+template object.
+
+`StepType` is an enum in `pkg/model/summarizer/step_type.go`, so unknown custom
+step names currently cannot be parsed into the main `Steps` map without a model
+change.
+
+`FieldType` is an enum in `pkg/model/summarizer/field_type.go`, so custom output
+fields also need an explicit model. Otherwise several custom steps would still
+collide into the same small set of output fields.
+
+Output readback is currently fixed-field based:
+
+- `chunk-keys` writes to `Chunk.MoleKeysD`/`Chunk.MoleKeys`, then X-Ray
+  `chunkKeywords`
+- `chunk-summary` writes molecule summary/search metadata, then X-Ray
+  `suggestedText`
+- `sect-summary` writes `Chunk.SectionMeta.Search`, then X-Ray
+  `sectionSummary`
+- `doc-summary` writes `Chunk.DocumentMeta.Search`, then X-Ray emits top-level
+  `fileSummary` when one consistent document summary applies, or per-chunk
+  `fileSummary` when chunk document summaries diverge
+
+The Python SDK loader parses those fixed JSON fields, and Arcadia's routed
+reassembly allowlist includes `chunkKeywords`, `sectionSummary`, and
+chunk-level `fileSummary`. The Python document loader and Arcadia reassembly
+currently iterate chunk fields and do not route top-level `xray.fileSummary` as
+workflow output. The current runtime, SDK, Arcadia, and harness surfaces do not
+have a generic custom output map. Custom step support therefore requires both a
+storage decision and a readback/X-Ray decision, especially for document-level
+outputs; adding step names alone is not enough.
+
+### Arcadia
+
+`internal-arcadia-agents/prompts/arcadia_manager.py` currently builds three
+workflow steps:
+
+- `chunk_instruct` for statement extraction
+- `chunk_keys` for charge extraction
+- `chunk_summary` for meter extraction
+
+`internal-arcadia-agents/tasks/download.py` hardcodes the Celery graph as a
+chord:
+
+- `reconcile_meters -> qa_meters`
+- `reconcile_statement -> qa_statement`
+- body `save_agents -> agent -> save_agents`
+
+`classes/arcadia_agent_request.py`, `tasks/agent.py`, and `tasks/save.py` are
+tied to hardcoded request type strings and next-step routing.
+
+Arcadia already depends on the SDK prompt manager to reload authored YAML from
+the deployed workflow extract. Any custom step or task-graph contract must
+therefore be preserved in the authored YAML path, not just in a local sidecar.
+Its `Statement.load_xray` path currently reads only the fixed X-Ray output
+fields listed in `XRAY_REASSEMBLY_OUTPUT_ATTRS`, so custom outputs must either
+extend that allowlist or teach the reassembler the new custom output map shape.
+
+### Harness and Docs
+
+`groundx-studio-harness` currently documents and validates the old three-slot
+menu in the extraction workflow skill. The compiler, X-Ray helper,
+`templates/validate_workflow_json.py`, `SKILL.md`, `SKILL.public.md`,
+`references/*`, `evals/evals.json`, examples, changelog entries, and scanner
+tests all assume only the current proven slots. The local X-Ray helper reads
+`chunkKeywords` for charges, `suggestedText`/`chunkSummary` for meters, and
+`sectionSummary` for statement fields; it does not read custom output maps or
+document `fileSummary`.
+
+Public docs in `eyelevel-fern-config` currently teach the simple Python SDK
+path with `prepare_extraction_yaml(...)`, workflow create, `client.ingest(...)`,
+and `get_extract(...)`. Public docs should stay centered on the user-visible
+workflow and should avoid harness terms.
+
+## Locked Contract Direction
+
+Use an explicit custom-step model instead of pretending arbitrary extra keys on
+the existing `WorkflowSteps` object are enough.
+
+The central planning contract is locked to this model:
+
+- legacy fixed steps remain available as-is
+- public workflow config adds a workflow-level `customSteps` array, separate
+  from the legacy fixed `steps` object
+- each custom step has a stable `name`
+- each custom step declares a `level`: `chunk`, `section`, or `document`
+- each custom step declares an extraction/output `kind`
+- custom step names have one canonical form, explicit conversion rules between
+  YAML, JSON, Go, Python, and X-Ray, and hard failures for invalid characters,
+  duplicates, reserved names, fixed-step collisions, and duplicate output
+  destinations
+- each custom step has an exact public record shape: `name`, `level`, `kind`,
+  optional `config`, and optional `requiredTemplateKeys`
+- `config` reuses the existing element-targeted workflow step shape, but custom
+  step config entries cannot set the legacy fixed-output `field`; custom output
+  storage comes from `level`, `kind`, `outputRoutes`, and `leafFields`
+- each custom step has an explicit output destination that can be stored,
+  returned in X-Ray, and mapped back to extraction workflow groups
+- the prepared metadata maps each workflow output back to its final JSON path,
+  including the exact custom X-Ray/readback path used by Arcadia reassembly
+- persisted workflow extract metadata has an explicit version and documented
+  behavior for missing, current, unknown, and future versions
+- `template` is exposed as workflow/process config matching Go
+  `Process.Template *map[string]string`, and is shared by fixed and custom step
+  prompts
+- `template` is not exposed as a top-level partner compatibility field unless a
+  repo-owned plan later proves that path is required and can keep the map type
+  separate from the existing partner template object
+- the contract enforces a maximum of 20 fields per executable workflow step in
+  the public API/runtime path, derived or verified by the server from canonical
+  `workflow.extract` metadata and mirrored by SDK, harness, and ADP validation
+
+The public API field name is `customSteps`. It avoids changing the meaning of
+the existing fixed `steps` field while keeping the API easy to explain.
+
+The X-Ray/readback shape is one predictable map per level:
+`customChunkOutputs`, `customSectionOutputs`, and `customDocumentOutputs`,
+instead of generating many ad hoc top-level X-Ray fields. Fixed legacy outputs
+such as `chunkKeywords`, `sectionSummary`, and `fileSummary` remain unchanged.
+Custom document outputs are read from `customDocumentOutputs`, not from the
+legacy top-level or per-chunk `fileSummary` behavior.
+
+Custom outputs are persisted through explicit workflow custom-output metadata.
+Repo-owned `cashbot-go` planning must first confirm whether the existing
+`layout.CustomMeta` level model can carry the data; otherwise it must add
+optional chunk/layout fields. Chunk-level custom outputs map to the Molecule
+level, section-level custom outputs map to the Section level, and document-level
+custom outputs map to the Document level. Missing custom-output metadata on old
+documents is treated as empty. No backfill is required; if a storage backend
+needs an added optional column or JSON field, repo-owned `cashbot-go` planning
+must include the additive migration plus backward-compatible readers.
+
+Document-level custom outputs must produce a single document value. They are
+returned only through top-level `customDocumentOutputs`; they do not reuse the
+legacy `fileSummary` behavior where a document summary can appear either
+top-level or per chunk. If document-level custom output computation produces
+conflicting per-chunk values, runtime validation fails instead of emitting a
+divergent custom document result.
+
+The release sequence is publish-last, then end-to-end validation. A spec PR may
+define the shape and local generation is allowed before release for repo-level
+verification. The final end-to-end path is expected to require published SDK and
+docs artifacts, so publishing is the last prerequisite before e2e, not something
+that waits until after e2e. The sequence is draft Fern/OpenAPI branch, local
+Python and TypeScript generation or generator smoke output, SDK/runtime/harness
+verification against the draft contract, runtime deployment verification,
+published SDK and docs, e2e validation against the published artifacts, then
+downstream dependency updates using lower bounds such as
+`groundx-python >= <released version>`. If post-publish e2e fails, the release
+is failed and must be fixed forward with a corrective patch or replacement
+publication. Generated files in `groundx-python` must not be hand-edited or
+committed as implementation work outside the approved Fern-generated release
+path.
+
+## YAML Authoring Direction
+
+Extraction YAML should remain centered on the final JSON the application wants
+back. Custom workflow steps should be authoring metadata, not final data groups.
+
+Example high-level shape:
+
+```yaml
+workflow:
+  metadata_version: 1
+  template:
+    plan_name: "ADP 401k plan"
+  custom_steps:
+    chunk:
+      - name: adp_employer_information
+        kind: instruct
+        required_template_keys:
+          - plan_name
+      - name: adp_contribution_rules
+        kind: instruct
+
+employer_information:
+  workflow_step: adp_employer_information
+  fields:
+    employer_name:
+      workflow_output_key: employer_name
+      prompt:
+        description: Employer name.
+        type: str
+```
+
+Representative custom step examples:
+
+```yaml
+workflow:
+  metadata_version: 1
+  custom_steps:
+    chunk:
+      - name: adp_employer_information
+        kind: instruct
+    section:
+      - name: adp_contribution_rules
+        kind: summary
+    document:
+      - name: adp_plan_overview
+        kind: summary
+
+employer_information:
+  workflow_step: adp_employer_information
+  fields:
+    employer_name:
+      workflow_output_key: employer_name
+      prompt:
+        description: Employer name.
+        type: str
+
+contribution_rules:
+  workflow_step: adp_contribution_rules
+  fields:
+    employee_deferral_rule:
+      workflow_output_key: employee_deferral_rule
+      prompt:
+        description: Employee deferral rule.
+        type: str
+
+plan_overview:
+  workflow_step: adp_plan_overview
+  fields:
+    summary:
+      workflow_output_key: summary
+      prompt:
+        description: Overall plan summary.
+        type: str
+```
+
+Top-level `workflow:` is always reserved as authoring metadata. Since no known
+legacy YAML uses `workflow` as a final output group, the SDK should fail clearly
+if a YAML tries to use top-level `workflow:` as final data. Final YAML groups
+assign to workflow steps with `workflow_step: <step-name>`.
+
+Existing YAML that uses `slot:` remains supported for legacy fixed slots.
+`workflow_step:` is the forward path for fixed and custom steps. If a group
+declares both `slot` and `workflow_step`, preparation must fail clearly instead
+of guessing precedence.
+
+YAML-authored prompt template values live at workflow level as
+`workflow.template`, matching public workflow/process `template` config and Go
+`Process.Template *map[string]string`. Custom step entries may declare
+`required_template_keys`, but they do not carry their own per-step `template`
+maps.
+
+Prompted fields may provide `workflow_output_key: <lower-snake-key>` as
+authoring-only metadata beside `prompt:`. This is the only authored YAML location
+for overriding the custom output map key. The SDK writes that value to persisted
+route metadata as `output_key` and to public JSON `outputRoutes[]` records as
+`outputKey`. `workflow_output_key` never appears in the final extracted JSON.
+
+SDK YAML preparation derives `leaf_fields` from the final schema and workflow
+assignments. Direct public workflow config uses a workflow-level `leafFields`
+array when the caller bypasses YAML preparation. `leafFields` is the public
+camelCase representation of persisted `workflow.extract.workflow.leaf_fields`.
+Requests with custom workflow steps must provide or derive both `outputRoutes`
+and `leafFields`; missing route or leaf metadata fails before execution.
+
+The field-load rule hard-fails another ADP case where 159 fields are sent
+through one executable step: one executable workflow step may own at most 20
+fields. Harness and ADP validation must hard-fail when a step exceeds 20 fields,
+but they cannot be the only guardrail. Direct SDK/API callers must be protected
+by SDK preparation and public API/runtime validation.
+
+The public API/runtime field-load source of truth is server-derived validation
+over canonical persisted `workflow.extract.workflow.output_routes` and
+`workflow.extract.workflow.leaf_fields`. SDK or harness preparation may include
+per-executable-step field counts and an integrity record, but caller-provided
+counts are not authoritative. The API/runtime must either recompute counts
+directly from canonical workflow extract metadata or verify a
+server-recomputable integrity record that binds the counts to the exact custom
+step identities, `output_routes`, and `leaf_fields` being stored. Workflow
+create/update requests that include custom extraction steps but omit verifiable
+metadata, include stale, caller-only, or mismatched counts, carry an unknown
+metadata version, or cannot be parsed into canonical field counts must fail
+before execution.
+
+## Remaining Contract Decisions
+
+These decisions close the remaining Phase 0 blockers.
+
+### Custom Step Records
+
+Public `customSteps[]` records are exact. Each item contains:
+
+- `name`: canonical lower-snake custom step name
+- `level`: `chunk`, `section`, or `document`
+- `kind`: one of the allowed output kinds for the level
+- `config`: optional element-targeted workflow step config
+- `requiredTemplateKeys`: optional string array
+
+The initial level/kind matrix mirrors existing fixed workflow behavior:
+
+- `chunk`: `instruct`, `keys`, `summary`
+- `section`: `instruct`, `keys`, `summary`
+- `document`: `keys`, `summary`
+
+Invalid level/kind combinations fail validation. The persisted
+`workflow.extract.workflow.custom_steps[]` form uses snake_case for
+`required_template_keys`; the other logical fields remain `name`, `level`,
+`kind`, and `config`.
+
+`config` reuses the existing element-targeted workflow step shape with element
+keys `all`, `figure`, `json`, `paragraph`, `table`, and `table-figure`. Each
+element config may carry the existing prompt, engine, and include settings. It
+must omit or null the legacy fixed-output `field`; custom output storage is
+derived from the custom step record plus route and leaf metadata. If `config` is
+omitted, repo-owned implementation plans must define the default prompt/config
+behavior for that `level`/`kind`.
+
+### Route Metadata
+
+Persisted workflow metadata must include route records that map custom readback
+outputs to final JSON fields. Authored YAML and persisted `workflow.extract`
+metadata use snake_case keys; public workflow config and X-Ray JSON use camelCase
+keys. Public workflow config exposes these records in a workflow-level
+`outputRoutes` array. Persisted `workflow.extract.workflow` stores the same
+records as `output_routes`.
+
+Each route record must include:
+
+- `workflow_group`: the prepared workflow group that owns the prompt field
+- `workflow_field`: the prepared workflow field name
+- `final_path`: the final JSON field as an RFC 6901 JSON Pointer
+- `step_name`: the canonical custom step name
+- `level`: `chunk`, `section`, or `document`
+- `output_map`: one of `customChunkOutputs`, `customSectionOutputs`, or
+  `customDocumentOutputs`
+- `output_key`: the key used inside the custom output map
+- `readback_path`: the exact X-Ray/readback path template
+
+Authored YAML provides `output_key` through field-level `workflow_output_key`.
+Direct public workflow config uses `outputKey` on `outputRoutes[]` records.
+Persisted `workflow.extract` metadata uses snake_case `output_key`. These names
+are the same logical value at different API boundaries.
+
+Public `outputRoutes[]` records use camelCase keys: `workflowGroup`,
+`workflowField`, `finalPath`, `stepName`, `level`, `outputMap`, `outputKey`, and
+`readbackPath`. `level` must be one of `chunk`, `section`, or `document`.
+`outputMap` must match `level`: `chunk` uses `customChunkOutputs`, `section`
+uses `customSectionOutputs`, and `document` uses `customDocumentOutputs`.
+`finalPath` must be an RFC 6901 JSON Pointer. Duplicate final paths and duplicate
+`(outputMap, stepName, outputKey)` destinations fail. `readbackPath` stores the
+canonical non-page path template for the output level; page-level chunk
+companions are derived from the canonical route when X-Ray includes page chunks.
+
+Route and leaf metadata must cross-check before hashing or execution. Every
+custom `output_routes` record must have exactly one matching `leaf_fields` record
+with the same `final_path`, `workflow_group`, `workflow_field`, `step_name`,
+`level`, and `output_key`. Every `leaf_fields` record must have exactly one
+matching `output_routes` record. The matched leaf record must also correspond to
+a prompted final-schema leaf at `final_path`, with schema-derived `field_type`,
+`is_repeated`, and `repetition_scope`. Missing, extra, duplicate, stale, or
+mismatched route/leaf records fail before field-count hashing or execution.
+
+Readback path templates are:
+
+- chunk: canonical route `/chunks/*/customChunkOutputs/<step_name>/<output_key>`;
+  page-level companion
+  `/documentPages/*/chunks/*/customChunkOutputs/<step_name>/<output_key>`
+- section: canonical route
+  `/chunks/*/customSectionOutputs/<step_name>/<output_key>`; page-level
+  companion
+  `/documentPages/*/chunks/*/customSectionOutputs/<step_name>/<output_key>`
+- document: `/customDocumentOutputs/<step_name>/<output_key>`
+
+`final_path` and `readback_path` are intentionally different. `final_path` tells
+Arcadia where the user wants the value in the final JSON. `readback_path` tells
+SDK/Arcadia where the runtime returned the value.
+
+### Naming And Normalization
+
+Custom step names use lower snake case only:
+
+```text
+^[a-z][a-z0-9_]{0,63}$
+```
+
+Names with uppercase letters, hyphens, dots, spaces, leading underscores,
+trailing underscores, or ambiguous auto-normalization are invalid. The canonical
+identity is exactly the authored lower-snake-case string. There is no
+case/kebab/camel conversion for custom step names.
+
+Custom step names are globally unique across all custom levels, not merely
+unique per level. They must not collide with fixed step names or their obvious
+snake_case aliases, including `chunk_instruct`, `chunk_keys`, `chunk_summary`,
+`sect_instruct`, `sect_keys`, `sect_summary`, `doc_keys`, `doc_summary`,
+`search_query`, and `text`. They must also avoid reserved workflow/runtime keys:
+`workflow`, `steps`, `custom_steps`, `customSteps`, `template`, `runtime`,
+`output_routes`, `outputRoutes`, `leaf_fields`, `leafFields`, `field_counts`,
+`fieldCounts`, `schema_hash`, `schemaHash`, `metadata_version`,
+`metadataVersion`, `_defs`, `_pseudo_groups`, and
+`_groundx_persisted_extract`.
+
+`output_key` follows the same lower-snake-case rule. It defaults to the prepared
+workflow field name when that name already satisfies the rule. If the prepared
+workflow field name is nested or otherwise invalid for an output key, the SDK
+must require an explicit valid field-level `workflow_output_key` in authored
+YAML, or `outputKey` in direct public workflow config. Duplicate
+`(output_map, step_name, output_key)` destinations fail. Duplicate final JSON
+field routes also fail.
+
+### Persisted Metadata Version
+
+The reserved `workflow:` metadata block carries `metadata_version: 1` in
+authored/persisted extract metadata. Public API JSON may expose the same concept
+as `metadataVersion`, but `workflow.extract` remains the canonical validation
+source.
+
+Compatibility behavior:
+
+- no `workflow:` block and no custom steps: legacy fixed-step fallback
+- `workflow:` block with `metadata_version: 1`: load and validate current
+  custom workflow metadata
+- `workflow:` block with missing metadata version: fail if custom steps,
+  output routes, or custom output maps are present
+- unknown, future, non-integer, or unsupported metadata versions: fail closed
+- current-version metadata must never be silently dropped during reload
+
+### Field-Count Validation
+
+The 20-field limit counts distinct final leaf field routes assigned to one
+executable workflow step. Repeated/list field definitions count as one field
+definition at schema validation time unless they introduce separate prompted
+leaf fields.
+
+The server recomputes counts from canonical
+`workflow.extract.workflow.output_routes` and
+`workflow.extract.workflow.leaf_fields`. SDK/harness may include `field_counts`
+and a `schema_hash` as a convenience, but the server treats those as
+non-authoritative hints. If hints are present, they must match the server
+recomputed counts and canonical hash. If custom steps are present but the server
+cannot recompute counts from canonical route and leaf-field metadata, workflow
+create/update fails.
+
+The canonical hash is SHA-256 over sorted-key, no-whitespace canonical JSON
+using persisted snake_case keys. Arrays are sorted before hashing with these
+ascending lexicographic identity tuples:
+
+- `custom_steps`: `(name)`
+- `output_routes`: `(final_path, workflow_group, workflow_field, step_name,
+  output_key)`
+- `leaf_fields`: `(final_path, workflow_group, workflow_field, step_name,
+  output_key)`
+
+The hash input is exactly:
+
+- `metadata_version`
+- `custom_steps`: one record per custom step with `name`, `level`, `kind`, and
+  any declared `required_template_keys`
+- `output_routes`: the route records described above
+- `leaf_fields`: one record per prompted final leaf field with `final_path`,
+  `workflow_group`, `workflow_field`, `step_name`, `level`, `output_key`,
+  `field_type`, `is_repeated`, and `repetition_scope`
+
+`leaf_fields` records use persisted snake_case keys. Public direct config uses
+the camelCase `leafFields[]` equivalent: `finalPath`, `workflowGroup`,
+`workflowField`, `stepName`, `level`, `outputKey`, `fieldType`, `isRepeated`,
+and `repetitionScope`. `is_repeated` is a boolean. `repetition_scope` is one of
+`none`, `field`, or `item`: `none` is valid only when `is_repeated` is false;
+`field` means a repeated/list value is prompted as one leaf and counts as one
+field for the step; `item` means repeated item/object schema introduces separate
+prompted leaves, and each prompted item leaf must appear as its own `leaf_fields`
+record at its full schema-level `final_path`. Invalid combinations fail before
+hashing or execution.
+
+For `repetition_scope: item`, the canonical `final_path` uses a literal `*`
+segment at each repeated-item boundary, such as `/fees/*/amount`. The `*`
+segment is a schema wildcard, not a runtime array index. It is still encoded as
+an RFC 6901 path segment and is reserved by this contract for repeated item
+schemas. Counts use the wildcard schema path once per prompted item leaf, not
+once per runtime array element. Duplicate wildcard final paths fail the same way
+as duplicate non-repeated final paths.
+
+Prompt prose, examples, model parameters, template values, and other data that
+does not affect executable-step field load are excluded from the field-count
+hash. Caller-only counts or hashes without matching canonical metadata are
+rejected.
+
+### Template Validation
+
+`template` is a workflow/process-level `map[string]string`. Public config keys
+are supplied without `{{...}}`; the runtime may accept already-braced keys for
+compatibility but stores and compares normalized logical keys. Values are literal
+strings. Template values are not recursively rendered or executed.
+
+Template validation rules:
+
+- template must be a map of string keys to string values
+- keys must match `^[A-Za-z][A-Za-z0-9_]{0,63}$` after removing optional
+  surrounding braces
+- keys using the reserved `GROUNDX_` prefix or workflow metadata names are
+  rejected
+- documented system prompt keys such as `LANGUAGE` and `PAGE_NUMBERS_*` may be
+  overridden because cashbot-go already supports default override behavior
+- extra keys are allowed because the template bag can serve multiple prompts
+- required template keys are declared explicitly on a workflow step as
+  `required_template_keys` in persisted/YAML metadata and `requiredTemplateKeys`
+  in public JSON; missing declared keys fail before rendering
+- required template keys use the same brace normalization, key regex, reserved
+  prefix, and workflow-metadata reserved-name checks as `template` keys; duplicate
+  required keys after normalization fail validation
+- unresolved optional placeholders keep the existing renderer behavior for
+  legacy fixed prompts
+- total serialized template payload must be no larger than 16 KiB, and one value
+  must be no larger than 4 KiB
+- invalid template shape fails workflow create/update; render-time failures
+  fail the workflow step with a clear step/template error
+
+Reserved workflow metadata template keys are checked after brace normalization.
+The reserved set is: `workflow`, `steps`, `custom_steps`, `customSteps`,
+`template`, `runtime`, `output_routes`, `outputRoutes`, `leaf_fields`,
+`leafFields`, `field_counts`, `fieldCounts`, `schema_hash`, `schemaHash`,
+`metadata_version`, `metadataVersion`, `workflow_group`, `workflowGroup`,
+`workflow_field`, `workflowField`, `final_path`, `finalPath`, `step_name`,
+`stepName`, `output_key`, `outputKey`, `readback_path`, `readbackPath`, `_defs`,
+`_pseudo_groups`, and `_groundx_persisted_extract`.
+
+### TypeScript Smoke Gate
+
+The shared Fern schema must pass TypeScript generation even if TypeScript
+feature docs are deferred. The repo-owned Fern plan must run
+`fern generate --group ts-sdk`, and must record evidence that the generator
+accepts `customSteps`,
+custom step `config`, custom step legacy `field` rejection, `outputRoutes`,
+`outputKey`, `leafFields`, route/leaf matching fields, `isRepeated`,
+`repetitionScope`, wildcard repeated-item final paths, `template`,
+`requiredTemplateKeys`, reserved template key validation, the custom output map
+schemas, and the 20-field validation/metadata schema without generator errors. A
+TypeScript generation failure blocks the shared OpenAPI/Fern contract change.
+
+## Arcadia Runtime Direction
+
+Arcadia should not execute arbitrary YAML. It should support an allowlisted
+runtime graph definition where YAML can select and order known task types.
+
+Follow-on concept:
+
+```yaml
+runtime:
+  graph:
+    - id: reconcile_statement
+      task: reconcile_statement
+      after: download
+    - id: qa_statement
+      task: qa_statement
+      after: reconcile_statement
+```
+
+When this block is missing, Arcadia must run the current hardcoded production
+graph exactly as it does today.
+
+The follow-on Arcadia fields plan must choose and document whether this belongs
+under a generic `runtime`, `orchestration`, or workflow-specific metadata key.
+Any implementation must validate:
+
+- only known tasks are allowed
+- graph references are acyclic
+- required save/finalization stages exist
+- existing request types remain supported
+- missing routed required values keep current hard-error behavior where already
+  defined
+- each authorable task has a documented input payload, output payload, retry or
+  idempotency assumption, and failure propagation behavior
+- chord/chain failures preserve current production error handling or fail with a
+  reviewed, explicit replacement behavior
+
+For the current plan, Arcadia keeps the existing reconcile, QA, and save task
+families except `qa_charges`, which is classified as dead legacy. The supported
+existing business actions remain `reconcile_charges`, `reconcile_meters`,
+`reconcile_statement`, `qa_meters`, `qa_statement`, `save_charges`,
+`save_meters`, and `save_statement`. The current `agent` and `save_agents` nodes
+stay internal and are preserved by a default compatibility adapter when custom
+runtime metadata is absent.
+
+A follow-on plan, created after cleanup and closeout of this central plan, must
+define and implement three new custom Arcadia actions:
+`reconcile_fields`, `qa_fields`, and `save_fields`. That follow-on plan must
+define what each action does, its input payload, output payload, retry or
+idempotency assumptions, failure propagation behavior, and required updates in
+`internal-arcadia-agents`. This central plan may record an
+`internal-arcadia-agents` deferral stub, but it must not require or start the
+follow-on Arcadia fields implementation before the central cleanup/closeout gate.
+
+## Template Direction
+
+Expose the existing Go `Process.Template *map[string]string` setting through
+public workflow/process config and generated SDKs. This follows the cashbot-go
+runtime path where `Process.Template` is loaded into prompt rendering through
+`gpt.InitTemplates(...)`. It must not be confused with the separate partner
+request template object. This must include:
+
+- Fern/OpenAPI schema update
+- generated Python SDK access
+- Go request/response/load/save tests
+- prompt rendering tests proving template values reach prompt expansion
+- validation tests for unknown keys, missing required keys, reserved keys,
+  invalid value types, excessive payload size, escaping/rendering failures, and
+  fixed/custom prompt behavior
+- docs and harness guidance
+- release notes or version gates so downstream repos depend on
+  `groundx-python >= <released version>` instead of an exact pin
+
+## Compatibility
+
+Legacy behavior is required:
+
+- existing YAML with `slot:` continues to work
+- new YAML uses `workflow_step:` for fixed and custom step assignment
+- existing `WorkflowSteps` fixed fields continue to work
+- workflows without custom steps run the default pipeline as before
+- Arcadia runs the existing chord/chain when no runtime graph metadata is
+  present
+- `qa_charges` is treated as dead legacy, not an authorable runtime task
+- old ADP/Arcadia YAML can be prepared and loaded without custom steps
+- existing tests are not weakened unless the user explicitly approves or a
+  review proves the test no longer represents correct behavior
+- public docs are updated only after runtime, SDK, and harness behavior are
+  verified
+- TypeScript generation compatibility is verified for shared Fern schema changes
+  even if TypeScript feature guidance is deferred
+- generated SDK and docs publishing happens only after local/runtime/schema/SDK
+  and harness verification, and immediately before the final e2e path that
+  requires published artifacts
+- downstream dependency updates are blocked until the published-artifact e2e
+  path passes
+- implementation does not begin until the post-contract repo-specific plans
+  exist with exact failing tests, expected failures, implementation steps,
+  verification commands, and commit checkpoints
+- implementation does not begin in a target repo until a clean isolated branch or
+  worktree exists and unrelated local changes are recorded as out of scope
+
+## Archive Ownership
+
+This central OpenSpec change is planning-only and cross-repo. It must not be
+archived into `groundx-python` specs while it contains durable requirements owned
+by `cashbot-go`, `eyelevel-fern-config`, `internal-arcadia-agents`,
+`groundx-studio-harness`, or `adp-poc`. Before archive, repo-owned OpenSpec
+changes must absorb their durable spec deltas. The central change can then be
+closed as planning documentation or reduced to requirements owned by
+`groundx-python` only.
+
+## Alternatives Considered
+
+### Approach A: Add Arbitrary Keys To `WorkflowSteps`
+
+This is tempting because the Python generated model allows extra keys. It is
+not sufficient. Go currently parses step keys into `StepType`, X-Ray has fixed
+fields, and docs/scanners do not know what extra keys mean. This approach hides
+the hard work.
+
+### Approach B: Add More Fixed Enum Slots
+
+This might solve ADP briefly but repeats the current limit. It does not create
+a real customer-defined model for chunk, section, and document steps.
+
+### Approach C: Add Explicit Custom Step Arrays
+
+This is the recommended direction. It preserves legacy fixed steps, gives the
+runtime a typed place for custom step definitions, and allows X-Ray/Arcadia/docs
+to reason about named custom outputs.
+
+## Risks
+
+- Custom step names may be confused with output field names unless the API keeps
+  those concepts separate.
+- X-Ray output may become hard to consume if custom fields are emitted as many
+  top-level ad hoc keys instead of a predictable map.
+- Chunk-only tracing could produce a design that fails for section or document
+  outputs.
+- A reserved `workflow:` YAML section could accidentally steal a legacy final
+  group named `workflow`.
+- A YAML that tries to use top-level `workflow:` as final output data must fail
+  clearly now that `workflow:` is always reserved.
+- Custom X-Ray output could be readable but still unusable by Arcadia if route
+  metadata does not include the exact custom output path.
+- Caller-provided field-count metadata could be spoofed unless the API/runtime
+  derives or verifies counts from canonical workflow extract metadata.
+- OpenAPI changes could break TypeScript generation even if the Python SDK path
+  works.
+- Arcadia could become unsafe if YAML can name arbitrary Celery tasks or import
+  arbitrary functions.
+- Harness docs and public docs can drift if both are not updated after the SDK
+  and runtime behavior is real.
+- A design that only works for ADP could break invoice/utility extraction.
+
+## Required Discovery Before Implementation
+
+The first task is not code. It is a full trace of `chunk-keywords` from public
+workflow config through Go processing, chunk storage, X-Ray output, SDK parsing,
+harness aggregation, and Arcadia reassembly, plus representative section and
+document summary traces through the same surfaces. The final implementation
+plan must be updated after that trace. After the public contract is locked, the
+next step is to create repo-specific implementation plans before code changes.

--- a/openspec/changes/support-custom-workflow-steps/execution-plan.md
+++ b/openspec/changes/support-custom-workflow-steps/execution-plan.md
@@ -1,0 +1,390 @@
+# Execution Chain: Support Custom Workflow Steps
+
+This chain is intentionally staged. Do not start implementation before Task 1
+and Task 2 produce a reviewed contract and Task 3 produces repo-specific
+implementation plans plus the `internal-arcadia-agents` deferral stub.
+
+Current status: Phase 0 discovery, contract, repo-owned planning artifacts, and
+the fresh-scan generated-SDK/X-Ray corrections are complete. Task 4 and Task 9
+are in `eyelevel-fern-config` PR #12 on branch
+`codex/support-custom-workflow-steps-fern`, current head `60efc8b`; the merge
+conflict with `main` is resolved, the PR is clean, `fern check`, OpenSpec
+strict validation, YAML parsing, and `git diff --check` passed locally. Public
+docs publishing remains gated on Fern org access and the publish-last e2e phase.
+
+Task 5 is in `cashbot-go` PR #1493 on branch
+`codex/support-custom-workflow-steps-runtime`, current head `c4e17a6cf`, base
+`hotfix-search-dell`. The branch was rebased from its earlier `master` base onto
+`hotfix-search-dell`; the workflow-template hotfix and custom workflow-step
+runtime/API changes were merged, duplicate OpenAPI schema/property entries were
+removed, targeted Go and OpenSpec checks passed, and the branch now has a clean
+local merge simulation against `origin/hotfix-search-dell`. GitHub checks pass
+after retarget; the remaining remote gate is review. `go test ./...` remains
+blocked locally by repo-wide generated `version.go` prerequisites plus external
+service/state dependencies.
+
+Task 6 is in `groundx-python` PR #11 on branch
+`codex/support-custom-workflow-steps-sdk`, current head `5cae434`. The helper
+implementation no longer changes generated folders under `src/groundx/types` or
+`src/groundx/workflows`; handwritten behavior lives under `src/groundx/extract`
+and `src/groundx/ingest.py`. Custom-step create/update helpers raise a clear
+runtime gate until the Fern-generated workflow client accepts the new custom
+fields. Full SDK pytest, mypy, OpenSpec strict validation, and `git diff
+--check` passed locally.
+
+Task 7 has two current-wave pieces in `internal-arcadia-agents` PR #66 on
+branch `codex/extraction-reassembly-metadata`, current head `e07f655`: the
+follow-on `reconcile_fields` / `qa_fields` / `save_fields` deferral remains
+explicit, and metadata-backed reassembly now consumes
+`customChunkOutputs`, `customSectionOutputs`, and `customDocumentOutputs`.
+Focused tests and the full Arcadia pytest suite passed locally.
+
+Task 8 is in `groundx-studio-harness` PR #19 on branch
+`codex/support-custom-workflow-steps-harness`, current head `4d4caf4`. Studio
+Harness remains the source repo; `groundx-agent-harness` is only the generated
+mirror output. Python template tests, Node skill/eval gates, plugin mirror and
+version checks, full `node scripts/validate.mjs`, OpenSpec strict validation,
+and `git diff --check` passed locally after the SDK generated-folder cleanup.
+GitHub still marks the PR blocked by external review/check policy, not by a
+local validation failure or merge conflict.
+
+Task 10 is in `adp-poc` PR #1 on branch
+`codex/support-custom-workflow-steps-adp`, current head `4e35397`. ADP manifest,
+converter/source-review, local SDK/harness compile, structural workflow
+validation, OpenSpec strict validation, and `git diff --check` passed locally
+after the SDK and harness corrections.
+
+Remaining current-wave execution is live deployed-path end-to-end validation and
+closeout. Task 11 has a partial e2e checkpoint in `task11-e2e-checkpoint.md`;
+release remains blocked until the runtime/API custom-step guardrail is merged
+and deployed, then SDK/docs are published last, and the published-artifact e2e
+path proves workflow create/update, ingest, X-Ray readback, and final extract
+output on the deployed platform.
+
+Repo-owned Task 3 artifacts, in dependency order:
+
+1. Fern/OpenAPI and public docs:
+   `/Users/benjaminfletcher/git/eyelevel-fern-config/openspec/changes/support-custom-workflow-steps/execution-plan.md`
+2. Go runtime/API and OpenAPI mirrors:
+   `/Users/benjaminfletcher/git/cashbot-go/openspec/changes/support-custom-workflow-steps/execution-plan.md`
+3. Python SDK generated and handwritten extract behavior:
+   `/Users/benjaminfletcher/git/groundx-python/openspec/changes/support-custom-workflow-steps-sdk/execution-plan.md`
+4. Arcadia current-wave deferral stub:
+   `/Users/benjaminfletcher/git/internal-arcadia-agents/openspec/notes/support-custom-workflow-steps-deferral.md`
+5. Harness compiler, readback, skills, scanners, and plugin mirrors:
+   `/Users/benjaminfletcher/git/groundx-studio-harness/openspec/changes/support-custom-workflow-steps/execution-plan.md`
+6. ADP migration and validation:
+   `/Users/benjaminfletcher/git/adp-poc/openspec/changes/support-custom-workflow-steps/execution-plan.md`
+
+All repo-owned OpenSpec changes validate with their repo-specific change IDs:
+`support-custom-workflow-steps` in `eyelevel-fern-config`, `cashbot-go`,
+`groundx-studio-harness`, and `adp-poc`, plus
+`support-custom-workflow-steps-sdk` in `groundx-python`. The central
+`groundx-python/openspec/changes/support-custom-workflow-steps/` change also
+validates, but remains a coordination artifact until Task 12 closes or reduces
+it.
+`internal-arcadia-agents` intentionally keeps the future
+`reconcile_fields` / `qa_fields` / `save_fields` task-graph work in a
+non-implementation deferral stub outside `openspec/changes/`. Its current-wave
+implementation is limited to metadata-backed custom X-Ray reassembly in PR #66.
+
+Locked decisions so far:
+
+- Public workflow config uses `customSteps`, separate from legacy `steps`.
+- Public `customSteps[]` records contain `name`, `level`, `kind`, optional
+  `config`, and optional `requiredTemplateKeys`; custom step `config` uses the
+  existing element-targeted workflow step shape but omits or nulls the legacy
+  fixed-output `field`.
+- Public workflow config uses `outputRoutes` for custom output route records,
+  with persisted `workflow.extract.workflow.output_routes` as the canonical
+  snake_case source.
+- Public workflow config uses `leafFields` for custom leaf-field records, with
+  persisted `workflow.extract.workflow.leaf_fields` as the canonical snake_case
+  source.
+- `outputRoutes` and `leafFields` must match one-to-one on final path, workflow
+  group/field, custom step, level, and output key.
+- Custom readback uses `customChunkOutputs`, `customSectionOutputs`, and
+  `customDocumentOutputs`, including matching page-level chunk paths under
+  `documentPages[].chunks[]` when X-Ray includes page chunks.
+- Top-level YAML `workflow:` is always reserved for authoring metadata.
+- New YAML uses `workflow_step:`; legacy `slot:` remains supported.
+- Public `template` follows cashbot-go workflow/process `Process.Template
+  *map[string]string`, not the separate partner template object. YAML-authored
+  template values live at workflow-level `workflow.template`; custom steps may
+  declare `required_template_keys` / public `requiredTemplateKeys`.
+- Explicit YAML custom output keys use field-level `workflow_output_key`,
+  persisted route metadata uses `output_key`, and public route records use
+  `outputKey`.
+- One executable workflow step may own at most 20 fields.
+- Field-count validation uses canonical `output_routes` and `leaf_fields`, with
+  deterministic hash sorting.
+- Leaf-field repetition is represented by `isRepeated`/`repetitionScope` in
+  public JSON and `is_repeated`/`repetition_scope` in persisted metadata.
+- Repeated item leaves use a literal `*` RFC 6901 path segment as the schema
+  wildcard, such as `/fees/*/amount`, and count once per prompted schema leaf.
+- Reserved template metadata key names are enumerated and apply equally to
+  `template` and `requiredTemplateKeys`.
+- Arcadia keeps existing reconcile/QA/save behavior except `qa_charges`, which
+  is dead legacy.
+- New Arcadia `reconcile_fields`, `qa_fields`, and `save_fields` work is a
+  follow-on plan after cleanup and closeout of this central plan; the current
+  gate requires only the `internal-arcadia-agents` deferral stub plus
+  metadata-backed custom X-Ray reassembly support.
+- SDK/docs publishing is allowed only late, as the final prerequisite for the
+  e2e path that requires published artifacts; downstream dependency changes wait
+  until that published-artifact e2e passes.
+
+## Phase 0: Discovery And Contract
+
+1. Complete `chunk-keywords-trace.md`.
+2. Complete representative section-summary and document-summary traces.
+3. Record the public custom-step shape: workflow-level `customSteps`.
+4. Record the exact public custom-step item shape and legacy `field` rejection
+   inside custom step `config`.
+5. Record the public custom output route container: workflow-level
+   `outputRoutes`, persisted as `workflow.extract.workflow.output_routes`.
+6. Record the public custom leaf-field container: workflow-level `leafFields`,
+   persisted as `workflow.extract.workflow.leaf_fields`.
+7. Record route/leaf one-to-one validation for `outputRoutes` and `leafFields`.
+8. Record the exact leaf-field repetition flags: `isRepeated` /
+   `is_repeated`, `repetitionScope` / `repetition_scope`, and allowed
+   repetition-scope values `none`, `field`, and `item`.
+9. Record repeated-item wildcard final-path semantics for
+   `repetition_scope: item`.
+10. Record the X-Ray custom output shape for chunk, section, and document
+   outputs: `customChunkOutputs`, `customSectionOutputs`, and
+   `customDocumentOutputs`, including `documentPages[].chunks[]` paths when
+   X-Ray includes page chunks.
+11. Record the YAML metadata key for assigning workflow groups to custom steps:
+   `workflow_step: <step-name>`.
+12. Record the YAML/public/persisted output-key boundary:
+   `workflow_output_key`, `outputKey`, and `output_key`.
+13. Record the maximum field count: 20 fields per executable workflow step,
+   hard-failed by public API/runtime validation and mirrored by SDK, harness,
+   and ADP validation.
+14. Record the Arcadia runtime graph decision: existing reconcile/QA/save tasks
+   remain supported except `qa_charges`, `agent` and `save_agents` remain
+   internal compatibility-adapter nodes, and `reconcile_fields`, `qa_fields`,
+   and `save_fields` are deferred to a follow-on plan.
+15. Record reserved YAML authoring behavior: top-level `workflow:` is always
+   reserved and cannot be a final output group.
+16. Record custom output route metadata from X-Ray/readback path to final JSON
+   path.
+17. Record TypeScript feature-support scope and the mandatory TypeScript
+    generation smoke coverage: `fern generate --group ts-sdk` must pass.
+18. Record downstream release/version gates, including the publish-last sequence
+    where SDK/docs publish after local/runtime/schema/SDK/harness verification
+    and immediately before the e2e path that requires published artifacts.
+19. Record custom step naming, reserved-name, uniqueness, normalization,
+    persisted metadata version, and unknown-version behavior.
+20. Record how the public API/runtime rejects oversized executable steps for
+    direct API users, and how SDK, harness, and ADP validation mirror that rule.
+    Define the server-derived or server-verified persisted workflow extract
+    metadata field-count source, `leaf_fields` shape, deterministic hash sorting,
+    and missing, stale, caller-only, spoofed, or mismatched metadata failures.
+21. Record storage, migration, and readback compatibility for custom outputs.
+22. Record `template` validation boundaries for unknown keys, required keys,
+    reserved keys, invalid value types, payload size, escaping/rendering
+    failures, fixed/custom prompt behavior, workflow-level YAML template values,
+    `requiredTemplateKeys`, exact reserved metadata names, and required-key
+    normalization/collision behavior.
+23. Update this OpenSpec change with the final contract.
+24. Create valid repo-specific OpenSpec changes or non-OpenSpec implementation
+    plans with exact tests, expected
+    failures, implementation steps, verification commands, and commit
+    checkpoints. For `internal-arcadia-agents`, defer the new field-action task
+    graph in this current wave while allowing metadata-backed custom X-Ray
+    reassembly support.
+25. Create or select clean branches/worktrees for every current-wave
+    implementation repo and record any existing dirty state that must not be
+    mixed into this work.
+26. Adversarial review.
+
+Review questions:
+
+- Did the trace cover Go runtime storage and not just OpenAPI/Python classes?
+- Did the trace cover chunk, section, and document outputs?
+- Did the document-output trace distinguish top-level `fileSummary` from
+  per-chunk `fileSummary`, and did the contract choose how SDK/Arcadia read
+  custom document outputs?
+- Is `template` included in the same contract?
+- Does the contract preserve legacy fixed steps?
+- Does the contract preserve final JSON group shape?
+- Can Arcadia reload everything from `workflow.extract`?
+- Does the field-load rule hard-fail the 159-field single-step workflow?
+- Does reserved `workflow:` behavior fail clearly for any attempted final group
+  named `workflow`?
+- Does route metadata make the custom output usable for final JSON reassembly?
+- Is the direct public route container `outputRoutes` defined with the same
+  logical fields as persisted `output_routes`?
+- Is the direct public leaf-field container `leafFields` defined with the same
+  logical fields as persisted `leaf_fields`?
+- Are `outputRoutes` and `leafFields` required to match one-to-one before counts
+  are trusted?
+- Are leaf-field repetition flags exact and validation-enforced?
+- Is repeated item path syntax exact enough to count schema leaves without
+  depending on runtime array length?
+- Are explicit output keys consistently represented as `workflow_output_key`,
+  `outputKey`, and `output_key` at the correct boundaries?
+- Are direct API users protected by the same field-load rule as harness users?
+- Can a direct API caller with spoofed or caller-only field-count metadata bypass
+  the oversized-step guardrail?
+- Does the field-count hash name deterministic sort tuples for `custom_steps`,
+  `output_routes`, and `leaf_fields`?
+- Can the Arcadia contract preserve the current `agent` / `save_agents` default
+  graph behavior as internal compatibility-adapter behavior?
+- Did the Arcadia contract explicitly classify the existing `qa_charges` branch
+  as dead legacy?
+- Are repo-owned OpenSpec changes independently valid and archiveable?
+- Are `template` validation and rendering failure boundaries explicit, with
+  workflow-level template values and step-level required-key declarations kept
+  separate, exact reserved metadata names listed, and required-key
+  normalization/collisions defined?
+- Is the TypeScript SDK generation path proven even if TS feature docs are
+  deferred?
+- Are branch/worktree and publish-last release gates concrete enough for another
+  agent to follow without mixing unrelated work or publishing early?
+
+## Phase 1: API And Runtime Foundation
+
+1. Update Fern/OpenAPI.
+2. Update cashbot-go model/load/save/process/X-Ray.
+3. Generate or verify SDK generated surfaces from the upstream Fern/OpenAPI
+   branch through local verification output or the approved release path.
+4. Add mandatory TypeScript generation smoke coverage, or block the Fern schema
+   change until the TypeScript generator can consume it.
+5. Add generated Python workflow-client serialization tests for `template` and
+   custom steps.
+6. Add SDK extract YAML support for custom step metadata and persisted reload.
+7. Add SDK X-Ray/readback support for `customChunkOutputs`,
+   `customSectionOutputs`, and `customDocumentOutputs`.
+8. Adversarial review.
+
+Review questions:
+
+- Does Go accept and execute custom steps without enum parse failures?
+- Are custom outputs stored and returned in X-Ray?
+- Can the SDK parse and expose those custom outputs?
+- Can generated workflow clients serialize the new request/response fields?
+- Are generated files treated as local verification output or approved
+  release-produced files, rather than hand-edited implementation files?
+- Do old fixed-step workflows still pass existing tests?
+- Does `template` reach prompt rendering?
+- Are downstream repos still blocked from bumping dependencies until the
+  published-artifact e2e path passes?
+- Is SDK/docs publishing sequenced after local/runtime/schema/SDK/harness
+  verification and immediately before final e2e?
+- Is local SDK generation clearly allowed for verification before public
+  publishing?
+
+## Phase 2: Arcadia Runtime
+
+Deferred from this central plan. After cleanup and closeout, create a new
+repo-owned plan for `internal-arcadia-agents` that defines and implements
+`reconcile_fields`, `qa_fields`, and `save_fields`. During this central plan,
+keep only the reviewed deferral stub.
+
+The follow-on plan must:
+
+1. Preserve legacy default behavior.
+2. Keep existing reconcile/QA/save tasks supported except `qa_charges`, which is
+   dead legacy.
+3. Define `reconcile_fields`, `qa_fields`, and `save_fields`.
+4. Define each task's input payload, output payload, retry/idempotency
+   assumptions, and failure propagation behavior.
+5. Add tests for custom output route metadata from X-Ray/readback path to final
+   JSON path.
+6. Implement workflow step construction from prepared YAML metadata.
+7. Implement allowlisted task graph construction.
+8. Adversarial review.
+
+Review questions:
+
+- Can YAML name only known task types?
+- Are cycles and missing final stages rejected?
+- Does the current production graph remain the default?
+- Is `qa_charges` excluded as dead legacy?
+- Are `reconcile_fields`, `qa_fields`, and `save_fields` defined only in the
+  follow-on plan?
+- Do custom outputs reassemble into final JSON without leaking workflow group
+  names?
+- Do statement, meter, and charge relationship rules still run on the final
+  reassembled shape?
+- Does every authorable task define its input payload, output payload, retry
+  behavior, and failure propagation?
+
+## Phase 3: Harness And Public Docs
+
+1. Update harness compiler, X-Ray helper, skill references, scanners, and plugin
+   mirror.
+2. Mirror the runtime/API hard-fail validation for the chosen field-count limit.
+3. Verify harness legacy and custom-step compile paths.
+4. Publish public docs in eyelevel-fern-config only after runtime/SDK/harness
+   verification, as the final prerequisite before e2e if the e2e path requires
+   published docs.
+5. Run compile, validation, docs, and plugin mirror gates.
+6. Adversarial review.
+
+Review questions:
+
+- Do harness docs describe implemented behavior only?
+- Do public docs avoid harness internals?
+- Do public docs describe only behavior already verified in runtime, SDK, and
+  harness?
+- Does oversized custom-step YAML fail rather than warn?
+
+## Phase 4: ADP Migration
+
+Status: completed in isolated worktree
+`/Users/benjaminfletcher/git/adp-poc-support-custom-workflow-steps` on branch
+`codex/support-custom-workflow-steps-adp` as commit `4e35397`.
+
+1. ADP converter/YAML now use 13 custom chunk/instruct workflow steps.
+2. The 20-field executable-step rule is mirrored in ADP validation; the largest
+   ADP custom step contains 18 fields.
+3. ADP YAML compiles through the updated unpublished SDK/harness worktrees.
+4. ADP manifest, converter, and source-review tests pass.
+5. Adversarial review is recorded in ADP OpenSpec.
+
+Review questions:
+
+- Does ADP preserve the same final 11-section JSON shape? Yes: tests and
+  conversion report preserve 11 sections and 159 final fields.
+- Does the ADP workflow avoid the 159-field single-slot load? Yes: 13 custom
+  steps, max 18 fields per step.
+- Is ADP using shared platform behavior instead of hardcoded shared-repo logic?
+  Yes for local validation via the updated SDK/harness worktrees; published
+  artifact e2e remains in Phase 5.
+
+## Phase 5: End-To-End Proof
+
+Status: partially executed and blocked. See `task11-e2e-checkpoint.md`.
+
+1. Run one legacy YAML path. Completed locally and via live workflow
+   create/get/delete.
+2. Run one custom-step YAML path. Completed locally and via live workflow
+   create/get/delete.
+3. Inspect workflow `extract`, X-Ray, and final JSON. Workflow `extract`
+   readback and local synthetic X-Ray-to-final-JSON route mapping are complete;
+   live X-Ray/final extract remains blocked.
+4. Confirm Arcadia legacy path and confirm custom field-action work remains
+   deferred to the follow-on plan. Current-wave deferral stub confirmed.
+5. Publish SDK/docs if required by the final e2e path. Blocked on publish
+   credentials/Fern org access and the deployed-runtime guardrail failure.
+6. Run e2e against the published SDK/docs/runtime artifacts. Blocked.
+7. Confirm downstream repos use `groundx-python >= <released version>` and no
+   exact SDK pins were introduced only after published-artifact e2e passes.
+   Blocked until publish and e2e pass.
+8. Confirm old persisted workflow extracts and old legacy YAML still load or
+   fail with the documented compatibility behavior. Legacy workflow
+   create/get/delete passed on the deployed API; broader persisted-workflow
+   checks remain blocked until the deployed validation failure is fixed.
+9. Confirm the deployed path with live credentials/documents/approval for release
+   readiness. Blocked: deployed API accepted an oversized/spoofed custom-step
+   workflow.
+10. Record skipped live checks only with the approving reviewer, substitute
+   evidence, or blocked-release status. Blocked-release status recorded.
+11. If published-artifact e2e fails, mark the release failed and fix forward
+    with a corrective patch or replacement publication before dependency bumps.
+    Current failure is deployed-runtime/API guardrail mismatch.
+12. Adversarial review and closeout. Pending after blocker resolution.

--- a/openspec/changes/support-custom-workflow-steps/fresh-scan-generated-sdk-and-xray-corrections.md
+++ b/openspec/changes/support-custom-workflow-steps/fresh-scan-generated-sdk-and-xray-corrections.md
@@ -1,0 +1,113 @@
+# Fresh Scan Corrections: Generated SDK Boundary And X-Ray Runtime
+
+Date: 2026-06-14
+
+## Why This Exists
+
+A fresh scan found two plan risks that must be corrected before closeout:
+
+1. The SDK helper implementation in `groundx-python` currently touches
+   generated folders that Fern will overwrite.
+2. The custom X-Ray readback contract is not complete until `cashbot-go`
+   actually emits `customChunkOutputs`, `customSectionOutputs`, and
+   `customDocumentOutputs`, and downstream consumers read those fields.
+
+This file is the central coordination checklist for the corrective work. It is
+not a substitute for each repo's implementation plan; it records the cross-repo
+contract and the documentation/implementation surfaces that must move together.
+
+## Corrected Execution Plan
+
+1. Update this central OpenSpec plan first.
+2. In `groundx-python` SDK helpers, remove all hand edits under generated
+   folders:
+   - `src/groundx/types`
+   - `src/groundx/workflows`
+3. Keep handwritten SDK behavior only in handwritten surfaces:
+   - `src/groundx/extract/*`
+   - `src/groundx/ingest.py`
+4. In Fern, define the public API shape that will generate SDK classes and
+   workflow client parameters:
+   - workflow `template`
+   - `customSteps`
+   - `outputRoutes`
+   - `leafFields`
+   - X-Ray `customChunkOutputs`, `customSectionOutputs`,
+     `customDocumentOutputs`
+5. In `cashbot-go`, implement the runtime and API mirror, not just docs:
+   - X-Ray structs expose the custom output maps.
+   - X-Ray creation populates those maps from runtime custom-output storage.
+   - Existing fixed fields still serialize exactly as before.
+   - `server/GroundX/openapi.yml` and `lambda/GroundX/openapi.yml` mirror the
+     Fern contract.
+6. In `internal-arcadia-agents`, read the new custom X-Ray output attrs in
+   metadata-backed reassembly:
+   - `customChunkOutputs`
+   - `customSectionOutputs`
+   - `customDocumentOutputs`
+   Legacy fixed attrs remain supported.
+7. In `groundx-studio-harness`, keep skill docs, compiler/readback helpers,
+   scanners, evals, and generated plugin mirrors aligned with the implemented
+   contract.
+8. In `adp-poc`, keep ADP-specific YAML/converter/docs aligned with the shared
+   SDK/harness contract. ADP must not hardcode shared platform behavior.
+9. Run repo-specific verification and adversarial review before claiming
+   closeout.
+
+## Repo Coverage Matrix
+
+| Repo / PR | Documentation To Update | Implementation To Update | OpenSpec / Agent Docs To Update |
+| --- | --- | --- | --- |
+| `groundx-python` plan, PR #10 | This central plan and task list. | No product implementation in the plan PR. | `openspec/changes/support-custom-workflow-steps/*`; this correction file. |
+| `groundx-python` SDK helpers, PR #11 | README or SDK docs only if helper examples change. | Move helper logic out of generated `src/groundx/types` and `src/groundx/workflows`; keep code in `src/groundx/extract/*` and `src/groundx/ingest.py`. | Repo-owned `support-custom-workflow-steps-sdk` OpenSpec must state generated files are release/generated-only. |
+| `eyelevel-fern-config` docs, PR #12 | Public MDX docs for workflow creation, YAML usage, MCP/workflow docs, and X-Ray/readback if exposed to users. | `fern/openapi.yml` owns generated schema/source API shape. | Repo OpenSpec must keep docs publish gated until runtime/SDK/harness verification. |
+| `groundx-studio-harness`, PR #19 | Extraction workflow skill docs, references, examples, scanner messages, eval expectations, and generated plugin mirrors. | Compiler, workflow validation, X-Ray/readback helper, and template/deploy helpers. | Harness OpenSpec plus skill docs must describe only implemented behavior. |
+| `internal-arcadia-agents`, PR #66 | Arcadia relationship/runtime docs only where reassembly behavior changes. | Metadata-backed X-Ray reassembly must read custom output attrs plus legacy fixed attrs. | Existing deferral stub remains for future `reconcile_fields` / `qa_fields` / `save_fields`; current-wave plan must not pretend those are implemented. |
+| `adp-poc`, PR #1 | ADP reference docs, source-material notes, conversion reports, and workflow docs. | ADP YAML/converter/validation must use shared SDK/harness behavior and preserve final output shape. | ADP OpenSpec documents migration and validation evidence. |
+| `cashbot-go` | Human/API docs and mirrored OpenAPI files. Agent docs only if contract guidance changes. | X-Ray structs, X-Ray creation/population, custom-output persistence/readback, workflow validation/runtime as needed. | Cashbot OpenSpec must include failing tests, implementation steps, OpenAPI mirror sync, and adversarial review. |
+
+## Fresh-Scan Checks Before Closeout
+
+- `groundx-python` SDK helper PR has no diff under `src/groundx/types` or
+  `src/groundx/workflows` unless that diff is explicitly produced by the
+  approved Fern-generated release path.
+- `src/groundx/extract/workflows.py` does not import new generated custom
+  workflow types for functionality that must survive Fern regeneration.
+- `eyelevel-fern-config/fern/openapi.yml` exposes the X-Ray custom output maps
+  and workflow custom-step fields.
+- `cashbot-go/pkg/model/layout/xray.go` exposes the X-Ray custom output maps.
+- Cashbot tests prove custom output maps serialize while fixed X-Ray fields stay
+  stable.
+- Cashbot `server/GroundX/openapi.yml`, `lambda/GroundX/openapi.yml`, and Fern
+  `fern/openapi.yml` agree on public X-Ray/readback shape.
+- `internal-arcadia-agents/classes/statement.py` includes the three custom
+  X-Ray output attrs in `XRAY_REASSEMBLY_OUTPUT_ATTRS`.
+- Arcadia tests cover reading at least one routed value from each new custom
+  output attr.
+- Harness docs/examples/scanners do not teach deprecated `slot` as the promoted
+  custom-step path.
+- ADP validation remains shared-contract driven and preserves its final JSON
+  shape.
+
+## Audit Status On 2026-06-14
+
+This audit checked the open PR branches named by the user plus the Cashbot PR
+created from the support worktree.
+
+| Surface | Current Audit Result | Required Follow-Up |
+| --- | --- | --- |
+| OpenSpec plan PR #10 | Corrective plan recorded in this file and central `execution-plan.md` / `tasks.md` updated with current pushed commit IDs and remaining release gates. PR #10 is pushed and GitHub checks pass. | Keep PR #10 draft until closeout, then merge or archive according to the final release decision. |
+| SDK helpers PR #11 | Fixed at `5cae434`. No diffs remain under `src/groundx/types` or `src/groundx/workflows`, and `src/groundx/extract/workflows.py` no longer imports generated workflow types. Full SDK pytest, mypy, OpenSpec, and `git diff --check` passed locally. | Merge after review; publish/regenerate generated clients only through the Fern/OpenAPI release path. |
+| Fern docs PR #12 | Clean at `60efc8b`. OpenAPI and docs mention `customSteps`, `outputRoutes`, `leafFields`, `requiredTemplateKeys`, and X-Ray custom output maps; the prior merge conflict is resolved. Local Fern/OpenSpec/YAML/diff checks passed. | Keep docs publish gated until runtime, SDK, harness, ADP, and published-artifact e2e checks pass. |
+| Studio Harness PR #19 | Revalidated at `4d4caf4` after SDK cleanup. Skill docs, compiler/readback helpers, validators, scanners, evals, and generated plugin mirrors reference `workflow_step`, `customSteps`, and custom X-Ray outputs. Local Python, Node, mirror/version, OpenSpec, and diff checks passed. | GitHub marks the PR blocked by external review/check policy; no local validation blocker found. |
+| Arcadia PR #66 | Fixed at `e07f655`. `classes/statement.py` reads `customChunkOutputs`, `customSectionOutputs`, and `customDocumentOutputs`; tests cover chunk, section, and document custom-output reassembly while preserving the future `reconcile_fields` / `qa_fields` / `save_fields` deferral. Full pytest passed locally. | Merge after review; keep the new custom field-action work in a separate follow-on plan. |
+| ADP PR #1 | Revalidated at `4e35397` after SDK/harness fixes. ADP docs/OpenSpec/YAML reference `workflow_step`, `workflow_output_key`, 20-field validation, and source-material decisions; local compile and structural workflow validation passed with the corrected SDK/harness worktrees. | Merge after upstream runtime/SDK/harness/docs gates are ready; do not hardcode shared platform behavior in ADP. |
+| Cashbot PR #1493 | Open at `c4e17a6cf`, base `hotfix-search-dell`. Runtime, X-Ray, tests, and OpenAPI mirror changes for custom output maps are pushed on the hotfix release branch. Targeted Go/OpenSpec/diff checks and local merge simulation against `origin/hotfix-search-dell` passed after removing duplicate rebased OpenAPI `WorkflowTemplate` and `template` entries. GitHub checks pass after retarget. | Review, merge, and deploy this runtime/API guardrail before published-artifact e2e; full `go test ./...` remains blocked locally by existing repo-wide generated `version.go` and external service/state dependencies. |
+
+## Release Gate
+
+Do not close this central plan until documentation and implementation updates
+are present in the relevant repo PRs or explicitly recorded as blocked. Public
+SDK/docs publishing remains publish-last: publish only after local/runtime/API,
+SDK, harness, and ADP validation have passed and immediately before the
+published-artifact end-to-end check.

--- a/openspec/changes/support-custom-workflow-steps/proposal.md
+++ b/openspec/changes/support-custom-workflow-steps/proposal.md
@@ -1,0 +1,190 @@
+# Change: Support Custom Workflow Steps
+
+Status: proposed, planning-only
+
+This change folder is the SDK-centered OpenSpec planning artifact for the
+cross-repo contract work. It intentionally starts with discovery before
+implementation.
+
+This change is not implementation-ready until the discovery trace, public
+contract, release gates, and repo-specific plans are reviewed. Code changes must
+start from isolated clean branches or worktrees in each target repository so
+this cross-repo feature does not mix with unrelated local work.
+
+This central change is a cross-repo planning artifact and must not be archived
+as-is into `groundx-python` specs. The spec deltas in this folder are draft
+contract slices used to drive discovery and repo-owned planning. Before archive,
+durable requirements must move into the owning repo OpenSpec changes and this
+central change must either be closed as planning documentation or reduced to
+only the `groundx-python`-owned requirements.
+
+## Problem
+
+ADP 401k extraction currently has 159 fields in
+`/Users/benjaminfletcher/git/adp-poc/workflows/adp_401k_v1/prompt.yaml`.
+Every final section is assigned to `slot: chunk-instruct`. That puts all fields
+through one chunk-level extraction slot. There are not enough current chunk-level
+slots to split the work safely, and the same limitation will exist for future
+section-level and document-level extraction work.
+
+The current platform exposes a fixed workflow step object with named fields
+such as `chunk-instruct`, `chunk-keys`, `chunk-summary`, `sect-summary`, and
+`doc-summary`. That fixed menu is too small for large structured extraction
+schemas. The system also has a `template` setting in
+`cashbot-go/pkg/model/summarizer/process.go`, but that setting is not exposed
+through the public Fern/OpenAPI/Python SDK workflow config surfaces.
+
+## Goals
+
+- Design a workflow config shape that supports custom arrays of chunk, section,
+  and document steps.
+- Keep the existing fixed step names and legacy YAML behavior working for
+  current customers.
+- Expose the existing Go `template` workflow setting through Fern, the Python
+  SDK, documentation, and harness guidance.
+- Account for the TypeScript SDK generator affected by the shared Fern schema,
+  with a mandatory generation smoke check. TypeScript feature documentation and
+  examples may be out of scope for the first release, but schema generation
+  compatibility is not optional.
+- Trace `chunk-keywords`/`chunkKeywords`/`ChunkKeys` end to end, and also trace
+  representative section and document summary paths, so the chosen custom output
+  map design covers all three levels it promises.
+- Preserve authored extraction YAML and custom step metadata in
+  `workflow.extract` so runtimes that download the workflow can see it.
+- Reserve top-level `workflow:` as authoring metadata and fail clearly if YAML
+  tries to use `workflow` as a final output group.
+- Keep legacy `slot:` YAML working while making `workflow_step:` the forward
+  assignment key for fixed and custom workflow steps.
+- Preserve route metadata from custom X-Ray/readback output paths back to final
+  JSON paths so downstream reassembly can work.
+- Define custom step naming, uniqueness, reserved-name, normalization, output
+  destination, persistence-version, and field-load validation rules before any
+  implementation begins.
+- Use explicit route records with `workflow_group`, `workflow_field`,
+  `final_path`, `step_name`, `level`, `output_map`, `output_key`, and
+  `readback_path`. Public workflow config carries these as workflow-level
+  `outputRoutes`; persisted metadata stores them as `output_routes`.
+- Use explicit leaf-field records with `final_path`, `workflow_group`,
+  `workflow_field`, `step_name`, `level`, `output_key`, `field_type`,
+  `is_repeated`, and `repetition_scope`. Public workflow config carries these as
+  workflow-level `leafFields`; persisted metadata stores them as `leaf_fields`.
+- Require `outputRoutes` and `leafFields` to match one-to-one on final path,
+  workflow group/field, custom step, level, and output key; reject missing, extra,
+  duplicate, stale, or mismatched route/leaf metadata before hashing or execution.
+- Use a literal `*` path segment as the schema wildcard for repeated item leaves,
+  for example `/fees/*/amount`, and count wildcard item leaves once per prompted
+  schema leaf rather than once per runtime array element.
+- Define public `customSteps[]` records as `name`, `level`, `kind`, optional
+  `config`, and optional `requiredTemplateKeys`; `config` reuses the existing
+  element-targeted workflow step shape but cannot set the legacy fixed-output
+  `field`.
+- Author explicit YAML custom output keys with field-level
+  `workflow_output_key`, persist them as `output_key`, and expose them in public
+  JSON route records as `outputKey`.
+- Use `workflow.metadata_version: 1` for custom workflow metadata and fail
+  closed on unknown or future custom metadata versions.
+- Use server-recomputed field counts from canonical `workflow.extract.workflow`
+  `output_routes` and `leaf_fields`; caller-provided counts and hashes are
+  non-authoritative hints only, and hash arrays use deterministic identity
+  sorting.
+- Enforce the executable-step field-load limit in the API/runtime contract and
+  mirror that rule in SDK, harness, and ADP validation so direct API users cannot
+  bypass the guardrail. The limit is 20 fields per executable workflow step.
+- Update `cashbot-go` to load, store, execute, and expose custom step output in
+  X-Ray without breaking existing workflow step behavior.
+- Update `internal-arcadia-agents` planning so the current reconcile, QA, and
+  save task families remain supported except `qa_charges`, which is dead legacy.
+  The new `reconcile_fields`, `qa_fields`, and `save_fields` actions belong in a
+  follow-on repo-owned plan after this central planning change is cleaned up and
+  closed out. The current central plan may record a deferral stub for
+  `internal-arcadia-agents`, but it must not require or start that follow-on
+  implementation before closeout.
+- Update `groundx-studio-harness` extraction/workflow skills, templates,
+  scanners, examples, and plugin mirror after the behavior is implemented.
+- Update `eyelevel-fern-config` public docs so engineers understand the public
+  SDK path without internal harness terms.
+
+## Non-goals
+
+- Do not immediately rewrite the ADP YAML before the platform contract is
+  designed and tested.
+- Do not weaken, skip, delete, or rewrite existing tests just to make the new
+  behavior pass.
+- Do not make arbitrary YAML task execution possible in Arcadia. Runtime task
+  graph support must be allowlisted.
+- Do not remove the current fixed `WorkflowSteps` fields.
+- Do not expose harness internals in public documentation.
+- Do not make sidecar metadata the only durable source of truth. The authored
+  YAML/custom step settings must survive through `workflow.extract`.
+- Do not hardcode the ADP plan shape into SDK, Go, Arcadia, harness, or docs.
+- Do not publish generated SDKs or public docs early. Publish them only after
+  local/runtime/schema/SDK/harness verification, as the final prerequisite for
+  the end-to-end proof that requires published artifacts.
+- Do not update downstream dependency bounds until the published-artifact
+  end-to-end path passes.
+
+## Repositories
+
+Primary plan lives here:
+
+- `/Users/benjaminfletcher/git/groundx-python`
+
+Current implementation planning and follow-on planning cover:
+
+- `/Users/benjaminfletcher/git/eyelevel-fern-config`
+- `/Users/benjaminfletcher/git/groundx-python`
+- `/Users/benjaminfletcher/git/cashbot-go`
+- `/Users/benjaminfletcher/git/internal-arcadia-agents` (deferral stub now;
+  follow-on implementation plan after central closeout)
+- `/Users/benjaminfletcher/git/groundx-studio-harness`
+- `/Users/benjaminfletcher/git/adp-poc`
+
+Each implementation repo must use a clean branch or worktree dedicated to this
+change before local files are modified. Existing unrelated branches or dirty
+worktrees are blockers unless the user explicitly approves using them.
+
+Repo-owned OpenSpec work must be valid and archiveable in that repo. Do not
+create an `openspec/changes/...` folder that contains only an execution plan; if
+there is no durable spec delta for a repo, keep tactical notes outside
+`openspec/changes/`.
+
+Public API/runtime field-load validation must not trust caller-asserted field
+counts. The API/runtime must derive per-executable-step field counts from the
+canonical persisted `workflow.extract.workflow.output_routes` and
+`workflow.extract.workflow.leaf_fields`, or verify a server-recomputable
+integrity record over that same canonical metadata. Custom extraction workflow
+requests with missing, unparseable, stale, mismatched, unknown-version, or
+caller-only field-count metadata must be rejected before runtime execution rather
+than accepted with an unknown or spoofable load.
+
+## Required Order
+
+1. Discovery trace and design proposal.
+2. Fern/OpenAPI contract.
+3. Repo-specific implementation plans with exact tests and verification gates.
+4. Isolated repo branches/worktrees and publish-last release gates.
+5. `cashbot-go` runtime support, API validation, persistence, and X-Ray support.
+6. Generated Python SDK verification/release path plus hand-written extract YAML
+   support.
+7. Arcadia prompt manager deferral stub and preservation requirements for
+   existing reconcile/QA/save behavior, with `qa_charges` removed from the future
+   authorable vocabulary.
+8. Harness extraction/workflow skill support.
+9. Public SDK and docs publishing after runtime, SDK, and harness behavior are
+   verified, as the last prerequisite before final e2e.
+10. ADP YAML migration and end-to-end validation against the published artifacts.
+11. Follow-on Arcadia fields plan for `reconcile_fields`, `qa_fields`, and
+   `save_fields` after this central plan is cleaned up and closed out.
+
+Downstream dependency changes must use a lower bound such as
+`groundx-python >= <released version>` rather than hardcoding an exact SDK
+version.
+
+Generated SDK changes must originate from the upstream Fern/OpenAPI source and
+the approved SDK regeneration or release workflow. Local generated artifacts may
+be used for verification, but generated files in `groundx-python` must not be
+hand-edited or committed as implementation work unless an approved release path
+explicitly produces that commit.
+
+Each implementation task must be followed by an adversarial review before the
+next task starts.

--- a/openspec/changes/support-custom-workflow-steps/repo-plan-blockers.md
+++ b/openspec/changes/support-custom-workflow-steps/repo-plan-blockers.md
@@ -1,0 +1,139 @@
+# Repo-Specific Planning Closeout Checklist
+
+This file records the repo-specific planning requirements that Task 3 needed to
+satisfy. Task 3 planning is now complete and reviewed; implementation remains
+blocked only on creating or selecting the clean implementation branch/worktree
+named by each repo-owned plan and saving the untracked planning artifacts.
+
+Locked decisions:
+
+- Workflow config uses `customSteps`, separate from legacy `steps`.
+- Custom output readback uses `customChunkOutputs`, `customSectionOutputs`, and
+  `customDocumentOutputs`.
+- Top-level YAML `workflow:` is always reserved.
+- New YAML uses `workflow_step:`; legacy `slot:` remains supported.
+- `template` follows cashbot-go workflow/process `Process.Template
+  *map[string]string`, not the partner template object.
+- One executable workflow step may own at most 20 fields.
+- Arcadia keeps existing reconcile/QA/save actions except `qa_charges`, which is
+  dead legacy. `agent` and `save_agents` stay internal.
+- `reconcile_fields`, `qa_fields`, and `save_fields` belong in a follow-on
+  `internal-arcadia-agents` plan after this central plan is cleaned up and
+  closed out.
+- SDK/docs publishing is the final prerequisite before the e2e path that
+  requires published artifacts; downstream dependency bumps wait until that e2e
+  passes.
+- Route metadata records `workflow_group`, `workflow_field`, `final_path`,
+  `step_name`, `level`, `output_map`, `output_key`, and `readback_path`.
+- Public workflow config carries route records as `outputRoutes`; persisted
+  metadata stores them as `workflow.extract.workflow.output_routes`.
+- Public workflow config carries leaf-field records as `leafFields`; persisted
+  metadata stores them as `workflow.extract.workflow.leaf_fields`.
+- `outputRoutes` and `leafFields` must match one-to-one on final path, workflow
+  group/field, custom step, level, and output key; missing, extra, duplicate,
+  stale, or mismatched route/leaf metadata fails before hashing or execution.
+- Explicit output keys are authored in YAML as field-level
+  `workflow_output_key`, persisted as `output_key`, and exposed in public JSON
+  route records as `outputKey`.
+- Public `customSteps[]` records contain `name`, `level`, `kind`, optional
+  `config`, and optional `requiredTemplateKeys`; custom step `config` reuses the
+  existing element-targeted workflow step shape but must omit or null the legacy
+  fixed-output `field`.
+- Custom step names are lower snake case, globally unique, fail on
+  auto-normalization ambiguity, and cannot collide with fixed aliases or
+  reserved workflow/runtime names.
+- `workflow.metadata_version: 1` is current. Unknown/future custom workflow
+  metadata versions fail closed; missing workflow metadata is legacy fallback
+  only when no custom workflow metadata is present.
+- Public API/runtime field counts are server-recomputed from canonical
+  `workflow.extract.workflow.output_routes` and
+  `workflow.extract.workflow.leaf_fields`. Caller-provided `field_counts` and
+  `schema_hash` are non-authoritative hints, and hash arrays use deterministic
+  identity sorting.
+- Leaf-field repetition uses explicit `is_repeated` and `repetition_scope`
+  metadata, exposed publicly as `isRepeated` and `repetitionScope`.
+- Repeated item leaves use a literal `*` RFC 6901 path segment as the schema
+  wildcard, such as `/fees/*/amount`, and count once per prompted schema leaf.
+- Template config is `map[string]string`, allows extra keys, blocks reserved
+  names and invalid types/sizes, stores YAML-authored values at workflow-level
+  `workflow.template`, declares required keys through step metadata, validates
+  required keys with the same normalization/rules as template keys, and keeps
+  existing fixed-prompt optional placeholder behavior.
+- Reserved template key names are enumerated by the central workflow-config spec
+  and must be reused for both `template` and `requiredTemplateKeys`.
+
+## `/Users/benjaminfletcher/git/eyelevel-fern-config`
+
+- Plan covers `customSteps`, `template`, the three custom output maps, and
+  the 20-field validation contract in OpenAPI/Fern.
+- Plan requires TypeScript generation smoke coverage.
+- Plan defines the publish-last SDK/docs gate and the downstream lower-bound
+  dependency sequence.
+
+## `/Users/benjaminfletcher/git/cashbot-go`
+
+- Plan chooses the Go model change that supports `customSteps` without
+  breaking fixed `StepType`/`FieldType` behavior.
+- Plan identifies storage and X-Ray/readback work for `customChunkOutputs`,
+  `customSectionOutputs`, and `customDocumentOutputs`.
+- Plan keeps fixed document-summary `fileSummary` behavior unchanged while
+  routing custom document outputs through `customDocumentOutputs`.
+- Plan enforces the 20-field limit from canonical `workflow.extract` schema
+  and route metadata, rejecting spoofed/caller-only counts.
+- Plan exposes workflow/process `template` matching `Process.Template
+  *map[string]string` and avoid confusing it with the partner template object.
+
+## `/Users/benjaminfletcher/git/groundx-python`
+
+- Plan consumes generated SDK surfaces from upstream Fern/OpenAPI.
+- Plan implements always-reserved `workflow:`, `workflow_step:` assignment,
+  legacy `slot:` compatibility, custom step naming rules, persisted metadata
+  versioning, and custom output route metadata.
+- Plan parses `customChunkOutputs`, `customSectionOutputs`, and
+  `customDocumentOutputs` while preserving fixed top-level and per-chunk
+  `fileSummary` behavior.
+- Plan mirrors the 20-field limit and emits/verifiably preserves the canonical
+  metadata needed by public API/runtime validation.
+
+## `/Users/benjaminfletcher/git/internal-arcadia-agents`
+
+- Current central plan records the Arcadia decisions but defers implementation.
+- The current Task 3 gate needs only a deferral stub for this repo, not a full
+  implementation plan for `reconcile_fields`, `qa_fields`, and `save_fields`.
+- Follow-on plan will use the three custom output maps for reassembly route
+  metadata.
+- Follow-on plan will keep `agent`/`save_agents` internal behind the default
+  compatibility adapter.
+- Follow-on plan will treat `qa_charges` as dead legacy.
+- Follow-on plan will define `reconcile_fields`, `qa_fields`, and `save_fields`
+  behavior, payloads, retry/idempotency assumptions, failure propagation, tests,
+  and implementation steps.
+
+## `/Users/benjaminfletcher/git/groundx-studio-harness`
+
+- Plan waits for SDK/runtime support for `customSteps` and custom output
+  maps before teaching or validating them as implemented behavior.
+- Plan mirrors the 20-field executable-step limit and public API/runtime
+  error behavior.
+- Plan keeps installed skill guidance behind real platform behavior.
+
+## `/Users/benjaminfletcher/git/adp-poc`
+
+- Plan uses `workflow_step:` assignment and the 20-field executable-step
+  limit.
+- ADP implementation remains sequenced after the updated harness/SDK compiler
+  path exists.
+- Plan preserves the 11 final ADP output sections while splitting the 159
+  fields across platform-supported custom executable steps.
+
+## Task 11 E2E Blocker
+
+- Local legacy/custom compile and live workflow create/get/delete checks passed.
+- Release e2e is blocked because the deployed API accepted an oversized/spoofed
+  custom-step workflow that assigned all 159 ADP routes to one custom step while
+  spoofing a low `field_counts` value.
+- The created negative-test workflow was deleted and a cleanup scan found no
+  remaining `codex-e2e-support-custom-workflow-steps-*` workflows.
+- Continue only after the runtime/API artifact with Task 5 field-count
+  validation is deployed or e2e is pointed at an approved equivalent deployed
+  environment.

--- a/openspec/changes/support-custom-workflow-steps/specs/arcadia-runtime/spec.md
+++ b/openspec/changes/support-custom-workflow-steps/specs/arcadia-runtime/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: Arcadia custom step support keeps legacy defaults
+
+Arcadia custom workflow-step and runtime-graph support SHALL preserve the
+current production default when custom runtime metadata is absent.
+
+#### Scenario: Arcadia defaults to current production graph
+
+- **GIVEN** Arcadia YAML without custom runtime graph metadata
+- **WHEN** Arcadia starts an extraction
+- **THEN** it uses the current production chord/chain graph
+- **AND** statement, meter, and charge reconciliation behavior remains
+  unchanged
+
+#### Scenario: Arcadia existing graph tasks have safe execution contracts
+
+- **GIVEN** Arcadia YAML with allowlisted runtime graph metadata
+- **WHEN** Arcadia validates and executes the graph
+- **THEN** the initial authorable task vocabulary is limited to reviewed
+  existing business actions: `reconcile_charges`, `reconcile_meters`,
+  `reconcile_statement`, `qa_meters`, `qa_statement`, `save_charges`,
+  `save_meters`, and `save_statement`
+- **AND** every authorable task has a documented input payload, output payload,
+  retry or idempotency assumption, and failure propagation behavior
+- **AND** the existing `qa_charges` code path is classified as dead legacy and
+  is not authorable
+- **AND** invalid payload handoff, unsupported graph shapes, cycles, and missing
+  required save or finalization stages fail before arbitrary task execution
+
+#### Scenario: Arcadia custom graph can represent the production default
+
+- **GIVEN** the current production graph includes the internal `agent` task and
+  `save_agents` aggregation behavior
+- **WHEN** the custom graph vocabulary is finalized
+- **THEN** the contract defines a compatibility adapter that preserves the
+  current default graph exactly when custom runtime metadata is absent
+- **AND** `agent` and `save_agents` remain internal graph nodes
+- **AND** the default graph can be represented, tested, and compared without
+  weakening existing statement, meter, or charge behavior
+
+### Requirement: Arcadia custom field actions are planned separately
+
+Arcadia SHALL add `reconcile_fields`, `qa_fields`, and `save_fields` as custom
+field actions only through a follow-on plan created after cleanup and closeout
+of this central planning change.
+
+#### Scenario: Central plan records only a deferral stub
+
+- **GIVEN** this central planning change is preparing current-wave implementation
+  work
+- **WHEN** repo-specific planning gates are reviewed
+- **THEN** `internal-arcadia-agents` has a deferral stub rather than a current
+  implementation plan
+- **AND** the stub records preserved legacy reconcile/QA/save behavior
+- **AND** the stub records that `qa_charges` is dead legacy and not future
+  authorable vocabulary
+- **AND** the stub records that `reconcile_fields`, `qa_fields`, and
+  `save_fields` require a follow-on repo-owned plan after central closeout
+
+#### Scenario: Custom field action work is deferred to a new plan
+
+- **GIVEN** this central plan is being closed out
+- **WHEN** Arcadia custom field action work is ready to begin
+- **THEN** a new repo-owned plan defines `reconcile_fields`, `qa_fields`, and
+  `save_fields`
+- **AND** that plan defines each action's behavior, input payload, output
+  payload, retry or idempotency assumptions, failure propagation behavior, and
+  required `internal-arcadia-agents` implementation changes
+- **AND** this central plan does not silently start that implementation work

--- a/openspec/changes/support-custom-workflow-steps/specs/cross-repo-planning/spec.md
+++ b/openspec/changes/support-custom-workflow-steps/specs/cross-repo-planning/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Central planning change is not archived as cross-repo truth
+
+The central `groundx-python` OpenSpec change SHALL remain a planning artifact
+until repo-owned OpenSpec changes absorb durable behavior requirements.
+
+#### Scenario: Central change is closed without archiving cross-repo specs
+
+- **GIVEN** this central planning change contains draft requirements for
+  `cashbot-go`, `eyelevel-fern-config`, `internal-arcadia-agents`,
+  `groundx-studio-harness`, or `adp-poc`
+- **WHEN** implementation work is ready to archive
+- **THEN** durable requirements have moved into valid OpenSpec changes in the
+  owning repos
+- **AND** this central change is either closed as planning documentation or
+  reduced to only `groundx-python`-owned requirements before archive
+- **AND** no cross-repo runtime, API, Arcadia, harness, ADP, or public-docs
+  requirement is archived into `groundx-python` as if that repo owned it

--- a/openspec/changes/support-custom-workflow-steps/specs/custom-output-readback/spec.md
+++ b/openspec/changes/support-custom-workflow-steps/specs/custom-output-readback/spec.md
@@ -1,0 +1,106 @@
+## ADDED Requirements
+
+### Requirement: Custom outputs are readable after extraction
+
+The runtime and SDK SHALL expose custom chunk, section, and document outputs in
+documented X-Ray/readback maps named `customChunkOutputs`,
+`customSectionOutputs`, and `customDocumentOutputs`.
+
+The custom output shape SHALL be additive to the existing fixed X-Ray fields.
+Existing `chunkKeywords`, `sectionSummary`, `fileSummary`, and related fixed
+fields SHALL remain available for legacy workflows and fixed-step consumers.
+
+Custom outputs SHALL be persisted through explicit workflow custom-output
+metadata. Chunk-level custom outputs map to molecule-level custom metadata,
+section-level custom outputs map to section-level custom metadata, and
+document-level custom outputs map to document-level custom metadata. Missing
+custom-output metadata on old documents SHALL be treated as empty.
+
+#### Scenario: Custom output readback is predictable
+
+- **GIVEN** a workflow with custom chunk, section, and document steps
+- **WHEN** the runtime processes a document and returns X-Ray
+- **THEN** custom chunk outputs are available under `customChunkOutputs`
+- **AND** custom section outputs are available under `customSectionOutputs`
+- **AND** custom document outputs are available under `customDocumentOutputs`
+- **AND** the SDK can parse the custom outputs
+- **AND** existing fixed outputs such as `chunkKeywords` remain available
+
+#### Scenario: Fixed readback fields remain stable
+
+- **GIVEN** a workflow using only existing fixed step outputs
+- **WHEN** the runtime returns X-Ray and the SDK loads the document
+- **THEN** chunk keyword output remains available as `chunkKeywords`
+- **AND** section summary output remains available as `sectionSummary`
+- **AND** document summary output remains available as top-level `fileSummary`
+  when the runtime emits one consistent document summary
+- **AND** per-chunk document summary output remains available as chunk
+  `fileSummary` when the runtime emits divergent chunk-level document summaries
+- **AND** custom output support does not require legacy consumers to read a new
+  custom output map for those fixed fields
+
+#### Scenario: Custom output route metadata supports reassembly
+
+- **GIVEN** a custom workflow group field routed to a final JSON path
+- **WHEN** the runtime returns the field under `customChunkOutputs`,
+  `customSectionOutputs`, or `customDocumentOutputs`
+- **THEN** workflow metadata identifies the exact custom output path
+- **AND** Arcadia can map the custom output value back to the final JSON path
+- **AND** custom workflow group names do not appear in the final JSON
+
+#### Scenario: Custom readback paths are exact and level-aware
+
+- **GIVEN** a workflow with custom chunk, section, and document outputs
+- **WHEN** route metadata is persisted and read back
+- **THEN** each route records the canonical custom step identity
+- **AND** each route records the output level: chunk, section, or document
+- **AND** each route records the exact X-Ray/readback path used by the SDK and
+  Arcadia
+- **AND** document-level custom output routes read from `customDocumentOutputs`
+  rather than legacy top-level or per-chunk `fileSummary`
+- **AND** duplicate custom output destinations fail according to the workflow
+  config naming and collision contract
+
+#### Scenario: Route metadata is explicit
+
+- **GIVEN** a custom output routed to a final JSON field
+- **WHEN** workflow metadata is persisted
+- **THEN** each route records `workflow_group`, `workflow_field`, `final_path`,
+  `step_name`, `level`, `output_map`, `output_key`, and `readback_path`
+- **AND** `final_path` is an RFC 6901 JSON Pointer to the final JSON field
+- **AND** each route has exactly one matching `leaf_fields` record for the same
+  `final_path`, `workflow_group`, `workflow_field`, `step_name`, `level`, and
+  `output_key`
+- **AND** `readback_path` is the X-Ray/readback path template where SDK and
+  Arcadia read the value
+- **AND** chunk route `readback_path` stores the canonical non-page path
+  `/chunks/*/customChunkOutputs/<step_name>/<output_key>`
+- **AND** when X-Ray includes page-level chunks, SDK and Arcadia derive the
+  companion chunk path
+  `/documentPages/*/chunks/*/customChunkOutputs/<step_name>/<output_key>`
+- **AND** section route `readback_path` stores the canonical non-page path
+  `/chunks/*/customSectionOutputs/<step_name>/<output_key>`
+- **AND** when X-Ray includes page-level chunks, SDK and Arcadia derive the
+  companion section path
+  `/documentPages/*/chunks/*/customSectionOutputs/<step_name>/<output_key>`
+- **AND** document readback paths use
+  `/customDocumentOutputs/<step_name>/<output_key>`
+
+#### Scenario: Document custom outputs are single document values
+
+- **GIVEN** a document-level custom output
+- **WHEN** runtime produces X-Ray
+- **THEN** the value is returned through top-level `customDocumentOutputs`
+- **AND** the value is not emitted through legacy top-level or per-chunk
+  `fileSummary`
+- **AND** conflicting per-chunk document custom values fail validation instead
+  of producing a divergent document custom output
+
+#### Scenario: Old documents remain readable
+
+- **GIVEN** an old processed document without custom-output metadata
+- **WHEN** X-Ray/readback is requested
+- **THEN** fixed legacy fields remain readable
+- **AND** custom output maps are absent or empty
+- **AND** the reader does not require a backfill migration before returning
+  legacy X-Ray

--- a/openspec/changes/support-custom-workflow-steps/specs/extract-yaml/spec.md
+++ b/openspec/changes/support-custom-workflow-steps/specs/extract-yaml/spec.md
@@ -1,0 +1,158 @@
+## ADDED Requirements
+
+### Requirement: Extraction YAML can assign workflow groups to custom steps
+
+The SDK SHALL support workflow metadata that assigns prepared workflow groups
+to named custom workflow steps without changing the final JSON group names.
+Top-level `workflow:` SHALL always be reserved for workflow authoring metadata.
+Final output schemas SHALL NOT use `workflow:` as a top-level final group.
+
+#### Scenario: Custom step assignment preserves final groups
+
+- **GIVEN** YAML with final groups and `workflow_step` metadata assigning those
+  groups to custom step names
+- **WHEN** `prepare_extraction_yaml(...)` prepares the YAML
+- **THEN** prepared final groups still match the real top-level final JSON
+  groups
+- **AND** prepared workflow groups expose the executable groups
+- **AND** workflow metadata includes the custom step assignment
+- **AND** pseudo/custom workflow group names do not appear as final groups
+
+#### Scenario: Custom steps exist at each supported level
+
+- **GIVEN** YAML with custom chunk, section, and document workflow step
+  definitions
+- **WHEN** the SDK prepares the YAML
+- **THEN** each custom step definition is preserved with its level
+- **AND** each custom step definition has `name`, `level`, `kind`, optional
+  `config`, and optional `required_template_keys`
+- **AND** valid level/kind combinations are `chunk` with `instruct`, `keys`, or
+  `summary`; `section` with `instruct`, `keys`, or `summary`; and `document`
+  with `keys` or `summary`
+- **AND** optional `config` uses the existing element-targeted workflow step
+  shape and omits or nulls the legacy fixed-output `field`
+- **AND** workflow group assignments can point to the custom step names
+- **AND** legacy fixed step names remain valid
+
+#### Scenario: Workflow template values are not per-step metadata
+
+- **GIVEN** YAML with workflow-level `workflow.template`
+- **AND** custom step definitions with optional `required_template_keys`
+- **WHEN** the SDK prepares workflow metadata
+- **THEN** `workflow.template` is treated as the workflow/process template map
+- **AND** `required_template_keys` is preserved as step metadata
+- **AND** custom step definitions with nested per-step `template` maps fail
+  clearly instead of creating per-step template behavior
+
+#### Scenario: Legacy slot metadata remains supported
+
+- **GIVEN** YAML that uses existing `slot:` metadata and no custom step
+  definitions
+- **WHEN** `prepare_extraction_yaml(...)` prepares the YAML
+- **THEN** current workflow group metadata behavior remains unchanged
+- **AND** callers do not need to add custom step definitions
+- **AND** new documentation treats `slot:` as legacy compatibility and teaches
+  `workflow_step:` as the forward path
+
+#### Scenario: Workflow step metadata replaces slot for new YAML
+
+- **GIVEN** YAML with a final group assigned by `workflow_step`
+- **WHEN** `prepare_extraction_yaml(...)` prepares the YAML
+- **THEN** the group is assigned to the canonical fixed or custom workflow step
+  named by `workflow_step`
+- **AND** final JSON group and field names remain unchanged
+
+#### Scenario: Slot and workflow_step conflict fails clearly
+
+- **GIVEN** YAML with a final group that declares both `slot` and
+  `workflow_step`
+- **WHEN** `prepare_extraction_yaml(...)` prepares the YAML
+- **THEN** preparation fails
+- **AND** the error states that only one workflow assignment key is allowed
+
+#### Scenario: Workflow is always reserved
+
+- **GIVEN** YAML with a top-level `workflow:` mapping
+- **WHEN** `prepare_extraction_yaml(...)` prepares the YAML
+- **THEN** `workflow:` is parsed only as workflow authoring metadata
+- **AND** a final output group named `workflow` is rejected with a clear
+  migration error
+
+#### Scenario: Invalid custom step identity fails clearly
+
+- **GIVEN** YAML with custom step definitions
+- **AND** a custom step name is invalid, duplicated within its uniqueness scope,
+  collides with a fixed workflow step name, uses a reserved name, or maps to a
+  duplicate custom output destination after normalization
+- **WHEN** `prepare_extraction_yaml(...)` prepares the YAML
+- **THEN** preparation fails
+- **AND** the error identifies the custom step and the identity rule that was
+  violated
+- **AND** valid custom step names match `^[a-z][a-z0-9_]{0,63}$`
+- **AND** custom step names are not auto-normalized across case, kebab, snake,
+  or camel forms
+
+#### Scenario: Custom step names normalize consistently
+
+- **GIVEN** YAML custom step names that use the allowed authoring form
+- **WHEN** the SDK prepares workflow metadata and serializes workflow config
+- **THEN** the same canonical step identity is used in workflow JSON, persisted
+  extract metadata, custom X-Ray/readback output paths, and route metadata
+- **AND** final JSON group and field names are not changed by the canonical
+  workflow step identity
+
+#### Scenario: Output keys are canonical
+
+- **GIVEN** YAML workflow field names assigned to custom steps
+- **WHEN** SDK preparation creates custom output route metadata
+- **THEN** an `output_key` defaults to the prepared workflow field name only
+  when the field name matches `^[a-z][a-z0-9_]{0,63}$`
+- **AND** invalid or nested workflow field names require an explicit valid
+  field-level `workflow_output_key` beside the prompted field definition
+- **AND** `workflow_output_key` is authoring-only metadata that is persisted as
+  route `output_key`, exposed in public JSON `outputRoutes[]` records as
+  `outputKey`, and never emitted as a final JSON field
+- **AND** duplicate `(output_map, step_name, output_key)` destinations fail
+- **AND** duplicate final JSON field routes fail
+
+### Requirement: Persisted workflow extract preserves custom step metadata
+
+The SDK SHALL preserve custom step definitions and workflow group assignments in
+the JSON-serializable persisted workflow extract payload. The payload SHALL
+include `workflow.metadata_version: 1` and enough canonical schema and route
+metadata for the public API/runtime to derive or verify per-executable-step field
+counts. The field-count metadata SHALL use the canonical `leaf_fields` shape
+defined by the workflow-config contract.
+
+#### Scenario: Custom step metadata survives workflow extract round trip
+
+- **GIVEN** YAML with custom step definitions and workflow group assignments
+- **WHEN** the SDK prepares the YAML and serializes
+  `PreparedExtractionYaml.persisted_workflow_extract`
+- **AND** the serialized mapping is prepared again
+- **THEN** the custom step definitions are still present
+- **AND** the workflow group assignments are still present
+- **AND** final groups, workflow groups, and route metadata still match the
+  original preparation
+- **AND** `leaf_fields` are derived from the YAML final schema and workflow
+  assignments using the workflow-config `leaf_fields` contract
+- **AND** derived `output_routes` and `leaf_fields` have a one-to-one match on
+  `final_path`, `workflow_group`, `workflow_field`, `step_name`, `level`, and
+  `output_key`
+- **AND** repeated item/object leaves use the workflow-config wildcard
+  schema path convention, such as `/fees/*/amount`
+- **AND** per-executable-step field counts can be derived or verified from the
+  persisted metadata without trusting caller-provided count fields alone
+- **AND** no executable workflow step is assigned more than 20 fields
+
+#### Scenario: Persisted workflow extract version compatibility is explicit
+
+- **GIVEN** a persisted workflow extract payload with missing, current, unknown,
+  or future-version custom workflow metadata
+- **WHEN** the SDK prepares that mapping input again
+- **THEN** `workflow.metadata_version: 1` metadata is loaded
+- **AND** missing `workflow:` metadata follows legacy fixed-step fallback only
+  when no custom steps, output routes, or custom output maps are present
+- **AND** missing metadata version fails when custom workflow metadata is present
+- **AND** unknown, future, non-integer, or unsupported versions fail closed
+- **AND** the result never silently drops custom step assignments

--- a/openspec/changes/support-custom-workflow-steps/specs/release-governance/spec.md
+++ b/openspec/changes/support-custom-workflow-steps/specs/release-governance/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: Downstream docs and repos follow publish-last e2e releases
+
+Public SDK and docs publishing SHALL happen late in the sequence, after local
+runtime, schema, SDK, and harness verification, because the final end-to-end
+test is expected to require published SDK and docs artifacts. Downstream repos
+SHALL move only after that published-artifact e2e path passes.
+
+#### Scenario: Public docs describe implemented behavior
+
+- **GIVEN** public docs that explain custom workflow steps
+- **WHEN** those docs are published for final end-to-end validation
+- **THEN** local Go runtime, Python SDK, and harness compile/readback
+  verification has already passed
+- **AND** the docs do not describe harness-only behavior as public API behavior
+- **AND** the published docs are included in the final e2e proof path
+
+#### Scenario: Downstream repos use a lower-bound SDK dependency
+
+- **GIVEN** a downstream repo needs the released SDK feature
+- **WHEN** the published SDK/docs/runtime e2e path has passed
+- **AND** its dependency is updated
+- **THEN** the dependency uses a lower bound such as
+  `groundx-python >= <released version>`
+- **AND** it does not pin exactly to one SDK version unless explicitly approved
+
+#### Scenario: Fern schema change accounts for TypeScript generation
+
+- **GIVEN** the shared Fern OpenAPI schema changes for custom steps or
+  `template`
+- **WHEN** release readiness is reviewed
+- **THEN** TypeScript generation has a passing smoke check using
+  `fern generate --group ts-sdk`
+- **AND** the smoke evidence shows the generator accepts `customSteps`,
+  custom step `config`, custom step legacy `field` rejection, `outputRoutes`,
+  `outputKey`, `leafFields`, route/leaf matching fields, `isRepeated`,
+  `repetitionScope`, wildcard repeated-item final paths, `template`,
+  `requiredTemplateKeys`, reserved template key validation, the custom output map
+  schemas, and the 20-field validation/metadata schema without generator errors
+- **AND** Python SDK behavior remains the release blocker for this feature
+- **AND** TypeScript feature documentation and examples may be deferred only if
+  generation compatibility is still proven
+
+#### Scenario: Generated SDK and docs publish as the final e2e prerequisite
+
+- **GIVEN** the Fern/OpenAPI contract has been updated for custom workflow steps
+  or `template`
+- **WHEN** generated SDKs or public docs must be published for final end-to-end
+  testing
+- **THEN** `cashbot-go`, Python SDK, harness compile/readback, TypeScript
+  generation smoke, and mirrored OpenAPI surfaces have already passed local or
+  repo-level verification
+- **AND** publishing is treated as the final prerequisite before the e2e run
+- **AND** downstream dependency changes wait until the published-artifact e2e
+  run passes
+
+#### Scenario: Local generation verifies the contract before publish
+
+- **GIVEN** the Fern/OpenAPI branch defines custom workflow steps or `template`
+- **WHEN** SDK and runtime work need generated surfaces for tests
+- **THEN** local Python and TypeScript generation or generator smoke output may
+  be used before publishing a released SDK
+- **AND** those local generated artifacts do not count as a public SDK release
+- **AND** public SDK and docs publishing wait until runtime, SDK, harness, and
+  mirrored OpenAPI verification pass
+- **AND** downstream dependency bumps wait until the published-artifact e2e path
+  passes
+
+#### Scenario: Published-artifact e2e can fail after publish
+
+- **GIVEN** the SDK and docs have been published as the final e2e prerequisite
+- **WHEN** the end-to-end test against the published artifacts fails
+- **THEN** the release is recorded as failed
+- **AND** follow-up work fixes forward with a corrective patch or replacement
+  publication
+- **AND** downstream dependency bumps and customer-facing closeout remain blocked
+  until the corrected published-artifact e2e path passes
+
+#### Scenario: Generated SDK files come from the approved source path
+
+- **GIVEN** generated Python SDK files change for custom workflow steps or
+  `template`
+- **WHEN** the SDK repo is reviewed for release readiness
+- **THEN** the generated files came from the upstream Fern/OpenAPI source and the
+  approved regeneration or release path
+- **AND** hand-written implementation commits did not directly edit generated
+  files outside that path
+- **AND** local generated artifacts used for verification are identified as
+  non-release artifacts unless the approved release workflow produced the commit
+
+#### Scenario: Release closeout requires deployed-path proof or an approved substitute
+
+- **GIVEN** downstream dependency bumps or customer-facing release closeout are
+  considered
+- **WHEN** live credentials, documents, or deployment approval are unavailable
+- **THEN** release remains blocked unless an explicitly reviewed non-live
+  substitute proves workflow create/update, persisted extract metadata, X-Ray or
+  readback shape, route metadata, and final JSON reassembly
+- **AND** skipped live checks are recorded with the approving reviewer and the
+  substitute evidence

--- a/openspec/changes/support-custom-workflow-steps/specs/workflow-config/spec.md
+++ b/openspec/changes/support-custom-workflow-steps/specs/workflow-config/spec.md
@@ -1,0 +1,286 @@
+## ADDED Requirements
+
+### Requirement: Template workflow config is exposed
+
+The public workflow config SHALL expose the existing runtime `template` setting
+so SDK callers can supply prompt template values. The public shape SHALL follow
+the cashbot-go workflow/process runtime model, where `Process.Template` is a
+`map[string]string` consumed by prompt rendering, and SHALL NOT reuse or blur
+the separate partner request template object.
+
+#### Scenario: Template mapping remains workflow-level metadata
+
+- **GIVEN** workflow/process config with a `template` mapping
+- **WHEN** the SDK serializes the workflow request
+- **THEN** the mapping is sent as workflow-level config
+- **AND** it is not treated as an extraction YAML final group
+- **AND** it can be used by fixed and custom workflow step prompts
+
+#### Scenario: Template compatibility path follows Process.Template
+
+- **GIVEN** the public workflow API exposes workflow create and update requests
+- **WHEN** workflow config includes `template`
+- **THEN** `template` is accepted as workflow/process config matching runtime
+  `Process.Template *map[string]string`
+- **AND** the contract does not expose `template` as a top-level partner
+  create/update compatibility field
+- **AND** a top-level partner template object cannot be silently accepted as the
+  workflow prompt-variable map
+
+#### Scenario: Template config has safe public boundaries
+
+- **GIVEN** workflow config with `template` values
+- **WHEN** the request is validated, persisted, loaded, and rendered into fixed
+  or custom prompts
+- **THEN** `template` is a map of string keys to string values
+- **AND** keys are supplied without braces or normalized after accepting optional
+  surrounding `{{...}}`
+- **AND** keys match `^[A-Za-z][A-Za-z0-9_]{0,63}$` after brace normalization
+- **AND** keys with the reserved `GROUNDX_` prefix or workflow metadata names
+  fail validation
+- **AND** documented system prompt keys such as `LANGUAGE` and
+  `PAGE_NUMBERS_*` may be overridden
+- **AND** extra keys are allowed
+- **AND** required template keys are declared explicitly on workflow step config
+  as `requiredTemplateKeys` in public JSON and `required_template_keys` in
+  persisted metadata
+- **AND** required template keys use the same brace normalization, key regex,
+  reserved `GROUNDX_` prefix rule, and workflow metadata reserved-name checks as
+  `template` keys
+- **AND** duplicate required template keys after normalization fail validation
+- **AND** missing declared required template keys fail clearly before rendering
+- **AND** reserved workflow metadata names are exactly `workflow`, `steps`,
+  `custom_steps`, `customSteps`, `template`, `runtime`, `output_routes`,
+  `outputRoutes`, `leaf_fields`, `leafFields`, `field_counts`, `fieldCounts`,
+  `schema_hash`, `schemaHash`, `metadata_version`, `metadataVersion`,
+  `workflow_group`, `workflowGroup`, `workflow_field`, `workflowField`,
+  `final_path`, `finalPath`, `step_name`, `stepName`, `output_key`, `outputKey`,
+  `readback_path`, `readbackPath`, `_defs`, `_pseudo_groups`, and
+  `_groundx_persisted_extract`
+- **AND** unresolved optional placeholders keep existing fixed-prompt rendering
+  behavior
+- **AND** the total serialized template payload is at most 16 KiB
+- **AND** each value is at most 4 KiB
+- **AND** template values cannot be interpreted as extraction YAML final groups
+  or custom step definitions
+
+### Requirement: Oversized executable steps are rejected by validation
+
+The custom-step contract SHALL define and enforce a maximum load of 20 fields
+per executable workflow step in the public API/runtime path and mirror that rule
+in SDK, harness, and ADP validation. Direct API callers SHALL NOT bypass the
+limit.
+
+#### Scenario: ADP-style single-step overload is rejected
+
+- **GIVEN** YAML that assigns an excessive number of fields to one executable
+  workflow step
+- **WHEN** the configured validation layer evaluates the YAML
+- **THEN** the validation fails
+- **AND** the message names the overloaded workflow step
+- **AND** the message states that one executable workflow step may own at most
+  20 fields
+- **AND** the message recommends splitting the fields across custom steps
+
+#### Scenario: Direct API callers cannot bypass the field-load guardrail
+
+- **GIVEN** a workflow create or update request sent through the public API or
+  generated SDK without using harness or ADP validation
+- **AND** the request assigns an excessive number of fields to one executable
+  workflow step
+- **WHEN** the configured validation layer evaluates the request
+- **THEN** the request fails before runtime execution
+- **AND** the error identifies the overloaded workflow step
+- **AND** the error identifies the 20-field limit
+
+#### Scenario: Field-load validation derives or verifies persisted metadata
+
+- **GIVEN** a workflow create or update request with custom extraction steps
+- **WHEN** the public API/runtime validates executable-step field load
+- **THEN** the field counts are derived from canonical persisted
+  `workflow.extract.workflow.output_routes` and
+  `workflow.extract.workflow.leaf_fields`, or verified through a
+  server-recomputable integrity record over that same metadata
+- **AND** the counts use the same canonical custom step identities as workflow
+  config and route metadata
+- **AND** caller-provided field counts are never authoritative by themselves
+- **AND** requests with missing, unparseable, stale, caller-only, mismatched, or
+  unknown-version field-count metadata fail before runtime execution
+- **AND** the server counts distinct final leaf field routes assigned to each
+  executable workflow step
+- **AND** repeated/list field definitions count as one field definition unless
+  they introduce separate prompted leaf fields
+- **AND** optional `field_counts` and `schema_hash` values are treated as hints
+  that must match the server-recomputed counts and canonical hash when present
+- **AND** the canonical hash is SHA-256 over sorted-key, no-whitespace canonical
+  JSON using persisted snake_case keys
+- **AND** canonical arrays are sorted ascending by deterministic identity tuples:
+  `custom_steps` by `(name)`, `output_routes` by `(final_path, workflow_group,
+  workflow_field, step_name, output_key)`, and `leaf_fields` by `(final_path,
+  workflow_group, workflow_field, step_name, output_key)`
+- **AND** the canonical hash input contains exactly `metadata_version`,
+  `custom_steps`, `output_routes`, and `leaf_fields`
+- **AND** each `custom_steps` record contains `name`, `level`, `kind`, and any
+  declared `required_template_keys`
+- **AND** each `leaf_fields` record contains `final_path`, `workflow_group`,
+  `workflow_field`, `step_name`, `level`, `output_key`, `field_type`,
+  `is_repeated`, and `repetition_scope`
+- **AND** `is_repeated` is a boolean
+- **AND** `repetition_scope` is one of `none`, `field`, or `item`
+- **AND** `none` is valid only when `is_repeated` is false
+- **AND** `field` means a repeated/list value is prompted as one leaf and counts
+  as one field for the executable step
+- **AND** `item` means repeated item/object schema introduces separate prompted
+  leaves, and each prompted item leaf appears as its own `leaf_fields` record at
+  its full schema-level final path
+- **AND** `item` leaf final paths use a literal `*` RFC 6901 path segment at each
+  repeated-item boundary, such as `/fees/*/amount`
+- **AND** the `*` segment is a schema wildcard, not a runtime array index
+- **AND** wildcard item leaf paths count once per prompted schema leaf rather
+  than once per runtime array element
+- **AND** invalid `is_repeated` and `repetition_scope` combinations fail before
+  hashing or execution
+- **AND** prompt prose, examples, model parameters, template values, and other
+  data that does not affect executable-step field load are excluded from the
+  field-count hash
+- **AND** every `output_routes` record has exactly one matching `leaf_fields`
+  record with the same `final_path`, `workflow_group`, `workflow_field`,
+  `step_name`, `level`, and `output_key`
+- **AND** every `leaf_fields` record has exactly one matching `output_routes`
+  record with the same identity
+- **AND** matched `leaf_fields` records must match the final extract schema's
+  prompted leaf at `final_path`, including `field_type`, `is_repeated`, and
+  `repetition_scope`
+- **AND** missing, extra, duplicate, stale, or mismatched route/leaf records fail
+  before field-count hashing or execution
+
+#### Scenario: Spoofed field-count metadata is rejected
+
+- **GIVEN** a workflow create or update request with custom extraction steps
+- **AND** the request provides field-count metadata that claims the step is under
+  the configured limit
+- **AND** canonical `workflow.extract.workflow.output_routes` and
+  `workflow.extract.workflow.leaf_fields` show the step is oversized
+- **WHEN** the public API/runtime validates executable-step field load
+- **THEN** the request fails before runtime execution
+- **AND** the error identifies the overloaded workflow step and the metadata
+  mismatch
+
+### Requirement: Custom step support keeps fixed workflow defaults
+
+Custom step support SHALL be additive to the existing fixed workflow-step
+contract.
+
+#### Scenario: Existing fixed workflow steps still work
+
+- **GIVEN** a workflow using only existing fixed `WorkflowSteps` fields
+- **WHEN** the workflow is created, updated, loaded, and processed
+- **THEN** existing fixed-step behavior remains unchanged
+- **AND** existing tests for `chunk-instruct`, `chunk-keys`,
+  `chunk-summary`, section, and document steps continue to pass
+
+### Requirement: Custom workflow steps are workflow-level config
+
+The public workflow config SHALL expose custom workflow steps through a
+workflow-level `customSteps` array while preserving the legacy fixed `steps`
+object.
+
+#### Scenario: Custom steps are separate from fixed steps
+
+- **GIVEN** workflow config with legacy fixed `steps`
+- **AND** workflow config with custom step definitions
+- **WHEN** the SDK serializes and the runtime validates the workflow
+- **THEN** legacy fixed steps remain under `steps`
+- **AND** custom step definitions are serialized under `customSteps`
+- **AND** each custom step record contains `name`, `level`, `kind`, optional
+  `config`, and optional `requiredTemplateKeys`
+- **AND** valid `level` values are `chunk`, `section`, and `document`
+- **AND** valid level/kind combinations are `chunk` with `instruct`, `keys`, or
+  `summary`; `section` with `instruct`, `keys`, or `summary`; and `document`
+  with `keys` or `summary`
+- **AND** invalid level/kind combinations fail validation
+- **AND** optional `config` uses the existing element-targeted workflow step
+  shape with element keys `all`, `figure`, `json`, `paragraph`, `table`, and
+  `table-figure`
+- **AND** custom step element config may carry existing prompt, engine, and
+  include settings
+- **AND** custom step element config omits or nulls the legacy fixed-output
+  `field` because custom output storage is derived from `level`, `kind`,
+  `outputRoutes`, and `leafFields`
+- **AND** persisted `workflow.extract.workflow.custom_steps[]` uses snake_case
+  `required_template_keys` for the same logical step-level required template keys
+- **AND** custom step names are not parsed as fixed `WorkflowSteps` enum keys
+
+#### Scenario: Custom step names are canonical
+
+- **GIVEN** workflow config with custom step definitions
+- **WHEN** names are validated
+- **THEN** custom step names match `^[a-z][a-z0-9_]{0,63}$`
+- **AND** names are globally unique across all custom levels
+- **AND** uppercase, hyphenated, dotted, spaced, leading-underscore, or
+  trailing-underscore names fail instead of being auto-normalized
+- **AND** names that collide with fixed step names, fixed snake_case aliases, or
+  reserved workflow/runtime keys fail validation
+- **AND** the canonical step identity is exactly the authored lower-snake-case
+  value
+
+### Requirement: Custom output routes are workflow-level config
+
+The public workflow config SHALL expose custom output route records through a
+workflow-level `outputRoutes` array. `outputRoutes` is the public camelCase
+representation of persisted `workflow.extract.workflow.output_routes`.
+
+#### Scenario: Direct public route records are explicit
+
+- **GIVEN** a direct workflow create or update request with custom workflow steps
+- **WHEN** the request defines custom output routes without using YAML preparation
+- **THEN** the routes are serialized under workflow-level `outputRoutes`
+- **AND** each route includes `workflowGroup`, `workflowField`, `finalPath`,
+  `stepName`, `level`, `outputMap`, `outputKey`, and `readbackPath`
+- **AND** `outputKey` follows the same lower-snake-case rule as persisted
+  `output_key`
+- **AND** `finalPath` is an RFC 6901 JSON Pointer
+- **AND** `level` is one of `chunk`, `section`, or `document`
+- **AND** `outputMap` matches `level`: `customChunkOutputs` for `chunk`,
+  `customSectionOutputs` for `section`, and `customDocumentOutputs` for
+  `document`
+- **AND** `readbackPath` uses the canonical non-page template for the output
+  level
+- **AND** duplicate final paths fail validation
+- **AND** duplicate `(outputMap, stepName, outputKey)` destinations fail
+- **AND** each route must have exactly one matching `leafFields` record with the
+  same `finalPath`, `workflowGroup`, `workflowField`, `stepName`, `level`, and
+  `outputKey`
+- **AND** the runtime persists the routes as snake_case
+  `workflow.extract.workflow.output_routes`
+- **AND** requests with custom workflow outputs but no derivable or supplied
+  `outputRoutes` fail before execution
+
+### Requirement: Custom leaf fields are workflow-level config
+
+The public workflow config SHALL expose custom workflow leaf-field metadata
+through a workflow-level `leafFields` array when the caller bypasses YAML
+preparation. `leafFields` is the public camelCase representation of persisted
+`workflow.extract.workflow.leaf_fields`.
+
+#### Scenario: Direct public leaf-field records are explicit
+
+- **GIVEN** a direct workflow create or update request with custom workflow steps
+- **WHEN** the request defines custom output routes without using YAML preparation
+- **THEN** the request supplies workflow-level `leafFields`, or the runtime can
+  derive equivalent `leaf_fields` from canonical persisted metadata
+- **AND** each public `leafFields` record includes `finalPath`, `workflowGroup`,
+  `workflowField`, `stepName`, `level`, `outputKey`, `fieldType`, `isRepeated`,
+  and `repetitionScope`
+- **AND** public `isRepeated` maps to persisted `is_repeated`
+- **AND** public `repetitionScope` maps to persisted `repetition_scope`
+- **AND** each `leafFields` record must have exactly one matching `outputRoutes`
+  record with the same `finalPath`, `workflowGroup`, `workflowField`,
+  `stepName`, `level`, and `outputKey`
+- **AND** each `leafFields` record must match the final extract schema's prompted
+  leaf at `finalPath`, including `fieldType`, `isRepeated`, and
+  `repetitionScope`
+- **AND** extra, missing, duplicate, stale, or mismatched `leafFields` records
+  fail validation
+- **AND** requests with custom workflow steps but no derivable or supplied
+  `leafFields` fail before execution

--- a/openspec/changes/support-custom-workflow-steps/task11-e2e-checkpoint.md
+++ b/openspec/changes/support-custom-workflow-steps/task11-e2e-checkpoint.md
@@ -1,0 +1,65 @@
+# Task 11 End-To-End Checkpoint
+
+## Status
+
+Partially executed. Release remains blocked.
+
+## Local Non-Live Evidence
+
+- Legacy YAML selected:
+  `/Users/benjaminfletcher/git/groundx-studio-harness-support-custom-workflow-steps/skills/groundx-extraction-workflows/examples/insurance-claim/prompt.yaml`.
+- Custom-step YAML selected:
+  `/Users/benjaminfletcher/git/adp-poc-support-custom-workflow-steps/workflows/adp_401k_v1/prompt.yaml`.
+- Both compiled and passed structural validation through the unpublished local
+  SDK/harness worktrees.
+- Legacy compiled workflow had no custom workflow metadata.
+- ADP custom compiled workflow had 13 custom steps, 159 output routes, and 159
+  leaf fields.
+- Synthetic ADP X-Ray readback mapped
+  `/chunks/*/customChunkOutputs/adp_f1_employer_information/f001_employer_name`
+  to final path `/employer_information/employer_name` with value
+  `Example Employer LLC`.
+- The synthetic ADP final JSON did not leak the custom step name.
+- The Arcadia current-wave deferral stub remains in place at
+  `/Users/benjaminfletcher/git/internal-arcadia-agents/openspec/notes/support-custom-workflow-steps-deferral.md`.
+
+## Live Workflow API Evidence
+
+Using the unpublished local SDK against the deployed API:
+
+- Legacy workflow create/get/delete succeeded.
+  - Created workflow ID: `6a530e16-d887-4ca1-8893-0b5a4354db66`
+  - Deleted successfully.
+  - Readback had no custom workflow metadata.
+- Custom ADP workflow create/get/delete succeeded.
+  - Created workflow ID: `3fab4070-d719-4b3a-91bc-14caa974f86f`
+  - Deleted successfully.
+  - Readback preserved `workflow.extract.workflow` with 13 custom steps, 159
+    output routes, and 159 leaf fields.
+- Negative oversized/spoofed workflow create unexpectedly succeeded.
+  - Created workflow ID: `13281022-1fcc-4b61-99fc-83a33f1aebcd`
+  - Deleted successfully.
+  - The request assigned all 159 ADP output routes to one custom step while
+    spoofing `field_counts` to a low value. The deployed API should have
+    rejected this before save.
+- Cleanup verification found zero remaining workflows with prefix
+  `codex-e2e-support-custom-workflow-steps-`.
+
+## Blockers
+
+- The deployed API does not currently enforce the 20-field executable custom
+  step limit against canonical route/leaf metadata. Release e2e cannot pass
+  until the runtime/API branch containing that validation is deployed and this
+  negative live check rejects the oversized/spoofed request.
+- `FERN_TOKEN` / Fern org access and `NPM_TOKEN` are unavailable in the local
+  environment, so docs publish and TypeScript package publish remain blocked.
+- Live representative document ingest/extract was not run because the deployed
+  oversized-step guardrail failed first. Running ingest before that guardrail is
+  fixed would not prove release readiness.
+
+## Required Next Step
+
+Deploy or otherwise point e2e at the runtime/API artifact containing the
+Task 5 validation, provide the publish credentials/access needed by the
+publish-last gate, then rerun Task 11 from the live negative oversized-step
+check onward.

--- a/openspec/changes/support-custom-workflow-steps/task3-adversarial-review.md
+++ b/openspec/changes/support-custom-workflow-steps/task3-adversarial-review.md
@@ -1,0 +1,41 @@
+# Task 3 Adversarial Review
+
+## Review Result
+
+Task 3 planning artifacts are complete and reviewed. No implementation task in
+Tasks 4-12 may begin until the clean branch/worktree named by the owning repo's
+plan is created or selected.
+
+## Checks
+
+- Repo-owned OpenSpec change folders exist for `eyelevel-fern-config`,
+  `cashbot-go`, `groundx-python`, `groundx-studio-harness`, and `adp-poc`.
+- The `groundx-python` repo-owned SDK/extract OpenSpec change exists at
+  `/Users/benjaminfletcher/git/groundx-python/openspec/changes/support-custom-workflow-steps-sdk/`.
+- The central
+  `/Users/benjaminfletcher/git/groundx-python/openspec/changes/support-custom-workflow-steps/`
+  folder remains a cross-repo coordination artifact, not the archiveable SDK
+  implementation plan.
+- `internal-arcadia-agents` keeps the future `reconcile_fields`, `qa_fields`,
+  and `save_fields` task-graph work in a non-implementation deferral stub
+  outside `openspec/changes/`, while current-wave metadata-backed custom X-Ray
+  reassembly is implemented in PR #66.
+- Every current-wave repo plan names files, failing tests, expected failures,
+  implementation steps, verification commands, commit checkpoints, generated
+  boundaries, branch/worktree state, and publish-last gates.
+- Current-wave repo-owned OpenSpec changes validate with their owning change IDs:
+  use `support-custom-workflow-steps` in `eyelevel-fern-config`, `cashbot-go`,
+  `groundx-studio-harness`, and `adp-poc`; use
+  `support-custom-workflow-steps-sdk` in `groundx-python`.
+- Existing dirty worktrees are recorded instead of hidden:
+  `cashbot-go`, `groundx-studio-harness`, and `adp-poc` require clean
+  implementation worktrees before code begins.
+
+## Residual Blockers Before Implementation
+
+- Create or select the clean implementation branch/worktree named in each
+  repo-owned plan.
+- Commit or otherwise save the untracked planning artifacts so the plan is not
+  lost between sessions.
+- Keep the central `groundx-python` OpenSpec change as a planning artifact until
+  Task 12 closes it or reduces it to central coordination-only requirements.

--- a/openspec/changes/support-custom-workflow-steps/tasks.md
+++ b/openspec/changes/support-custom-workflow-steps/tasks.md
@@ -1,0 +1,763 @@
+# Support Custom Workflow Steps Execution Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILLS: Use
+> `superpowers:brainstorming` for design refinement,
+> `superpowers:test-driven-development` for each implementation task, and
+> `superpowers:verification-before-completion` before claiming completion.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a durable, tested workflow model for custom chunk, section, and
+document extraction steps, while preserving legacy fixed-slot YAML and workflow
+behavior.
+
+**Architecture:** Start with a source-backed trace of `chunk-keywords` plus
+representative section and document output paths, then add a typed custom-step
+workflow config through Fern/OpenAPI, Go runtime, Python SDK, Arcadia runtime,
+harness skills, public docs, and ADP YAML. Keep fixed steps as the
+legacy/default path and use allowlisted runtime orchestration in Arcadia.
+
+**Tech Stack:** OpenAPI/Fern, Python SDK/Pydantic/PyYAML/pytest, Go workflow
+models/processors/X-Ray tests, Celery/pytest in Arcadia, Node harness scanners.
+
+---
+
+## Ground Rules
+
+- Do not change existing tests only to make them pass.
+- Existing tests may be changed only with explicit user/reviewer feedback or
+  overwhelming evidence that the test no longer represents correct behavior.
+- Prefer adding new regression tests beside existing tests.
+- Preserve legacy YAML and legacy workflow behavior.
+- Preserve authored YAML/custom metadata in `workflow.extract`.
+- Publish public docs only after runtime, SDK, and harness behavior has been
+  verified, as the final prerequisite before e2e if the e2e path requires
+  published docs.
+- Downstream repos must depend on `groundx-python >= <released version>`, not an
+  exact SDK version pin.
+- After Task 2 locks the contract, do not begin code changes until repo-specific
+  implementation plans exist with exact failing tests, expected failures,
+  implementation steps, verification commands, and commit checkpoints.
+- For `internal-arcadia-agents`, the current gate requires the deferral stub
+  that records preserved legacy behavior and the follow-on plan boundary, plus
+  metadata-backed custom X-Ray reassembly support. The full
+  `reconcile_fields` / `qa_fields` / `save_fields` implementation plan is
+  created after central cleanup and closeout.
+- Tasks 4-12 are blocked until Tasks 1-3 are complete, reviewed, and updated in
+  this OpenSpec change. Treat the later tasks as scope inventory until then.
+- Before any implementation task starts, create or select a clean isolated
+  branch or worktree in that repo and record any unrelated local changes that
+  must not be mixed into this work.
+- Do not publish generated SDKs or public docs early. Publishing is allowed only
+  after local/runtime/schema/SDK/harness verification, as the final prerequisite
+  before the e2e path that requires published artifacts.
+- Local generated SDK artifacts may be used for tests before release; downstream
+  dependency bumps are blocked until the published-artifact e2e path passes.
+- Generated SDK files in `groundx-python` must come from the upstream
+  Fern/OpenAPI source and approved regeneration or release path. Do not hand-edit
+  or commit generated files as implementation work outside that path.
+- The fresh-scan correction in
+  `fresh-scan-generated-sdk-and-xray-corrections.md` is mandatory closeout
+  scope. Documentation and implementation must be checked across the OpenSpec
+  plan PR, SDK helpers PR, Fern docs PR, Studio Harness PR, Arcadia PR, ADP PR,
+  and the Cashbot runtime/API work.
+- Run an adversarial review after each task before starting the next task.
+- Keep repo changes narrow and repo-owned.
+
+## Task 1: Complete The Cross-Repo Trace
+
+**Files to read:**
+
+- `/Users/benjaminfletcher/git/adp-poc/workflows/adp_401k_v1/prompt.yaml`
+- `/Users/benjaminfletcher/git/adp-poc/workflows/adp_401k_v1/conversion_report.json`
+- `/Users/benjaminfletcher/git/eyelevel-fern-config/fern/openapi.yml`
+- `/Users/benjaminfletcher/git/groundx-python/src/groundx/types/workflow_steps.py`
+- `/Users/benjaminfletcher/git/groundx-python/src/groundx/types/workflow_step_config.py`
+- `/Users/benjaminfletcher/git/groundx-python/src/groundx/types/workflow_step_config_field.py`
+- `/Users/benjaminfletcher/git/groundx-python/src/groundx/extract/classes/groundx.py`
+- `/Users/benjaminfletcher/git/groundx-python/src/groundx/extract/classes/document.py`
+- `/Users/benjaminfletcher/git/groundx-python/src/groundx/extract/prompt/utility.py`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/model/summarizer/process.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/model/summarizer/step_type.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/model/summarizer/field_type.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/model/completions/eyelevel/process.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/model/prompt/templates.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/processor/summarizer/chunks.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/processor/summarizer/sections.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/processor/summarizer/document.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/processor/summarizer/request.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/processor/summarizer/execute.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/processor/summarizer/util.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/processor/summarizer/processor.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/model/layout/chunk.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/model/layout/document.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/model/layout/search_meta.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/model/layout/custom_meta.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/model/layout/xray.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/partner/request.go`
+- `/Users/benjaminfletcher/git/cashbot-go/pkg/partner/workflow.go`
+- `/Users/benjaminfletcher/git/internal-arcadia-agents/prompts/arcadia_manager.py`
+- `/Users/benjaminfletcher/git/internal-arcadia-agents/classes/arcadia_agent_request.py`
+- `/Users/benjaminfletcher/git/internal-arcadia-agents/classes/statement.py`
+- `/Users/benjaminfletcher/git/internal-arcadia-agents/classes/extraction_reassembly.py`
+- `/Users/benjaminfletcher/git/internal-arcadia-agents/tasks/download.py`
+- `/Users/benjaminfletcher/git/internal-arcadia-agents/tasks/agent.py`
+- `/Users/benjaminfletcher/git/internal-arcadia-agents/tasks/save.py`
+- `/Users/benjaminfletcher/git/groundx-studio-harness/skills/groundx-extraction-workflows/templates/compile_workflow.py`
+- `/Users/benjaminfletcher/git/groundx-studio-harness/skills/groundx-extraction-workflows/templates/xray_to_extract.py`
+- `/Users/benjaminfletcher/git/groundx-studio-harness/skills/groundx-extraction-workflows/templates/validate_workflow_json.py`
+- `/Users/benjaminfletcher/git/groundx-studio-harness/skills/groundx-extraction-workflows/SKILL.md`
+- `/Users/benjaminfletcher/git/groundx-studio-harness/skills/groundx-extraction-workflows/SKILL.public.md`
+- `/Users/benjaminfletcher/git/groundx-studio-harness/skills/groundx-extraction-workflows/evals/evals.json`
+- `/Users/benjaminfletcher/git/groundx-studio-harness/scripts/tests/test-groundx-extraction-workflows.mjs`
+
+- [x] Trace `chunk-keys` from workflow config to Go `StepType`.
+- [x] Trace `chunk-keys` from Go `FieldType` to chunk storage.
+- [x] Trace `chunkKeywords` from Go X-Ray output to Python SDK parsing.
+- [x] Trace `sect-summary`/`sect-sum` from workflow config to Go processing,
+      storage, X-Ray output, SDK parsing, harness aggregation, and Arcadia use.
+- [x] Trace `doc-summary`/`doc-sum` from workflow config to Go processing,
+      storage, X-Ray output, SDK parsing, harness aggregation or lack of
+      aggregation, and Arcadia use.
+- [x] Trace `chunkKeywords` through harness local X-Ray aggregation.
+- [x] Trace `chunkKeywords` through Arcadia routed reassembly tests.
+- [x] Trace `Process.Template` from workflow JSON load to prompt rendering.
+- [x] Trace current reserved top-level YAML key handling.
+- [x] Decide how a new `workflow:` authoring section avoids stealing a legacy
+      final group: top-level `workflow:` is always reserved, and attempted final
+      groups named `workflow` fail clearly.
+- [x] Identify every place a custom step name must survive serialization.
+- [x] Identify every place a custom output value must be stored and read:
+      custom outputs are stored in explicit workflow custom-output metadata,
+      surfaced through `customChunkOutputs`, `customSectionOutputs`, and
+      `customDocumentOutputs`, and routed to final JSON through route metadata.
+- [x] Identify every harness scanner, eval, example, and reference that teaches
+      or enforces the old fixed-slot model.
+- [x] Update `chunk-keywords-trace.md` with missing code points.
+- [x] Adversarial review: confirm the trace follows real runtime paths for
+      chunk, section, and document outputs, not only tests or docs.
+- [x] Fresh-scan correction recorded for generated SDK boundary and X-Ray
+      runtime/readback coverage across all touched repos.
+
+## Task 2: Finalize The Public Contract
+
+**Files to update:**
+
+- This change folder's `design.md`
+- This change folder's `specs/extract-yaml/spec.md`
+- This change folder's `specs/workflow-config/spec.md`
+- This change folder's `specs/custom-output-readback/spec.md`
+- This change folder's `specs/arcadia-runtime/spec.md`
+- This change folder's `specs/release-governance/spec.md`
+- This change folder's `specs/cross-repo-planning/spec.md`
+
+- [x] Decide the OpenAPI shape for custom steps: add workflow-level
+      `customSteps` while preserving existing `steps`.
+- [x] Decide the exact public `customSteps[]` item shape: `name`, `level`,
+      `kind`, optional `config`, and optional `requiredTemplateKeys`; custom
+      step `config` uses the existing element-targeted workflow step shape but
+      omits or nulls the legacy fixed-output `field`.
+- [x] Decide the custom output X-Ray shape: use `customChunkOutputs`,
+      `customSectionOutputs`, and `customDocumentOutputs`, while preserving
+      fixed legacy fields.
+- [x] Decide the exact route metadata shape from each custom output path back
+      to its final JSON path: each route records `workflow_group`,
+      `workflow_field`, `final_path`, `step_name`, `level`, `output_map`,
+      `output_key`, and `readback_path`.
+- [x] Decide the public route-record container: direct public workflow config uses
+      workflow-level `outputRoutes`, and persisted metadata uses
+      `workflow.extract.workflow.output_routes`.
+- [x] Decide the public leaf-field container: direct public workflow config uses
+      workflow-level `leafFields`, and persisted metadata uses
+      `workflow.extract.workflow.leaf_fields`.
+- [x] Decide route/leaf integrity: every `outputRoutes` record must have exactly
+      one matching `leafFields` record, and every `leafFields` record must have
+      exactly one matching `outputRoutes` record, using final path, workflow
+      group/field, custom step, level, and output key.
+- [x] Decide where explicit output keys are authored: YAML uses field-level
+      `workflow_output_key`, persisted route metadata uses `output_key`, and
+      public JSON route records use `outputKey`.
+- [x] Decide how YAML workflow group metadata points to a custom step name:
+      `workflow_step: <step-name>` is the forward path; legacy `slot:` remains
+      supported for existing fixed-slot YAML.
+- [x] Decide whether `workflow:` is the reserved YAML authoring section and how
+      legacy final groups named `workflow` behave: top-level `workflow:` is
+      always reserved; no known legacy final group exists, and attempted final
+      groups named `workflow` fail clearly.
+- [x] Replace the default opt-in rule: there is no opt-in rule; top-level
+      `workflow:` is always authoring metadata.
+- [x] Decide how `template` is represented in public workflow config: expose
+      workflow/process config matching cashbot-go `Process.Template
+      *map[string]string`; do not expose the separate partner template object;
+      YAML-authored template values live at workflow-level `workflow.template`.
+- [x] Decide `template` validation boundaries for unknown keys, missing required
+      keys, reserved keys, invalid value types, payload size, escaping/rendering
+      failures, and fixed/custom prompt behavior; required keys are declared by
+      step metadata, not inferred from prompt parsing, and validate with the same
+      normalization/rules as template keys.
+- [x] Decide the maximum field count for one executable workflow step and the
+      layer that hard-fails validation: 20 fields, hard-failed by public
+      API/runtime validation and mirrored by SDK, harness, and ADP validation.
+- [x] Record the exact initial Arcadia task vocabulary: keep existing
+      reconcile/QA/save tasks except `qa_charges`, treat `agent`/`save_agents`
+      as internal compatibility nodes, classify `qa_charges` as dead legacy, and
+      defer `reconcile_fields`/`qa_fields`/`save_fields` to a follow-on plan.
+- [x] Decide TypeScript feature-support scope and the mandatory TypeScript
+      generation smoke coverage. TypeScript generation compatibility is required
+      because the shared Fern schema feeds the TypeScript SDK; use
+      `fern generate --group ts-sdk`.
+- [x] Decide downstream release/version gates, including the minimum
+      `groundx-python >= <released version>` required by Arcadia and harness
+      after the published-artifact e2e path passes.
+- [x] Decide the publish-last gate: generated SDK/docs publishing is allowed only
+      after local/runtime/schema/SDK/harness verification and immediately before
+      the e2e path that requires published artifacts; downstream dependency
+      bumps wait until that e2e path passes.
+- [x] Decide the draft-generation path: Fern/OpenAPI branch, local
+      Python/TypeScript generation or smoke output, runtime and SDK verification
+      against the draft contract, then public SDK/docs publishing as the final
+      e2e prerequisite.
+- [x] Decide custom step naming rules: valid characters, canonical form,
+      case/kebab/snake/camel conversion, uniqueness scope, reserved names,
+      collision behavior with fixed step names, and duplicate output destination
+      behavior.
+- [x] Decide the persisted `workflow.extract` metadata version and behavior for
+      missing, unknown, old, and future versions: `workflow.metadata_version: 1`
+      is current; unknown/future versions fail closed; missing metadata is
+      legacy fallback only when no custom workflow metadata is present.
+- [x] Decide how field-load validation is enforced by the public API/runtime, SDK
+      YAML preparation, harness validation, and ADP validation. Direct API users
+      must be protected by the public API/runtime path; the limit is 20 fields
+      per executable workflow step.
+- [x] Decide the field-count source for public API/runtime validation:
+      server-recomputed counts from canonical
+      `workflow.extract.workflow.output_routes` and
+      `workflow.extract.workflow.leaf_fields`; caller-provided
+      `field_counts` and `schema_hash` are non-authoritative hints that must
+      match when present.
+- [x] Decide the exact field-count hash input: `metadata_version`,
+      `custom_steps`, `output_routes`, and `leaf_fields` with prompt prose,
+      examples, model parameters, and template values excluded.
+- [x] Decide exact `leaf_fields` repetition metadata: persisted
+      `is_repeated`/`repetition_scope`, public `isRepeated`/`repetitionScope`,
+      and allowed `repetition_scope` values `none`, `field`, and `item`.
+- [x] Decide repeated-item path semantics: `repetition_scope: item` uses a
+      literal `*` RFC 6901 path segment as the schema wildcard, such as
+      `/fees/*/amount`, and counts once per prompted schema leaf.
+- [x] Decide exact reserved template metadata names and require the same list for
+      `template` and `requiredTemplateKeys`.
+- [x] Decide deterministic hash sorting: `custom_steps` by `(name)`,
+      `output_routes` by `(final_path, workflow_group, workflow_field,
+      step_name, output_key)`, and `leaf_fields` by `(final_path,
+      workflow_group, workflow_field, step_name, output_key)`.
+- [x] Decide custom output persistence, storage migration/backward compatibility,
+      and readback behavior for existing documents and workflows.
+- [x] Decide exact legacy fallback semantics.
+- [x] Add examples for one custom chunk step, one custom section step, and one
+      custom document step.
+- [x] Adversarial review: confirm the contract separates step identity, output
+      field, extraction group, and final JSON group.
+
+## Task 3: Create Repo-Specific Implementation Plans
+
+**Repos:**
+
+- `/Users/benjaminfletcher/git/eyelevel-fern-config`
+- `/Users/benjaminfletcher/git/cashbot-go`
+- `/Users/benjaminfletcher/git/groundx-python`
+- `/Users/benjaminfletcher/git/internal-arcadia-agents`
+- `/Users/benjaminfletcher/git/groundx-studio-harness`
+- `/Users/benjaminfletcher/git/adp-poc`
+
+**Repo-owned planning artifacts to create or update:**
+
+- Valid OpenSpec change folders in each repo that owns durable behavior:
+  - `/Users/benjaminfletcher/git/eyelevel-fern-config/openspec/changes/support-custom-workflow-steps/`
+  - `/Users/benjaminfletcher/git/cashbot-go/openspec/changes/support-custom-workflow-steps/`
+  - `/Users/benjaminfletcher/git/groundx-python/openspec/changes/support-custom-workflow-steps-sdk/`
+  - `/Users/benjaminfletcher/git/groundx-studio-harness/openspec/changes/support-custom-workflow-steps/`
+  - `/Users/benjaminfletcher/git/adp-poc/openspec/changes/support-custom-workflow-steps/`
+- A non-implementation deferral stub for
+  `/Users/benjaminfletcher/git/internal-arcadia-agents` that keeps the full
+  custom field-action plan after central cleanup/closeout, while allowing the
+  current-wave custom X-Ray reassembly support needed by readback.
+- Each repo OpenSpec change folder must include `proposal.md`, `tasks.md`, and
+  `execution-plan.md`.
+- Each repo OpenSpec change folder must include `specs/<capability>/spec.md`
+  deltas for durable behavior owned by that repo.
+- If a repo only needs tactical notes and no durable spec delta, store those
+  notes outside `openspec/changes/`; do not create an execution-plan-only
+  OpenSpec change folder.
+
+- [x] Create or update one repo-owned execution plan in every repo that will
+      receive current-wave changes.
+- [x] Confirm every repo-owned OpenSpec change is independently valid and
+      archiveable, or move non-OpenSpec notes out of `openspec/changes/`.
+- [x] Each repo plan must name exact files, exact failing tests, expected
+      failures, implementation steps, verification commands, and commit
+      checkpoints.
+- [x] Each repo plan must state generated-file boundaries and release
+      dependencies.
+- [x] Each repo plan that consumes generated SDK/API surfaces must state whether
+      generated artifacts are local verification output or release-produced files
+      that may be committed.
+- [x] Each repo plan must state the branch/worktree to use and confirm whether
+      the repo was clean before implementation began.
+- [x] Each repo plan must state the repo-specific publish-last release gate and how
+      it depends on upstream runtime/API, SDK, harness, or documentation changes.
+- [x] The `internal-arcadia-agents` deferral stub must state the preserved legacy
+      behavior, the exclusion of `qa_charges` from future authorable vocabulary,
+      and the follow-on boundary for `reconcile_fields`, `qa_fields`, and
+      `save_fields`.
+- [x] The main plan must link to each repo-owned execution plan in dependency
+      order and to the `internal-arcadia-agents` deferral stub.
+- [x] Adversarial review: confirm no implementation task below begins until the
+      repo-specific plans and the Arcadia deferral stub are complete and reviewed.
+
+## Task 4: Update Fern/OpenAPI Contract
+
+**Repo:** `/Users/benjaminfletcher/git/eyelevel-fern-config`
+
+**Likely files:**
+
+- `fern/openapi.yml`
+- `fern/generators.yml`
+- generated smoke output or review notes for `python-sdk` and `ts-sdk`
+
+- [x] Add failing OpenAPI/schema checks or exact diffs for `customSteps`,
+      custom step `config`, custom step legacy `field` rejection, `outputRoutes`,
+      `outputKey`, `leafFields`, route/leaf one-to-one validation, `isRepeated`,
+      `repetitionScope`, wildcard repeated-item final paths, `template`,
+      `requiredTemplateKeys`, reserved template key names, custom output maps, and
+      field-count metadata.
+- [x] Add `template` to the workflow config schema.
+- [x] Add the custom-step and custom route schemas chosen in Task 2.
+- [x] Keep existing fixed `WorkflowSteps` fields.
+- [x] Run `fern generate --group ts-sdk` as the TypeScript generation smoke
+      check. If generation cannot pass, block the schema change instead of
+      treating generator compatibility as out of scope.
+- [x] Run `fern check` and `fern generate --docs` as local docs/OpenAPI
+      validation. Do not publish docs until the publish-last gate opens.
+      Note: `fern check` passed. Release-mode TypeScript generation requires
+      `NPM_TOKEN`, so the successful smoke command was
+      `fern generate --group ts-sdk --local --no-require-env-vars --no-prompt`.
+      `fern generate --docs --preview --skip-upload --no-require-env-vars
+      --no-prompt` reached 0 docs-definition errors, then attempted remote
+      preview publishing and failed with `User does not belong to organization`;
+      docs publish remains gated on Fern org access during publish-last.
+- [x] Adversarial review: confirm the schema is additive, generated SDKs can
+      represent it, and no public docs describe unverified behavior yet.
+
+## Task 5: Update cashbot-go Models, Loading, Processing, And X-Ray
+
+**Repo:** `/Users/benjaminfletcher/git/cashbot-go`
+
+Status: completed and pushed to PR #1493 in worktree
+`/Users/benjaminfletcher/git/cashbot-go-support-custom-workflow-steps` on
+branch `codex/support-custom-workflow-steps-runtime`, current head
+`c4e17a6cf`, base `hotfix-search-dell`. The Fern mirror endpoint correction is
+committed in `eyelevel-fern-config` and merged into the current Fern PR head
+`60efc8b`. Plan-specific targeted Go packages, OpenSpec strict validation,
+`git diff --check`, and local merge simulation against
+`origin/hotfix-search-dell` pass. CI staticcheck initially failed on two S1011
+findings in `pkg/model/summarizer/custom_workflow.go`; rebased commit
+`f62b0e5c6` applies the variadic-append fix, and local package-level checks now
+pass. GitHub checks pass after retarget; the remaining remote gate is review.
+`go test ./...` remains blocked locally by repo-wide generated `version.go`
+prerequisites and external service/state dependencies.
+
+**Likely files:**
+
+- `pkg/model/summarizer/process.go`
+- `pkg/model/summarizer/step.go`
+- `pkg/model/summarizer/step_type.go`
+- `pkg/model/summarizer/field_type.go`
+- `pkg/model/completions/eyelevel/process.go`
+- `pkg/model/prompt/templates.go`
+- `pkg/processor/summarizer/chunks.go`
+- `pkg/processor/summarizer/sections.go`
+- `pkg/processor/summarizer/document.go`
+- `pkg/processor/summarizer/request.go`
+- `pkg/processor/summarizer/execute.go`
+- `pkg/processor/summarizer/util.go`
+- `pkg/processor/summarizer/processor.go`
+- `pkg/model/layout/chunk.go`
+- `pkg/model/layout/document.go`
+- `pkg/model/layout/search_meta.go`
+- `pkg/model/layout/custom_meta.go`
+- `pkg/model/layout/xray.go`
+- `pkg/model/workflow/workflow.go`
+- `pkg/partner/request.go`
+- `pkg/partner/workflow.go`
+- `server/GroundX/openapi.yml`
+- `lambda/GroundX/openapi.yml`
+
+- [x] Add tests that prove the current runtime rejects or drops the proposed
+      custom-step shape.
+- [x] Add tests that prove `template` round-trips through workflow create/update
+      and reaches prompt rendering through workflow/process config, while the
+      separate top-level partner template object is not silently accepted as the
+      workflow prompt-variable map.
+- [x] Add tests for `template` unknown keys, missing required keys, reserved keys,
+      invalid value types, payload size, escaping/rendering failures, and fixed
+      versus custom prompt behavior.
+- [x] Add model support for custom named steps without breaking `StepType`.
+- [x] Add storage support for custom chunk/section/document outputs.
+- [x] Add persistence and readback tests for old workflows/documents, new custom
+      outputs, missing metadata versions, and unknown metadata versions.
+- [x] Add processor support for executing allowlisted custom step levels/kinds.
+- [x] Add X-Ray output support for custom outputs.
+- [x] Add custom section/document output persistence support for the chosen
+      storage/readback shape.
+- [x] Enforce the chosen field-load validation in the public API/runtime path so
+      direct callers cannot bypass the guardrail.
+- [x] Reject custom extraction workflow create/update requests with missing,
+      unparseable, stale, caller-only, mismatched, or unknown-version
+      field-count metadata.
+- [x] Add a direct API regression test proving spoofed caller-provided field
+      counts cannot bypass the oversized-step guardrail.
+- [x] Add direct API regression tests proving mismatched, missing, extra, or
+      duplicate route/leaf records cannot bypass field-load validation.
+- [x] Update server and lambda OpenAPI mirrors.
+- [x] Extend existing `chunk-keys`/`ChunkKeywords` tests instead of replacing
+      them.
+- [x] Run targeted Go tests for summarizer model, processor, X-Ray, workflow,
+      and partner workflow paths.
+- [x] Adversarial review: confirm default workflows and existing fixed-step
+      overlays still behave exactly as before.
+
+## Task 6: Regenerate And Extend groundx-python
+
+**Repo:** `/Users/benjaminfletcher/git/groundx-python`
+
+**Likely files:**
+
+- Generated files under `src/groundx/types/` after Fern release/regeneration
+- Generated workflow clients under `src/groundx/workflows/` after Fern
+  release/regeneration
+- `src/groundx/extract/prompt/utility.py`
+- `src/groundx/extract/prompt/manager.py`
+- `src/groundx/extract/classes/groundx.py`
+- `src/groundx/extract/classes/document.py`
+- `tests/custom/`
+- `tests/extract/prompt/test_manager.py`
+- `tests/extract/prompt/test_persisted_workflow_extract.py`
+- `tests/extract/classes/test_groundx.py`
+- `tests/extract/classes/test_document.py`
+
+Status: completed and pushed to PR #11 in isolated worktree
+`/Users/benjaminfletcher/git/groundx-python-support-custom-workflow-steps-sdk`
+on branch `codex/support-custom-workflow-steps-sdk`, final commit `5cae434`.
+No implementation diffs remain under generated folders `src/groundx/types` or
+`src/groundx/workflows`. Handwritten helper behavior lives in
+`src/groundx/extract/*` and `src/groundx/ingest.py`; custom-step create/update
+helpers now raise a clear runtime gate until the Fern-generated workflow client
+accepts `custom_steps`, `output_routes`, and `leaf_fields`. Verification passed:
+
+- `poetry run pytest tests/custom/test_extraction_workflow_client_exports.py tests/extract/test_extraction_workflow_definitions.py -q`
+  (`21 passed`)
+- `poetry run pytest tests/custom tests/extract -q`
+  (`135 passed, 2 skipped, 5 subtests passed`)
+- `poetry run mypy src/groundx/extract/workflows.py src/groundx/ingest.py tests/extract/test_extraction_workflow_definitions.py tests/custom/test_extraction_workflow_client_exports.py`
+  (`Success: no issues found`)
+- `poetry run pytest -rP -n auto .`
+  (`204 passed, 2 skipped`)
+- `poetry run mypy .`
+  (`Success: no issues found`)
+- `OPENSPEC_TELEMETRY=0 npx @fission-ai/openspec@1.3.1 validate support-custom-workflow-steps-sdk --strict`
+- `git diff --check`
+
+- [x] Consume generated SDK surfaces from the upstream Fern/OpenAPI change through
+      local verification output or the approved SDK release path; do not hand-edit
+      generated files.
+- [x] Add helper tests proving current create/update helpers pass the base YAML
+      path and raise a clear runtime gate for custom-step kwargs until the
+      generated client is released with the Fern/OpenAPI fields.
+- [x] Add hand-written extract tests for YAML custom step metadata.
+- [x] Add hand-written extract tests for invalid custom step names, duplicate
+      names, fixed-step collisions, case normalization, reserved names, and
+      duplicate output destinations.
+- [x] Add hand-written extract tests for reserved `workflow:` handling,
+      duplicate/conflicting reserved names, and attempted final groups named
+      `workflow` failing with a clear migration error.
+- [x] Add hand-written extract tests for legacy `slot:` behavior.
+- [x] Add extract X-Ray tests for the chosen custom chunk/section/document
+      output shape.
+- [x] Add document loader tests proving custom X-Ray outputs are available to
+      extraction code without breaking `chunkKeywords`.
+- [x] Add document-loader/readback tests proving legacy top-level
+      `xray.fileSummary` and per-chunk `chunk.fileSummary` behavior remains
+      unchanged while custom document outputs use `customDocumentOutputs`.
+- [x] Add tests proving custom output route metadata maps the chosen X-Ray path
+      back to the final JSON path.
+- [x] Ensure `PreparedExtractionYaml.persisted_workflow_extract` preserves
+      custom step definitions.
+- [x] Ensure mapping input reloads custom step definitions from workflow
+      `extract`.
+- [x] Add persisted extract version tests for missing, current, unknown, and
+      future-version metadata.
+- [x] Add SDK-side validation or mirrored errors for oversized executable steps
+      according to the Task 2 contract.
+- [x] Ensure `PreparedExtractionYaml.persisted_workflow_extract` includes the
+      canonical metadata needed for public API/runtime validation to derive or
+      verify per-executable-step field counts; optional `field_counts` and
+      `schema_hash` remain non-authoritative hints.
+- [x] Add tests proving caller-provided field counts that disagree with canonical
+      workflow extract metadata fail validation rather than becoming accepted SDK
+      output.
+- [x] Add tests proving mismatched, missing, extra, or duplicate `outputRoutes`
+      and `leafFields` fail validation.
+- [x] Add tests proving repeated item/object leaves use wildcard schema paths and
+      count once per prompted item leaf.
+- [x] Keep `workflow_groups` execution-only.
+- [x] Run `poetry run pytest tests/extract -q`.
+- [x] Run `poetry run pytest -rP -n auto tests/custom tests/extract`.
+- [x] Run `poetry run mypy .`.
+- [x] Run `poetry run pytest -rP -n auto .` before PR or release readiness.
+- [x] Adversarial review: confirm generated files are not hand-edited directly
+      unless the repo guide permits it.
+
+## Task 7: Create Follow-On internal-arcadia-agents Plan
+
+**Repo:** `/Users/benjaminfletcher/git/internal-arcadia-agents`
+
+**Likely files:**
+
+- `prompts/arcadia_manager.py`
+- `prompts/yaml.py`
+- `tasks/download.py`
+- `tasks/agent.py`
+- `tasks/save.py`
+- `classes/arcadia_agent_request.py`
+- `classes/statement.py`
+- `classes/extraction_reassembly.py`
+- `docs/arcadia-yaml-relationship-algorithm.md`
+- `docs/arcadia-yaml-classes/statement.md`
+- `docs/arcadia-yaml-classes/meter.md`
+- `docs/arcadia-yaml-classes/charge.md`
+- co-located tests in `prompts/`, `classes/`, and `testdata/`
+
+Status: current-wave deferral stub plus custom X-Ray reassembly support are
+complete in `internal-arcadia-agents` PR #66 on branch
+`codex/extraction-reassembly-metadata`, current head `e07f655`. The deferral
+stub lives at
+`/Users/benjaminfletcher/git/internal-arcadia-agents/openspec/notes/support-custom-workflow-steps-deferral.md`.
+The new `reconcile_fields`, `qa_fields`, and `save_fields` task graph remains
+intentionally follow-on work after central cleanup and closeout, not a
+prerequisite for Task 8.
+
+- [x] During this central plan, create only the deferral stub required by Task 3.
+- [x] During this central plan, add metadata-backed reassembly support for
+      `customChunkOutputs`, `customSectionOutputs`, and `customDocumentOutputs`
+      without changing the current Arcadia runtime graph.
+- [ ] After cleanup and closeout of this central planning change, create a new
+      repo-owned plan for implementation.
+- [ ] The follow-on plan must preserve current reconcile/QA/save behavior except
+      `qa_charges`, which is dead legacy and not authorable.
+- [ ] The follow-on plan must keep `agent` and `save_agents` internal behind the
+      default compatibility adapter.
+- [ ] The follow-on plan must define `reconcile_fields`, `qa_fields`, and
+      `save_fields`.
+- [ ] The follow-on plan must define each new task's behavior, input payload,
+      output payload, retry or idempotency assumptions, failure propagation
+      behavior, and validation rules.
+- [ ] The follow-on plan must name exact failing tests, expected failures,
+      implementation steps, verification commands, and commit checkpoints.
+- [ ] The follow-on plan must include tests proving missing custom runtime
+      metadata uses the current hardcoded workflow steps and current Celery
+      graph.
+- [x] Add current-wave tests proving custom output route metadata maps from
+      `customChunkOutputs`, `customSectionOutputs`, or `customDocumentOutputs`
+      to the final JSON path during reassembly.
+- [ ] The follow-on plan must preserve current statement/meter/charge
+      relationship logic after reassembly.
+- [x] Run focused reassembly/metadata tests and full `PYTHONPATH=$PWD pytest`
+      (`191 passed, 1 skipped`).
+- [x] Adversarial review: confirm the current-wave change consumes explicit
+      custom X-Ray maps through route metadata and leaves the new field-action
+      runtime graph deferred.
+
+## Task 8: Update groundx-studio-harness
+
+**Repo:** `/Users/benjaminfletcher/git/groundx-studio-harness`
+
+**Likely files:**
+
+- `skills/groundx-extraction-workflows/SKILL.md`
+- `skills/groundx-extraction-workflows/SKILL.public.md`
+- `skills/groundx-extraction-workflows/CHANGELOG.md`
+- `skills/groundx-extraction-workflows/references/2_schema_design.md`
+- `skills/groundx-extraction-workflows/references/3_prompt_pipeline.md`
+- `skills/groundx-extraction-workflows/references/4_sdk_integration.md`
+- `skills/groundx-extraction-workflows/references/README.md`
+- `skills/groundx-extraction-workflows/references/public-docs.md`
+- `skills/groundx-extraction-workflows/templates/compile_workflow.py`
+- `skills/groundx-extraction-workflows/templates/xray_to_extract.py`
+- `skills/groundx-extraction-workflows/templates/validate_workflow_json.py`
+- `skills/groundx-extraction-workflows/templates/test_compile_workflow.py`
+- `skills/groundx-extraction-workflows/examples/*`
+- `skills/groundx-extraction-workflows/evals/evals.json`
+- `scripts/tests/test-groundx-extraction-workflows.mjs`
+- plugin mirror through `node scripts/sync-plugin.mjs`
+
+Status: completed in isolated worktree
+`/Users/benjaminfletcher/git/groundx-studio-harness-support-custom-workflow-steps`
+on branch `codex/support-custom-workflow-steps-harness`, current PR #19 head
+`4d4caf4`. `groundx-studio-harness` is the source repo; `groundx-agent-harness`
+is generated mirror output only. Plugin payloads were mirrored to
+`plugins/groundx-studio-harness/` and `plugins/groundx-agent-harness/`; plugin
+version bumped to `2.1.6`. Verification was rerun after the SDK
+generated-folder cleanup and passed:
+
+- `python -m pytest skills/groundx-extraction-workflows/templates/test_compile_workflow.py skills/groundx-extraction-workflows/templates/test_validate_workflow_json.py skills/groundx-extraction-workflows/templates/test_xray_to_extract.py skills/groundx-extraction-workflows/templates/test_imports.py -q`
+  (`40 passed`)
+- `node scripts/tests/test-groundx-extraction-workflows.mjs`
+- `node scripts/tests/test-evals.mjs`
+- `node scripts/sync-plugin.mjs --check`
+- `node scripts/scans/scan-version-bump.mjs`
+- `node scripts/validate.mjs`
+- `OPENSPEC_TELEMETRY=0 npx @fission-ai/openspec@1.3.1 validate support-custom-workflow-steps --strict`
+- `git diff --check`
+
+- [x] Update harness compiler/templates to emit custom steps only after SDK and
+      Go support exists.
+- [x] Update X-Ray local aggregation to read `customChunkOutputs`,
+      `customSectionOutputs`, and `customDocumentOutputs`.
+- [x] Update references so agents know when to use custom steps.
+- [x] Update public-docs guidance so agents keep public docs plain and
+      SDK-centered.
+- [x] Update scanners that currently enforce the old three-slot menu.
+- [x] Update evals/examples/changelog language that says only the old three
+      slots are supported.
+- [x] Update `validate_workflow_json.py` to validate both legacy fixed slots and
+      custom-step workflow JSON.
+- [x] Mirror the runtime/API hard-fail behavior for custom-step YAML that exceeds
+      20 fields per executable workflow step.
+- [x] Add compile tests for legacy YAML and custom-step YAML.
+- [x] Run `node scripts/validate.mjs`.
+- [x] Run `node scripts/sync-plugin.mjs --check` after mirror update.
+- [x] Adversarial review: confirm installed skill guidance does not describe
+      unimplemented platform behavior.
+
+## Task 9: Update Public Docs
+
+**Repo:** `/Users/benjaminfletcher/git/eyelevel-fern-config`
+
+**Likely files:**
+
+- `fern/pages/extract-data-from-documents.mdx`
+- `fern/pages/mcp.mdx`
+
+- [x] Update public docs only after cashbot-go, groundx-python, and harness have
+      verified runtime, SDK, and harness behavior.
+- [ ] Publish public docs only as the final prerequisite before e2e if published
+      docs are required by that e2e path.
+- [x] Explain custom workflow steps in plain language without harness internals.
+- [x] Explain `template` as workflow-level config.
+- [x] Include one legacy YAML example and one custom-step YAML example if the
+      final contract supports YAML authoring directly.
+- [x] Run `fern generate --docs` as the local docs validation check. Do not
+      publish docs until the publish-last gate opens.
+      Note: `fern generate --docs --preview --skip-upload --no-require-env-vars
+      --no-prompt` reported 0 docs-definition errors and 3 warnings, then failed
+      at remote preview publishing with `User does not belong to organization`.
+- [x] Adversarial review: confirm public docs explain what engineers do, not
+      the internal implementation.
+
+## Task 10: Update ADP POC YAML And Validation
+
+**Repo:** `/Users/benjaminfletcher/git/adp-poc`
+
+Status: completed in isolated worktree
+`/Users/benjaminfletcher/git/adp-poc-support-custom-workflow-steps` on branch
+`codex/support-custom-workflow-steps-adp` as commit `4e35397`. Verification was
+rerun after the SDK generated-folder cleanup and harness revalidation:
+
+- `python -m pytest tests/test_v1_schema_manifest.py -q` (`4 passed`)
+- `python -m pytest tests/test_convert_v1_schema_to_yaml.py tests/test_source_review_tools.py -q`
+  (`53 passed`)
+- Local compile via
+  `/Users/benjaminfletcher/git/groundx-studio-harness-support-custom-workflow-steps/skills/groundx-extraction-workflows/templates/compile_workflow.py`
+  with
+  `PYTHONPATH=/Users/benjaminfletcher/git/groundx-python-support-custom-workflow-steps-sdk/src`
+- Local workflow structural validation passed with the same SDK/harness
+  worktrees (`OK /tmp/adp_401k_v1_workflow.json: structural validation passed`)
+- `OPENSPEC_TELEMETRY=0 npx @fission-ai/openspec@1.3.1 validate support-custom-workflow-steps --strict`
+- `git diff --check`
+
+**Likely files:**
+
+- `workflows/adp_401k_v1/prompt.yaml`
+- `workflows/adp_401k_v1/conversion_report.json`
+- `tools/convert_v1_schema_to_yaml.py`
+- `tests/test_convert_v1_schema_to_yaml.py`
+- `tests/test_v1_schema_manifest.py`
+- `docs/reference/groundx-extraction-implementation.md`
+- `openspec/specs/adp-401k-extraction-yaml/spec.md`
+
+- [x] Add a failing validation that hard-rejects assigning all 159 fields to one
+      chunk-level extraction step once custom steps are available.
+- [x] Encode the 20-field executable-step limit in the converter or local
+      validation tests.
+- [x] Confirm ADP validation mirrors, but does not replace, the shared SDK and
+      runtime/API 20-field executable-step validation.
+- [x] Update the converter to assign coherent final sections or pseudo groups
+      to custom steps.
+- [x] Preserve the 11 final output sections.
+- [x] Keep field count and source-review requirements unchanged.
+- [x] Compile the YAML through the updated harness/SDK path.
+- [x] Run ADP converter and manifest tests.
+- [x] Adversarial review: confirm the ADP migration uses platform features and
+      does not hardcode ADP into shared repos.
+
+## Task 11: End-To-End Validation
+
+Status: partially executed and blocked. Evidence is recorded in
+`task11-e2e-checkpoint.md`.
+
+- [x] Create or select one legacy YAML and one custom-step YAML.
+- [x] Compile both.
+- [x] Create/update workflows with both.
+- [x] Confirm workflow `extract` preserves authored YAML/custom step metadata.
+- [ ] For release readiness, ingest one small representative document for each
+      path with live credentials, representative documents, and approval. If any
+      are unavailable, record blocked-release status or the explicitly reviewed
+      non-live substitute evidence approved by release governance.
+- [ ] Retrieve X-Ray and final extract output.
+- [ ] Confirm custom step outputs are visible in X-Ray under the chosen shape.
+- [x] Confirm custom output route metadata maps the X-Ray/readback value to the
+      expected final JSON field.
+- [x] Confirm final JSON uses only user-facing YAML group/value names.
+- [ ] Confirm old persisted workflow extracts and legacy YAML continue to load or
+      fail with the documented compatibility behavior.
+- [ ] Confirm direct workflow create/update rejects spoofed, caller-only, or
+      mismatched field-count metadata for an oversized custom step.
+      Blocked: the deployed API accepted an oversized/spoofed custom-step
+      workflow and the test workflow was immediately deleted. This remains
+      blocked until the Cashbot runtime/API guardrail in PR #1493 is merged and
+      deployed.
+- [ ] Confirm Arcadia default path works for legacy YAML.
+- [x] Confirm Arcadia custom field-action implementation is deferred to the
+      follow-on `reconcile_fields`/`qa_fields`/`save_fields` plan.
+- [ ] Publish SDK/docs if required by the final e2e path, after
+      local/runtime/schema/SDK/harness verification passes.
+- [ ] Run e2e against the published SDK/docs/runtime artifacts.
+- [ ] Confirm downstream repos use `groundx-python >= <released version>` and
+      no exact SDK pins were introduced only after published-artifact e2e
+      passes.
+- [ ] Confirm live deployed-path E2E passed, or record the explicitly reviewed
+      non-live substitute evidence approved to unblock release.
+- [ ] Adversarial review: confirm the test proves the deployed path, not only
+      local compile.
+
+## Task 12: Closeout
+
+- [ ] Update OpenSpec specs in each repo that received code/doc changes.
+- [ ] Archive completed OpenSpec plans only after tests pass and PRs merge.
+- [ ] Update GitHub/Linear issues with brief human summaries.
+- [ ] Record remaining risks and skipped live tests.
+- [ ] Confirm the central `groundx-python` planning change was not archived as-is
+      with cross-repo durable specs; repo-owned spec deltas were moved to owning
+      repo OpenSpec changes before archive.
+- [ ] Confirm harness plugin version was bumped when plugin payload changed.
+- [ ] Adversarial review: confirm no repo has uncommitted plan/code changes,
+      no stale harness plugin mirror, and no docs claiming unavailable behavior.

--- a/src/groundx/extract/__init__.py
+++ b/src/groundx/extract/__init__.py
@@ -34,6 +34,7 @@ if typing.TYPE_CHECKING:
         ContainerUploadSettings,
         GroundXSettings,
     )
+    from .workflows import ExtractionDefinition
 
 
 __all__ = [
@@ -46,6 +47,7 @@ __all__ = [
     "Document",
     "DocumentRequest",
     "Element",
+    "ExtractionDefinition",
     "ExtractedField",
     "FinalFieldPath",
     "GroundXDocument",
@@ -80,6 +82,7 @@ _EXPORT_MODULES = {
     "Document": ".classes",
     "DocumentRequest": ".classes",
     "Element": ".classes",
+    "ExtractionDefinition": ".workflows",
     "ExtractedField": ".classes",
     "FinalFieldPath": ".prompt.utility",
     "GroundXDocument": ".classes",

--- a/src/groundx/extract/classes/document.py
+++ b/src/groundx/extract/classes/document.py
@@ -1,28 +1,32 @@
-import json, os, shutil, requests, time, typing
+import json
+import os
+import shutil
+import time
+import typing
 from datetime import datetime, timezone
 from io import BytesIO
 from pathlib import Path
+from urllib.parse import urlparse
+
+import requests
+from ..prompt.manager import PromptManager
+from ..services.logger import Logger
+from ..services.upload import Upload
+from ..utility import clean_json
+from .element import Element
+from .field import ExtractedField
+from .groundx import GroundXDocument, XRayDocument
+from .group import Group
 from PIL import Image
 from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
-    model_validator,
     PrivateAttr,
     SerializeAsAny,
     ValidationInfo,
+    model_validator,
 )
-from urllib.parse import urlparse
-
-from .element import Element
-from .field import ExtractedField
-from .groundx import GroundXDocument, XRayDocument
-from .group import Group
-from ..prompt.manager import PromptManager
-from ..services.logger import Logger
-from ..services.upload import Upload
-from ..utility import clean_json
-
 
 DocT = typing.TypeVar("DocT", bound="Document")
 
@@ -366,7 +370,59 @@ class Document(Group):
                     if err:
                         raise Exception(f"\n\ninit fileSummary error:\n\t{err}\n")
 
+            self.load_custom_outputs(
+                getattr(chunk, "customChunkOutputs", None),
+                "customChunkOutputs",
+            )
+            self.load_custom_outputs(
+                getattr(chunk, "customSectionOutputs", None),
+                "customSectionOutputs",
+            )
+
+        self.load_custom_outputs(
+            getattr(xray, "customDocumentOutputs", None),
+            "customDocumentOutputs",
+        )
         self.finalize_init()
+
+    def load_custom_outputs(
+        self,
+        custom_outputs: typing.Optional[typing.Mapping[str, typing.Any]],
+        source: str,
+    ) -> None:
+        if not custom_outputs:
+            return
+
+        for step_name, outputs in custom_outputs.items():
+            if not isinstance(outputs, dict):
+                continue
+
+            output_mapping = typing.cast(typing.Dict[str, typing.Any], outputs)
+            for output_key, value in output_mapping.items():
+                data: typing.Any = value
+                if isinstance(data, str):
+                    try:
+                        data = json.loads(clean_json(data))
+                    except json.JSONDecodeError:
+                        pass
+
+                if isinstance(data, dict):
+                    data_mapping = typing.cast(typing.Dict[str, typing.Any], data)
+                    for key, nested_value in data_mapping.items():
+                        err = self.add(key, nested_value)
+                        if err:
+                            raise Exception(
+                                f"\n\ninit {source} error for "
+                                f"[{step_name}.{output_key}]:\n\t{err}\n"
+                            )
+                    continue
+
+                err = self.add(output_key, data)
+                if err:
+                    raise Exception(
+                        f"\n\ninit {source} error for "
+                        f"[{step_name}.{output_key}]:\n\t{err}\n"
+                    )
 
     def add(self, k: str, value: typing.Any) -> typing.Union[str, None]:
         self.print("WARNING", "add is not implemented")

--- a/src/groundx/extract/classes/groundx.py
+++ b/src/groundx/extract/classes/groundx.py
@@ -74,6 +74,8 @@ class Chunk(BaseModel):
     chunk: typing.Optional[str] = None
     chunkKeywords: typing.Optional[str] = None
     contentType: Annotated[typing.List[str], Field(default_factory=list)]
+    customChunkOutputs: typing.Optional[typing.Dict[str, typing.Dict[str, typing.Any]]] = None
+    customSectionOutputs: typing.Optional[typing.Dict[str, typing.Dict[str, typing.Any]]] = None
     fileKeywords: typing.Optional[str] = None
     fileSummary: typing.Optional[str] = None
     json_: typing.Optional[typing.List[typing.Any]] = Field(default=None, alias="json")
@@ -145,6 +147,7 @@ class DocumentPage(BaseModel):
 
 class XRayDocument(BaseModel):
     chunks: typing.List[Chunk]
+    customDocumentOutputs: typing.Optional[typing.Dict[str, typing.Dict[str, typing.Any]]] = None
     documentPages: Annotated[typing.List[DocumentPage], Field(default_factory=list)]
     sourceUrl: str
     fileKeywords: typing.Optional[str] = None

--- a/src/groundx/extract/prompt/manager.py
+++ b/src/groundx/extract/prompt/manager.py
@@ -212,26 +212,18 @@ class PromptManager:
 
     def cache_workflow(self, file_name: str, workflow_id: str) -> None:
         if workflow_id in self._cache:
-            version: typing.Optional[str] = None
-            try:
-                version = self._config_source.peek(workflow_id)
-            except Exception as e:
-                self.logger.debug_msg(
-                    f"_config_source.peek exception [{e}]",
-                    workflow_id=workflow_id,
-                )
-
-            if not version:
-                self.logger.debug_msg(
-                    f"_config_source.peek failed\ntrying _cache_source [{file_name}.yaml]...",
-                    workflow_id=workflow_id,
-                )
-                version = self._cache_source.peek(file_name)
+            version, peek_failed = self._peek_workflow_version(file_name, workflow_id)
             if (
                 version
                 and workflow_id in self._versions
                 and self._versions.get(workflow_id) == version
             ):
+                return
+            if not version and peek_failed and workflow_id in self._versions:
+                self.logger.debug_msg(
+                    "workflow version peek unavailable; using cached workflow",
+                    workflow_id=workflow_id,
+                )
                 return
             if version and workflow_id in self._versions:
                 self.logger.info_msg(
@@ -263,6 +255,36 @@ class PromptManager:
         self._final_group_metadata[workflow_id] = prepared.final_group_metadata
         self._workflow_group_metadata[workflow_id] = prepared.workflow_group_metadata
         self._versions[workflow_id] = version
+
+    def _peek_workflow_version(
+        self, file_name: str, workflow_id: str
+    ) -> typing.Tuple[typing.Optional[str], bool]:
+        version: typing.Optional[str] = None
+        peek_failed = False
+        try:
+            version = self._config_source.peek(workflow_id)
+        except Exception as e:
+            peek_failed = True
+            self.logger.debug_msg(
+                f"_config_source.peek exception [{e}]",
+                workflow_id=workflow_id,
+            )
+
+        if not version:
+            self.logger.debug_msg(
+                f"_config_source.peek failed\ntrying _cache_source [{file_name}.yaml]...",
+                workflow_id=workflow_id,
+            )
+            try:
+                version = self._cache_source.peek(file_name)
+            except Exception as e:
+                peek_failed = True
+                self.logger.debug_msg(
+                    f"_cache_source.peek exception [{e}]",
+                    workflow_id=workflow_id,
+                )
+
+        return version, peek_failed
 
     def _fetch_workflow_config(
         self, file_name: str, workflow_id: str
@@ -634,25 +656,17 @@ class PromptManager:
     def reload_if_changed(self, workflow_id: typing.Optional[str] = None) -> None:
         workflow_id = self.workflow_id(workflow_id)
 
-        current_version: typing.Optional[str] = None
-        try:
-            current_version = self._config_source.peek(workflow_id)
-        except Exception as e:
+        previous_version = self._versions.get(workflow_id)
+        current_version, peek_failed = self._peek_workflow_version(
+            self.file_name(None), workflow_id
+        )
+
+        if previous_version and not current_version and peek_failed:
             self.logger.debug_msg(
-                f"_config_source.peek exception [{e}]",
+                "workflow version peek unavailable; keeping cached workflow",
                 workflow_id=workflow_id,
             )
-
-        if not current_version:
-            try:
-                current_version = self._cache_source.peek(self.file_name(None))
-            except Exception as e:
-                self.logger.debug_msg(
-                    f"_cache_source.peek exception [{e}]",
-                    workflow_id=workflow_id,
-                )
-
-        previous_version = self._versions.get(workflow_id)
+            return
 
         if not previous_version or current_version != previous_version:
             raw, version = self._fetch_workflow_config(

--- a/src/groundx/extract/prompt/utility.py
+++ b/src/groundx/extract/prompt/utility.py
@@ -1,6 +1,9 @@
 import collections.abc
 import copy
 import dataclasses
+import hashlib
+import json
+import re
 import typing
 
 import yaml
@@ -10,9 +13,101 @@ from ..classes.group import Group
 from ..classes.prompt import Prompt
 
 _PERSISTED_WORKFLOW_EXTRACT_KEY = "_groundx_persisted_extract"
-_RESERVED_TOP_LEVEL_KEYS = {"_defs", "_pseudo_groups", _PERSISTED_WORKFLOW_EXTRACT_KEY}
+_CUSTOM_WORKFLOW_KEY = "workflow"
+_CUSTOM_WORKFLOW_GROUP_METADATA_KEY = "workflow_step"
+_CUSTOM_WORKFLOW_FIELD_METADATA_KEY = "workflow_output_key"
+_CUSTOM_WORKFLOW_METADATA_VERSION = 1
+_CUSTOM_WORKFLOW_MAX_FIELDS = 20
+_CUSTOM_WORKFLOW_OUTPUT_MAPS = {
+    "chunk": "customChunkOutputs",
+    "section": "customSectionOutputs",
+    "document": "customDocumentOutputs",
+}
+_RESERVED_TOP_LEVEL_KEYS = {
+    "_defs",
+    "_pseudo_groups",
+    _PERSISTED_WORKFLOW_EXTRACT_KEY,
+    _CUSTOM_WORKFLOW_KEY,
+}
 _PSEUDO_GROUP_BODY_KEYS = {"prompt", "fields"}
 _PSEUDO_FIELD_KEYS = {"path"}
+_CUSTOM_STEP_NAME_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_TEMPLATE_KEY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
+_CUSTOM_WORKFLOW_RESERVED_NAMES = {
+    "workflow",
+    "steps",
+    "custom_steps",
+    "customSteps",
+    "template",
+    "runtime",
+    "output_routes",
+    "outputRoutes",
+    "leaf_fields",
+    "leafFields",
+    "field_counts",
+    "fieldCounts",
+    "schema_hash",
+    "schemaHash",
+    "metadata_version",
+    "metadataVersion",
+    "workflow_group",
+    "workflowGroup",
+    "workflow_field",
+    "workflowField",
+    "CUSTOM_WORKFLOW_GROUP",
+    "CUSTOM_WORKFLOW_FIELD",
+    "CUSTOM_WORKFLOW_FINAL_PATH",
+    "CUSTOM_WORKFLOW_STEP_NAME",
+    "CUSTOM_WORKFLOW_OUTPUT_KEY",
+    "CUSTOM_WORKFLOW_READBACK_PATH",
+    "final_path",
+    "finalPath",
+    "step_name",
+    "stepName",
+    "output_key",
+    "outputKey",
+    "readback_path",
+    "readbackPath",
+    "_defs",
+    "_pseudo_groups",
+    _PERSISTED_WORKFLOW_EXTRACT_KEY,
+    "chunk_instruct",
+    "chunk_keys",
+    "chunk_summary",
+    "doc_instruct",
+    "doc_keys",
+    "doc_summary",
+    "document_instruct",
+    "document_keys",
+    "document_summary",
+    "search_query",
+    "section_instruct",
+    "section_keys",
+    "section_summary",
+    "sect_instruct",
+    "sect_keys",
+    "sect_summary",
+    "chunk-instruct",
+    "chunk-keys",
+    "chunk-summary",
+    "doc-instruct",
+    "doc-keys",
+    "doc-summary",
+    "search-query",
+    "sect-instruct",
+    "sect-keys",
+    "sect-summary",
+}
+_CUSTOM_WORKFLOW_AUTHORING_KEYS = {"template", "custom_steps"}
+_CUSTOM_WORKFLOW_PERSISTED_KEYS = {
+    "metadata_version",
+    "template",
+    "custom_steps",
+    "output_routes",
+    "leaf_fields",
+    "field_counts",
+    "schema_hash",
+}
 
 
 def _metadata_factory() -> typing.Dict[str, typing.Any]:
@@ -491,13 +586,719 @@ def _without_unset_metadata(
     return {key: value for key, value in metadata.items() if value is not None}
 
 
+def _normalize_template_key(raw: typing.Any, path: str) -> str:
+    if not isinstance(raw, str):
+        raise ValueError(f"Expected string template key at [{path}]")
+
+    key = raw.strip()
+    validation_key = key
+    if key.startswith("{{") and key.endswith("}}"):
+        validation_key = key[2:-2].strip()
+
+    if not _TEMPLATE_KEY_RE.match(validation_key):
+        raise ValueError(f"invalid template key [{raw}]")
+    if validation_key.startswith("GROUNDX_"):
+        raise ValueError(f"reserved template key prefix [{raw}]")
+    if validation_key in _CUSTOM_WORKFLOW_RESERVED_NAMES:
+        raise ValueError(f"reserved template key [{raw}]")
+
+    return key
+
+
+def _normalize_workflow_template(value: typing.Any) -> typing.Dict[str, str]:
+    if value is None:
+        return {}
+
+    template = _ensure_mapping(value, f"{_CUSTOM_WORKFLOW_KEY}.template")
+    normalized: typing.Dict[str, str] = {}
+    for raw_key, raw_value in template.items():
+        key = _normalize_template_key(
+            raw_key, f"{_CUSTOM_WORKFLOW_KEY}.template.{raw_key}"
+        )
+        if key in normalized:
+            raise ValueError(f"duplicate template key [{key}] after normalization")
+        if not isinstance(raw_value, str):
+            raise ValueError(
+                f"Expected string template value at [{_CUSTOM_WORKFLOW_KEY}.template.{raw_key}]"
+            )
+        normalized[key] = raw_value
+
+    return normalized
+
+
+def _valid_custom_workflow_kind(level: str, kind: str) -> bool:
+    if level in {"chunk", "section"}:
+        return kind in {"instruct", "keys", "summary"}
+    if level == "document":
+        return kind in {"keys", "summary"}
+    return False
+
+
+def _normalize_required_template_keys(
+    value: typing.Any, template: typing.Dict[str, str], path: str
+) -> typing.List[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"Expected list at [{path}]")
+
+    keys: typing.List[str] = []
+    seen: typing.Set[str] = set()
+    raw_keys = typing.cast(typing.List[typing.Any], value)
+    for idx, raw_key in enumerate(raw_keys):
+        key = _normalize_template_key(raw_key, f"{path}[{idx}]")
+        if key in seen:
+            raise ValueError(f"duplicate required template key [{key}]")
+        if key not in template:
+            raise ValueError(f"missing template key [{key}]")
+        seen.add(key)
+        keys.append(key)
+
+    return keys
+
+
+def _normalize_custom_step_config(
+    value: typing.Any, path: str
+) -> typing.Optional[typing.Dict[str, typing.Any]]:
+    if value is None:
+        return None
+
+    config = _ensure_mapping(value, path)
+    normalized = _copy_mapping(config)
+    for element_name, raw_element_config in normalized.items():
+        if raw_element_config is None:
+            continue
+        element_config = _ensure_mapping(
+            raw_element_config, f"{path}.{element_name}"
+        )
+        if "field" in element_config:
+            raise ValueError("custom workflow step config cannot set fixed field")
+
+    return normalized
+
+
+def _normalize_custom_workflow_steps(
+    value: typing.Any,
+    template: typing.Dict[str, str],
+) -> typing.Tuple[
+    typing.List[typing.Dict[str, typing.Any]],
+    typing.Dict[str, typing.Dict[str, typing.Any]],
+]:
+    if value is None:
+        return [], {}
+    if not isinstance(value, list):
+        raise ValueError(f"Expected list at [{_CUSTOM_WORKFLOW_KEY}.custom_steps]")
+
+    steps: typing.List[typing.Dict[str, typing.Any]] = []
+    by_name: typing.Dict[str, typing.Dict[str, typing.Any]] = {}
+    raw_steps = typing.cast(typing.List[typing.Any], value)
+    for idx, raw_step in enumerate(raw_steps):
+        path = f"{_CUSTOM_WORKFLOW_KEY}.custom_steps[{idx}]"
+        step = _ensure_mapping(raw_step, path)
+        name = step.get("name")
+        if not isinstance(name, str) or not _CUSTOM_STEP_NAME_RE.match(name):
+            raise ValueError(f"invalid custom step name [{name}]")
+        if name in _CUSTOM_WORKFLOW_RESERVED_NAMES:
+            raise ValueError(f"reserved custom step name [{name}]")
+        if name in by_name:
+            raise ValueError(f"duplicate custom step name [{name}]")
+
+        level = step.get("level")
+        kind = step.get("kind")
+        if not isinstance(level, str) or not isinstance(kind, str):
+            raise ValueError(f"custom step [{name}] is missing level or kind")
+        if not _valid_custom_workflow_kind(level, kind):
+            raise ValueError(f"invalid custom step level/kind [{level}/{kind}]")
+
+        normalized_step: typing.Dict[str, typing.Any] = {
+            "name": name,
+            "level": level,
+            "kind": kind,
+        }
+        config = _normalize_custom_step_config(step.get("config"), f"{path}.config")
+        if config is not None:
+            normalized_step["config"] = config
+        required_template_keys = _normalize_required_template_keys(
+            step.get("required_template_keys", step.get("requiredTemplateKeys")),
+            template,
+            f"{path}.required_template_keys",
+        )
+        if required_template_keys:
+            normalized_step["required_template_keys"] = required_template_keys
+
+        steps.append(normalized_step)
+        by_name[name] = normalized_step
+
+    return steps, by_name
+
+
+def _parse_pointer_segments(pointer: typing.Any, path: str) -> typing.Tuple[str, ...]:
+    if not isinstance(pointer, str):
+        raise ValueError(f"Expected JSON Pointer string at [{path}]")
+    if not pointer.startswith("/"):
+        raise ValueError(f"finalPath [{pointer}] is not an RFC 6901 JSON Pointer")
+
+    raw_segments = pointer.split("/")[1:]
+    if not raw_segments or any(segment == "" for segment in raw_segments):
+        raise ValueError(f"unsupported final field path [{pointer}]")
+
+    return tuple(_decode_pointer_segment(segment, pointer) for segment in raw_segments)
+
+
+def _custom_workflow_output_map(level: str) -> str:
+    output_map = _CUSTOM_WORKFLOW_OUTPUT_MAPS.get(level)
+    if not output_map:
+        raise ValueError(f"invalid custom workflow level [{level}]")
+    return output_map
+
+
+def _custom_workflow_readback_path(
+    level: str, step_name: str, output_key: str
+) -> str:
+    output_map = _custom_workflow_output_map(level)
+    if level == "document":
+        return f"/{output_map}/{step_name}/{output_key}"
+
+    return f"/chunks/*/{output_map}/{step_name}/{output_key}"
+
+
+def _validate_output_key(value: typing.Any, path: str) -> str:
+    if not isinstance(value, str) or not _CUSTOM_STEP_NAME_RE.match(value):
+        raise ValueError(f"invalid output key [{value}] at [{path}]")
+    if value in _CUSTOM_WORKFLOW_RESERVED_NAMES:
+        raise ValueError(f"reserved output key [{value}] at [{path}]")
+    return value
+
+
+def _field_type(field: typing.Dict[str, typing.Any]) -> str:
+    prompt = field.get("prompt")
+    if isinstance(prompt, dict):
+        prompt_mapping = typing.cast(typing.Dict[str, typing.Any], prompt)
+        if isinstance(prompt_mapping.get("type"), str):
+            return typing.cast(str, prompt_mapping["type"])
+
+    return "unknown"
+
+
+def _repetition_scope(segments: typing.Tuple[str, ...]) -> str:
+    if "*" not in segments:
+        return "none"
+
+    idx = segments.index("*")
+    return _encode_pointer(segments[: idx + 1])
+
+
+def _custom_workflow_field_name(
+    prefix: typing.Tuple[str, ...], field_name: str
+) -> str:
+    return ".".join(segment for segment in (*prefix, field_name) if segment != "*")
+
+
+def _custom_route_identity(route: typing.Dict[str, typing.Any]) -> str:
+    return "\x00".join(
+        [
+            route["final_path"],
+            route["workflow_group"],
+            route["workflow_field"],
+            route["step_name"],
+            route["output_key"],
+        ]
+    )
+
+
+def _custom_leaf_identity(leaf: typing.Dict[str, typing.Any]) -> str:
+    return "\x00".join(
+        [
+            leaf["final_path"],
+            leaf["workflow_group"],
+            leaf["workflow_field"],
+            leaf["step_name"],
+            leaf["output_key"],
+        ]
+    )
+
+
+def _custom_route_leaf_match_key(item: typing.Dict[str, typing.Any]) -> str:
+    return "\x00".join(
+        [
+            item["final_path"],
+            item["workflow_group"],
+            item["workflow_field"],
+            item["step_name"],
+            item["level"],
+            item["output_key"],
+        ]
+    )
+
+
+def _custom_workflow_schema_hash(
+    metadata: typing.Dict[str, typing.Any]
+) -> str:
+    steps: typing.List[typing.Dict[str, typing.Any]] = []
+    for step in metadata.get("custom_steps", []):
+        normalized_step = {
+            "name": step["name"],
+            "level": step["level"],
+            "kind": step["kind"],
+        }
+        keys = sorted(step.get("required_template_keys", []))
+        if keys:
+            normalized_step["required_template_keys"] = keys
+        steps.append(normalized_step)
+
+    routes = [
+        {
+            "final_path": route["final_path"],
+            "workflow_group": route["workflow_group"],
+            "workflow_field": route["workflow_field"],
+            "step_name": route["step_name"],
+            "level": route["level"],
+            "output_map": route["output_map"],
+            "output_key": route["output_key"],
+            "readback_path": route["readback_path"],
+        }
+        for route in metadata.get("output_routes", [])
+    ]
+    leaves = [
+        {
+            "final_path": leaf["final_path"],
+            "workflow_group": leaf["workflow_group"],
+            "workflow_field": leaf["workflow_field"],
+            "step_name": leaf["step_name"],
+            "level": leaf["level"],
+            "output_key": leaf["output_key"],
+            "field_type": leaf["field_type"],
+            "is_repeated": leaf["is_repeated"],
+            "repetition_scope": leaf["repetition_scope"],
+        }
+        for leaf in metadata.get("leaf_fields", [])
+    ]
+
+    steps.sort(key=lambda step: step["name"])
+    routes.sort(key=_custom_route_identity)
+    leaves.sort(key=_custom_leaf_identity)
+
+    payload: typing.Dict[str, typing.Any] = {
+        "metadata_version": metadata.get(
+            "metadata_version", _CUSTOM_WORKFLOW_METADATA_VERSION
+        )
+    }
+    if steps:
+        payload["custom_steps"] = steps
+    if routes:
+        payload["output_routes"] = routes
+    if leaves:
+        payload["leaf_fields"] = leaves
+
+    encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _normalize_custom_route(
+    value: typing.Any,
+    idx: int,
+    steps_by_name: typing.Dict[str, typing.Dict[str, typing.Any]],
+) -> typing.Dict[str, typing.Any]:
+    path = f"{_CUSTOM_WORKFLOW_KEY}.output_routes[{idx}]"
+    route = _ensure_mapping(value, path)
+    normalized: typing.Dict[str, typing.Any] = {}
+    for key in (
+        "workflow_group",
+        "workflow_field",
+        "final_path",
+        "step_name",
+        "level",
+        "output_map",
+        "output_key",
+        "readback_path",
+    ):
+        raw_value = route.get(key)
+        if not isinstance(raw_value, str) or raw_value == "":
+            raise ValueError(f"custom workflow output route is missing [{key}]")
+        normalized[key] = raw_value
+
+    _parse_pointer_segments(normalized["final_path"], f"{path}.final_path")
+    _validate_output_key(normalized["output_key"], f"{path}.output_key")
+    step = steps_by_name.get(normalized["step_name"])
+    if step is None:
+        raise ValueError(f"unknown custom step [{normalized['step_name']}]")
+    if normalized["level"] != step["level"]:
+        raise ValueError(
+            f"route level [{normalized['level']}] does not match step [{step['name']}]"
+        )
+    if normalized["output_map"] != _custom_workflow_output_map(normalized["level"]):
+        raise ValueError(
+            f"output map [{normalized['output_map']}] does not match level [{normalized['level']}]"
+        )
+
+    return normalized
+
+
+def _normalize_custom_leaf(
+    value: typing.Any,
+    idx: int,
+    steps_by_name: typing.Dict[str, typing.Dict[str, typing.Any]],
+) -> typing.Dict[str, typing.Any]:
+    path = f"{_CUSTOM_WORKFLOW_KEY}.leaf_fields[{idx}]"
+    leaf = _ensure_mapping(value, path)
+    normalized: typing.Dict[str, typing.Any] = {}
+    for key in (
+        "final_path",
+        "workflow_group",
+        "workflow_field",
+        "step_name",
+        "level",
+        "output_key",
+        "field_type",
+        "repetition_scope",
+    ):
+        raw_value = leaf.get(key)
+        if not isinstance(raw_value, str) or raw_value == "":
+            raise ValueError(f"custom workflow leaf field is missing [{key}]")
+        normalized[key] = raw_value
+
+    is_repeated = leaf.get("is_repeated")
+    if not isinstance(is_repeated, bool):
+        raise ValueError("custom workflow leaf field is missing [is_repeated]")
+    normalized["is_repeated"] = is_repeated
+
+    segments = _parse_pointer_segments(normalized["final_path"], f"{path}.final_path")
+    _validate_output_key(normalized["output_key"], f"{path}.output_key")
+    step = steps_by_name.get(normalized["step_name"])
+    if step is None:
+        raise ValueError(f"unknown custom step [{normalized['step_name']}]")
+    if normalized["level"] != step["level"]:
+        raise ValueError(
+            f"leaf level [{normalized['level']}] does not match step [{step['name']}]"
+        )
+    if normalized["is_repeated"] and "*" not in segments:
+        raise ValueError("repeated leaf field must use a literal * path segment")
+    if not normalized["is_repeated"] and normalized["repetition_scope"] != "none":
+        raise ValueError("non-repeated leaf field cannot set repetition_scope")
+
+    return normalized
+
+
+def _validate_custom_workflow_routes_and_leaves(
+    routes: typing.List[typing.Dict[str, typing.Any]],
+    leaves: typing.List[typing.Dict[str, typing.Any]],
+) -> typing.Dict[str, int]:
+    route_by_match_key: typing.Dict[str, typing.Dict[str, typing.Any]] = {}
+    leaf_by_match_key: typing.Dict[str, typing.Dict[str, typing.Any]] = {}
+    route_destinations: typing.Set[typing.Tuple[str, str]] = set()
+    counts: typing.Dict[str, int] = {}
+
+    for route in routes:
+        match_key = _custom_route_leaf_match_key(route)
+        if match_key in route_by_match_key:
+            raise ValueError(f"duplicate route identity for [{route['final_path']}]")
+        destination = (route["step_name"], route["output_key"])
+        if destination in route_destinations:
+            raise ValueError(
+                "duplicate output destination "
+                f"[{route['step_name']}.{route['output_key']}]"
+            )
+        route_destinations.add(destination)
+        route_by_match_key[match_key] = route
+        counts[route["step_name"]] = counts.get(route["step_name"], 0) + 1
+
+    for leaf in leaves:
+        match_key = _custom_route_leaf_match_key(leaf)
+        if match_key in leaf_by_match_key:
+            raise ValueError(f"duplicate leaf identity for [{leaf['final_path']}]")
+        leaf_by_match_key[match_key] = leaf
+
+    for match_key, route in route_by_match_key.items():
+        if match_key not in leaf_by_match_key:
+            raise ValueError(f"missing leaf field for route [{route['final_path']}]")
+    for match_key, leaf in leaf_by_match_key.items():
+        if match_key not in route_by_match_key:
+            raise ValueError(f"missing route for leaf field [{leaf['final_path']}]")
+
+    for step_name, count in counts.items():
+        if count > _CUSTOM_WORKFLOW_MAX_FIELDS:
+            raise ValueError(
+                f"custom step [{step_name}] owns {count} fields; "
+                f"one executable workflow step may own at most {_CUSTOM_WORKFLOW_MAX_FIELDS} fields"
+            )
+
+    return dict(sorted(counts.items()))
+
+
+def _is_custom_workflow_authoring_metadata(
+    workflow: typing.Dict[str, typing.Any]
+) -> bool:
+    return any(key in workflow for key in _CUSTOM_WORKFLOW_AUTHORING_KEYS)
+
+
+def _is_custom_workflow_persisted_metadata(
+    workflow: typing.Dict[str, typing.Any]
+) -> bool:
+    return any(key in workflow for key in _CUSTOM_WORKFLOW_PERSISTED_KEYS - _CUSTOM_WORKFLOW_AUTHORING_KEYS)
+
+
+def _custom_workflow_input(
+    data: typing.Dict[str, typing.Any]
+) -> typing.Optional[typing.Tuple[str, typing.Dict[str, typing.Any]]]:
+    if _CUSTOM_WORKFLOW_KEY not in data:
+        return None
+
+    workflow = _ensure_mapping(data[_CUSTOM_WORKFLOW_KEY], _CUSTOM_WORKFLOW_KEY)
+    unsupported = set(workflow.keys()) - (
+        _CUSTOM_WORKFLOW_AUTHORING_KEYS | _CUSTOM_WORKFLOW_PERSISTED_KEYS
+    )
+    if unsupported or "fields" in workflow:
+        raise ValueError(
+            "top-level [workflow] is reserved for custom workflow metadata; "
+            "rename the final output group"
+        )
+
+    is_persisted = _is_custom_workflow_persisted_metadata(workflow)
+    is_authoring = _is_custom_workflow_authoring_metadata(workflow)
+    if is_persisted:
+        return "persisted", workflow
+    if is_authoring:
+        return "authoring", workflow
+
+    raise ValueError(
+        "top-level [workflow] is reserved for custom workflow metadata; "
+        "rename the final output group"
+    )
+
+
+def _normalize_persisted_custom_workflow_metadata(
+    workflow: typing.Dict[str, typing.Any]
+) -> typing.Dict[str, typing.Any]:
+    version = workflow.get("metadata_version")
+    if version != _CUSTOM_WORKFLOW_METADATA_VERSION:
+        raise ValueError("unsupported custom workflow metadata_version")
+
+    template = _normalize_workflow_template(workflow.get("template"))
+    custom_steps, steps_by_name = _normalize_custom_workflow_steps(
+        workflow.get("custom_steps"), template
+    )
+    routes = [
+        _normalize_custom_route(route, idx, steps_by_name)
+        for idx, route in enumerate(workflow.get("output_routes") or [])
+    ]
+    leaves = [
+        _normalize_custom_leaf(leaf, idx, steps_by_name)
+        for idx, leaf in enumerate(workflow.get("leaf_fields") or [])
+    ]
+    if custom_steps and (not routes or not leaves):
+        raise ValueError(
+            "custom workflow steps require output routes and leaf fields; "
+            "add workflow_output_key metadata to routed fields"
+        )
+    field_counts = _validate_custom_workflow_routes_and_leaves(routes, leaves)
+
+    caller_field_counts = workflow.get("field_counts")
+    if caller_field_counts is not None and caller_field_counts != field_counts:
+        raise ValueError("caller field_counts do not match route metadata")
+
+    metadata: typing.Dict[str, typing.Any] = {
+        "metadata_version": _CUSTOM_WORKFLOW_METADATA_VERSION,
+        "custom_steps": custom_steps,
+        "output_routes": routes,
+        "leaf_fields": leaves,
+    }
+    if template:
+        metadata["template"] = template
+    if field_counts:
+        metadata["field_counts"] = field_counts
+
+    schema_hash = _custom_workflow_schema_hash(metadata)
+    caller_schema_hash = workflow.get("schema_hash")
+    if caller_schema_hash is not None and caller_schema_hash != schema_hash:
+        raise ValueError("caller schema_hash does not match route metadata")
+    metadata["schema_hash"] = schema_hash
+
+    return metadata
+
+
+def _collect_custom_workflow_routes(
+    fields: typing.Dict[str, typing.Any],
+    group_name: str,
+    step_name: typing.Optional[str],
+    steps_by_name: typing.Dict[str, typing.Dict[str, typing.Any]],
+    prefix: typing.Tuple[str, ...] = (),
+) -> typing.Tuple[
+    typing.List[typing.Dict[str, typing.Any]],
+    typing.List[typing.Dict[str, typing.Any]],
+]:
+    routes: typing.List[typing.Dict[str, typing.Any]] = []
+    leaves: typing.List[typing.Dict[str, typing.Any]] = []
+
+    for field_name, field_value in fields.items():
+        field_path = ".".join([group_name, *prefix, field_name])
+        if isinstance(field_value, list):
+            field_items = typing.cast(typing.List[typing.Any], field_value)
+            for item in field_items:
+                item_mapping = _ensure_mapping(item, field_path)
+                nested_step = item_mapping.pop(
+                    _CUSTOM_WORKFLOW_GROUP_METADATA_KEY, step_name
+                )
+                if "fields" in item_mapping:
+                    item_fields = _ensure_fields_mapping(
+                        item_mapping.get("fields"), f"{field_path}.fields"
+                    )
+                    nested_routes, nested_leaves = _collect_custom_workflow_routes(
+                        item_fields,
+                        group_name,
+                        typing.cast(typing.Optional[str], nested_step),
+                        steps_by_name,
+                        (*prefix, field_name, "*"),
+                    )
+                    routes.extend(nested_routes)
+                    leaves.extend(nested_leaves)
+            continue
+
+        if not isinstance(field_value, dict):
+            continue
+
+        field_mapping = typing.cast(typing.Dict[str, typing.Any], field_value)
+        nested_step = field_mapping.pop(_CUSTOM_WORKFLOW_GROUP_METADATA_KEY, step_name)
+        output_key_raw = field_mapping.pop(_CUSTOM_WORKFLOW_FIELD_METADATA_KEY, None)
+        if output_key_raw is not None:
+            if not nested_step:
+                raise ValueError(
+                    f"field [{field_path}] declares workflow_output_key without workflow_step"
+                )
+            if not isinstance(nested_step, str):
+                raise ValueError(f"workflow_step for [{field_path}] must be a string")
+            step = steps_by_name.get(nested_step)
+            if step is None:
+                raise ValueError(f"unknown custom step [{nested_step}]")
+            output_key = _validate_output_key(
+                output_key_raw,
+                f"{field_path}.{_CUSTOM_WORKFLOW_FIELD_METADATA_KEY}",
+            )
+            segments = (group_name, *prefix, field_name)
+            final_path = _encode_pointer(segments)
+            level = typing.cast(str, step["level"])
+            workflow_field = _custom_workflow_field_name(prefix, field_name)
+            route = {
+                "workflow_group": group_name,
+                "workflow_field": workflow_field,
+                "final_path": final_path,
+                "step_name": nested_step,
+                "level": level,
+                "output_map": _custom_workflow_output_map(level),
+                "output_key": output_key,
+                "readback_path": _custom_workflow_readback_path(
+                    level, nested_step, output_key
+                ),
+            }
+            leaf = {
+                "final_path": final_path,
+                "workflow_group": group_name,
+                "workflow_field": workflow_field,
+                "step_name": nested_step,
+                "level": level,
+                "output_key": output_key,
+                "field_type": _field_type(field_mapping),
+                "is_repeated": "*" in segments,
+                "repetition_scope": _repetition_scope(segments),
+            }
+            routes.append(route)
+            leaves.append(leaf)
+
+        if _is_group_mapping(field_mapping) and not _is_field_mapping(field_mapping):
+            nested_fields = _ensure_fields_mapping(
+                field_mapping.get("fields"), f"{field_path}.fields"
+            )
+            nested_routes, nested_leaves = _collect_custom_workflow_routes(
+                nested_fields,
+                group_name,
+                typing.cast(typing.Optional[str], nested_step),
+                steps_by_name,
+                (*prefix, field_name),
+            )
+            routes.extend(nested_routes)
+            leaves.extend(nested_leaves)
+        elif not _is_field_mapping(field_mapping):
+            nested_routes, nested_leaves = _collect_custom_workflow_routes(
+                field_mapping,
+                group_name,
+                typing.cast(typing.Optional[str], nested_step),
+                steps_by_name,
+                (*prefix, field_name),
+            )
+            routes.extend(nested_routes)
+            leaves.extend(nested_leaves)
+
+    return routes, leaves
+
+
+def _build_authored_custom_workflow_metadata(
+    workflow: typing.Dict[str, typing.Any],
+    groups: typing.Dict[str, typing.Dict[str, typing.Any]],
+    final_workflow_metadata: typing.Dict[str, typing.Dict[str, typing.Any]],
+) -> typing.Dict[str, typing.Any]:
+    template = _normalize_workflow_template(workflow.get("template"))
+    custom_steps, steps_by_name = _normalize_custom_workflow_steps(
+        workflow.get("custom_steps"), template
+    )
+    if not custom_steps:
+        raise ValueError("workflow.custom_steps is required for custom workflow metadata")
+
+    routes: typing.List[typing.Dict[str, typing.Any]] = []
+    leaves: typing.List[typing.Dict[str, typing.Any]] = []
+    for group_name, group in groups.items():
+        group_step = final_workflow_metadata.get(group_name, {}).get(
+            _CUSTOM_WORKFLOW_GROUP_METADATA_KEY
+        )
+        fields = _ensure_fields_mapping(group.get("fields"), f"{group_name}.fields")
+        group_routes, group_leaves = _collect_custom_workflow_routes(
+            fields,
+            group_name,
+            typing.cast(typing.Optional[str], group_step),
+            steps_by_name,
+        )
+        routes.extend(group_routes)
+        leaves.extend(group_leaves)
+
+    if not routes or not leaves:
+        raise ValueError(
+            "custom workflow steps require output routes and leaf fields; "
+            "add workflow_output_key metadata to routed fields"
+        )
+    field_counts = _validate_custom_workflow_routes_and_leaves(routes, leaves)
+    metadata: typing.Dict[str, typing.Any] = {
+        "metadata_version": _CUSTOM_WORKFLOW_METADATA_VERSION,
+        "custom_steps": custom_steps,
+        "output_routes": routes,
+        "leaf_fields": leaves,
+    }
+    if template:
+        metadata["template"] = template
+    if field_counts:
+        metadata["field_counts"] = field_counts
+    metadata["schema_hash"] = _custom_workflow_schema_hash(metadata)
+    return metadata
+
+
+def _apply_custom_workflow_field_paths(
+    workflow_field_paths: typing.Dict[str, typing.Dict[str, str]],
+    custom_workflow_metadata: typing.Optional[typing.Dict[str, typing.Any]],
+) -> None:
+    if not custom_workflow_metadata:
+        return
+
+    for route in custom_workflow_metadata.get("output_routes", []):
+        group_name = route["workflow_group"]
+        workflow_field = route["workflow_field"]
+        final_path = route["final_path"]
+        workflow_field_paths.setdefault(group_name, {})[workflow_field] = final_path
+
+
 def _has_declared_metadata(
     data: typing.Dict[str, typing.Any],
     top_metadata_keys: typing.Set[str],
     final_metadata_keys: typing.Set[str],
     workflow_metadata_keys: typing.Set[str],
 ) -> bool:
-    if "_defs" in data or "_pseudo_groups" in data:
+    if "_defs" in data or "_pseudo_groups" in data or _CUSTOM_WORKFLOW_KEY in data:
         return True
 
     if any(key in data for key in top_metadata_keys):
@@ -521,8 +1322,11 @@ def _persisted_workflow_extract(
     top_metadata_keys: typing.Set[str],
     final_metadata_keys: typing.Set[str],
     workflow_metadata_keys: typing.Set[str],
+    custom_workflow_metadata: typing.Optional[typing.Dict[str, typing.Any]] = None,
 ) -> typing.Dict[str, typing.Any]:
     persisted: typing.Dict[str, typing.Any] = _copy_mapping(workflow_groups)
+    if custom_workflow_metadata:
+        persisted[_CUSTOM_WORKFLOW_KEY] = _copy_mapping(custom_workflow_metadata)
     if _has_declared_metadata(
         authored_data,
         top_metadata_keys,
@@ -595,10 +1399,14 @@ def prepare_extraction_yaml(
                 _PERSISTED_WORKFLOW_EXTRACT_KEY,
             )
         )
+    custom_workflow_kind_and_input = _custom_workflow_input(data)
     top_metadata_key_set = set(top_level_metadata_keys or [])
     final_metadata_key_set = set(final_group_metadata_keys or [])
     workflow_metadata_key_set = set(workflow_group_metadata_keys or [])
-    metadata_overlap = final_metadata_key_set & workflow_metadata_key_set
+    effective_workflow_metadata_key_set = workflow_metadata_key_set | {
+        _CUSTOM_WORKFLOW_GROUP_METADATA_KEY
+    }
+    metadata_overlap = final_metadata_key_set & effective_workflow_metadata_key_set
     if metadata_overlap:
         raise ValueError(
             "metadata keys cannot be both final-group and workflow-group scoped: "
@@ -626,7 +1434,14 @@ def prepare_extraction_yaml(
     for group_name, raw_group in raw_groups.items():
         group = _ensure_mapping(raw_group, group_name)
         group, final_metadata = _split_metadata(group, final_metadata_key_set)
-        group, workflow_metadata = _split_metadata(group, workflow_metadata_key_set)
+        group, workflow_metadata = _split_metadata(
+            group, effective_workflow_metadata_key_set
+        )
+        if "slot" in workflow_metadata and _CUSTOM_WORKFLOW_GROUP_METADATA_KEY in workflow_metadata:
+            raise ValueError(
+                f"group [{group_name}] cannot declare both [slot] and "
+                f"[{_CUSTOM_WORKFLOW_GROUP_METADATA_KEY}]"
+            )
         group = _compose_group_fields(group_name, group, defs)
         _validate_group_shape(group, group_name)
         groups[group_name] = group
@@ -635,6 +1450,20 @@ def prepare_extraction_yaml(
         workflow_metadata = _without_unset_metadata(workflow_metadata)
         if workflow_metadata:
             final_workflow_metadata[group_name] = workflow_metadata
+
+    custom_workflow_metadata: typing.Optional[typing.Dict[str, typing.Any]] = None
+    if custom_workflow_kind_and_input:
+        custom_workflow_kind, custom_workflow_input = custom_workflow_kind_and_input
+        if custom_workflow_kind == "persisted":
+            custom_workflow_metadata = _normalize_persisted_custom_workflow_metadata(
+                custom_workflow_input
+            )
+        else:
+            custom_workflow_metadata = _build_authored_custom_workflow_metadata(
+                custom_workflow_input,
+                groups,
+                final_workflow_metadata,
+            )
 
     raw_pseudo_groups: typing.Dict[str, typing.Any] = {}
     if "_pseudo_groups" in data:
@@ -655,7 +1484,7 @@ def prepare_extraction_yaml(
             raw_pseudo_group, f"_pseudo_groups.{pseudo_group_name}"
         )
         pseudo_group, explicit_workflow_metadata = _split_metadata(
-            pseudo_group, workflow_metadata_key_set
+            pseudo_group, effective_workflow_metadata_key_set
         )
         unsupported_pseudo_keys = set(pseudo_group.keys()) - _PSEUDO_GROUP_BODY_KEYS
         if unsupported_pseudo_keys:
@@ -752,24 +1581,30 @@ def prepare_extraction_yaml(
             explicit_workflow_metadata,
             parent_paths,
             final_workflow_metadata,
-            workflow_metadata_key_set,
+            effective_workflow_metadata_key_set,
         )
         if resolved_metadata:
             workflow_group_metadata[pseudo_group_name] = resolved_metadata
 
     if not pseudo_groups:
         workflow_groups = _copy_mapping(groups)
+        workflow_field_paths = _build_identity_route_map(groups)
+        _apply_custom_workflow_field_paths(
+            workflow_field_paths,
+            custom_workflow_metadata,
+        )
         return PreparedExtractionYaml(
             groups=groups,
             workflow_groups=workflow_groups,
             pseudo_groups={},
-            workflow_field_paths=_build_identity_route_map(groups),
+            workflow_field_paths=workflow_field_paths,
             persisted_workflow_extract=_persisted_workflow_extract(
                 data,
                 workflow_groups,
                 top_metadata_key_set,
                 final_metadata_key_set,
-                workflow_metadata_key_set,
+                effective_workflow_metadata_key_set,
+                custom_workflow_metadata,
             ),
             top_level_metadata=top_level_metadata,
             final_group_metadata=final_group_metadata,
@@ -792,6 +1627,10 @@ def prepare_extraction_yaml(
             workflow_group_metadata[group_name] = copy.deepcopy(
                 final_workflow_metadata[group_name]
             )
+    _apply_custom_workflow_field_paths(
+        workflow_field_paths,
+        custom_workflow_metadata,
+    )
 
     return PreparedExtractionYaml(
         groups=groups,
@@ -803,7 +1642,8 @@ def prepare_extraction_yaml(
             workflow_groups,
             top_metadata_key_set,
             final_metadata_key_set,
-            workflow_metadata_key_set,
+            effective_workflow_metadata_key_set,
+            custom_workflow_metadata,
         ),
         top_level_metadata=top_level_metadata,
         final_group_metadata=final_group_metadata,

--- a/src/groundx/extract/services/upload_minio.py
+++ b/src/groundx/extract/services/upload_minio.py
@@ -69,7 +69,10 @@ class MinIOClient:
                 self.parse_url(url),
             )
 
-            return response.read()
+            try:
+                return response.read()
+            finally:
+                self._close_response(response)
         except S3Error as e:
             self.logger.error_msg(
                 f"Failed to get object from [{url}] [{self.parse_url(url)}]: {str(e)}"
@@ -97,7 +100,10 @@ class MinIOClient:
                 self.parse_url(url),
             )
 
-            body = response.read()
+            try:
+                body = response.read()
+            finally:
+                self._close_response(response)
 
             return body, meta
         except S3Error as e:
@@ -184,6 +190,16 @@ class MinIOClient:
         except S3Error as e:
             self.logger.error_msg(f"Failed to put object in [{bucket}/{key}]: {str(e)}")
             raise
+
+    @staticmethod
+    def _close_response(response: typing.Any) -> None:
+        close = getattr(response, "close", None)
+        if callable(close):
+            close()
+
+        release_conn = getattr(response, "release_conn", None)
+        if callable(release_conn):
+            release_conn()
 
     def put_json_stream(
         self,

--- a/src/groundx/extract/services/upload_s3.py
+++ b/src/groundx/extract/services/upload_s3.py
@@ -33,7 +33,7 @@ class S3Client:
 
             response = self.client.get_object(Bucket=s3_bucket, Key=s3_key)
 
-            return response.get("Body").read()
+            return self._read_body(response)
         except Exception as e:
             self.logger.error_msg(f"[{url}] exception: {e}")
             raise
@@ -50,12 +50,9 @@ class S3Client:
 
             response = self.client.get_object(Bucket=s3_bucket, Key=s3_key)
 
-            body = response.get("Body").read()
+            body = self._read_body(response)
 
-            return body, {
-                "ETag": response.get("ETag", ""),
-                "LastModified": str(response.get("LastModified").timestamp()),
-            }
+            return body, self._metadata_from_response(response)
 
         except Exception as e:
             self.logger.error_msg(f"[{url}] exception: {e}")
@@ -71,10 +68,7 @@ class S3Client:
 
             response = self.client.head_object(Bucket=s3_bucket, Key=s3_key)
 
-            return {
-                "ETag": response.get("ETag", ""),
-                "LastModified": str(response.get("LastModified").timestamp()),
-            }
+            return self._metadata_from_response(response)
         except Exception as e:
             self.logger.error_msg(f"[{url}] exception: {e}")
             raise
@@ -108,6 +102,37 @@ class S3Client:
             Body=data,
             ContentType=content_type,
         )
+
+    @staticmethod
+    def _read_body(response: typing.Dict[str, typing.Any]) -> bytes:
+        body = response.get("Body")
+        if body is None:
+            raise Exception("S3 response missing Body")
+
+        try:
+            return typing.cast(bytes, body.read())
+        finally:
+            close = getattr(body, "close", None)
+            if callable(close):
+                close()
+
+    @staticmethod
+    def _metadata_from_response(
+        response: typing.Dict[str, typing.Any]
+    ) -> typing.Dict[str, str]:
+        etag = response.get("ETag", "")
+        metadata: typing.Dict[str, str] = {
+            "ETag": str(etag) if etag is not None else ""
+        }
+
+        last_modified = response.get("LastModified")
+        if last_modified:
+            timestamp = getattr(last_modified, "timestamp", None)
+            metadata["LastModified"] = str(
+                timestamp() if callable(timestamp) else last_modified
+            )
+
+        return metadata
 
     def put_json_stream(
         self,

--- a/src/groundx/extract/workflows.py
+++ b/src/groundx/extract/workflows.py
@@ -1,0 +1,513 @@
+import copy
+import dataclasses
+import inspect
+import typing
+from collections.abc import Mapping
+from pathlib import Path
+
+from .prompt import PreparedExtractionYaml, prepare_extraction_yaml
+
+_PERSISTED_WORKFLOW_EXTRACT_KEY = "_groundx_persisted_extract"
+_WORKFLOW_METADATA_KEY = "workflow"
+_WORKFLOW_EXTRACT_MAPPING_KIND = "workflow_extract"
+_AUTHORED_YAML_MAPPING_KIND = "authored_yaml"
+_PERSISTED_WORKFLOW_METADATA_KEYS = {
+    "metadata_version",
+    "output_routes",
+    "leaf_fields",
+    "field_counts",
+    "schema_hash",
+}
+_FIXED_DEFAULT_STEP_KEYS = (
+    "chunk-instruct",
+    "chunk-keys",
+    "chunk-summary",
+    "doc-keys",
+    "doc-summary",
+    "sect-instruct",
+    "sect-summary",
+)
+_UNRELEASED_WORKFLOW_KWARGS = (
+    "custom_steps",
+    "output_routes",
+    "leaf_fields",
+)
+_CUSTOM_STEP_ALIASES = {
+    "requiredTemplateKeys": "required_template_keys",
+}
+_OUTPUT_ROUTE_ALIASES = {
+    "workflowGroup": "workflow_group",
+    "workflowField": "workflow_field",
+    "finalPath": "final_path",
+    "stepName": "step_name",
+    "outputMap": "output_map",
+    "outputKey": "output_key",
+    "readbackPath": "readback_path",
+}
+_LEAF_FIELD_ALIASES = {
+    "finalPath": "final_path",
+    "workflowGroup": "workflow_group",
+    "workflowField": "workflow_field",
+    "stepName": "step_name",
+    "outputKey": "output_key",
+    "fieldType": "field_type",
+    "isRepeated": "is_repeated",
+    "repetitionScope": "repetition_scope",
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class ExtractionDefinition:
+    """
+    Loaded extraction workflow settings.
+    """
+
+    extract: typing.Dict[str, typing.Any]
+    prepared: typing.Optional[PreparedExtractionYaml] = None
+    template: typing.Optional[typing.Dict[str, str]] = None
+    custom_steps: typing.Optional[typing.Sequence[typing.Any]] = None
+    output_routes: typing.Optional[typing.Sequence[typing.Any]] = None
+    leaf_fields: typing.Optional[typing.Sequence[typing.Any]] = None
+    chunk_strategy: typing.Optional[typing.Any] = None
+    section_strategy: typing.Optional[typing.Any] = None
+    steps: typing.Optional[typing.Any] = None
+
+
+def load_extraction_definition_from_yaml(
+    *,
+    path: typing.Any = ...,
+    yaml_text: typing.Any = ...,
+    mapping: typing.Any = ...,
+    prepared: typing.Any = ...,
+    mapping_kind: typing.Optional[str] = None,
+) -> ExtractionDefinition:
+    source_name, source_value = _select_source(
+        path=path,
+        yaml_text=yaml_text,
+        mapping=mapping,
+        prepared=prepared,
+    )
+
+    if mapping_kind is not None and source_name != "mapping":
+        raise ValueError("mapping_kind is only valid when mapping is the selected source")
+
+    if source_name == "path":
+        raw_yaml = Path(source_value).read_text(encoding="utf-8")
+        prepared_value = prepare_extraction_yaml(raw_yaml)
+        return _definition_from_prepared(prepared_value)
+
+    if source_name == "yaml_text":
+        prepared_value = prepare_extraction_yaml(source_value)
+        return _definition_from_prepared(prepared_value)
+
+    if source_name == "prepared":
+        if not isinstance(source_value, PreparedExtractionYaml):
+            raise TypeError("prepared must be a PreparedExtractionYaml")
+        return _definition_from_prepared(source_value)
+
+    if source_name == "mapping":
+        effective_kind = mapping_kind or _AUTHORED_YAML_MAPPING_KIND
+        if effective_kind not in {_AUTHORED_YAML_MAPPING_KIND, _WORKFLOW_EXTRACT_MAPPING_KIND}:
+            raise ValueError(
+                "mapping_kind must be 'authored_yaml' or 'workflow_extract'"
+            )
+
+        mapping_value = _ensure_mapping(source_value, "mapping")
+        if effective_kind == _WORKFLOW_EXTRACT_MAPPING_KIND:
+            return _definition_from_workflow_extract(mapping_value)
+
+        if _looks_like_workflow_extract_mapping(mapping_value):
+            raise ValueError(
+                "mapping looks like an existing workflow extract; pass "
+                "mapping_kind='workflow_extract' to load it explicitly"
+            )
+        prepared_value = prepare_extraction_yaml(mapping_value)
+        return _definition_from_prepared(prepared_value)
+
+    raise AssertionError(f"unsupported source {source_name}")
+
+
+def load_extraction_definition_from_workflow_response(
+    workflow_id: str,
+    response: typing.Any,
+) -> ExtractionDefinition:
+    workflow = getattr(response, "workflow", None)
+    if workflow is None and isinstance(response, Mapping):
+        response_mapping = typing.cast(typing.Mapping[str, typing.Any], response)
+        workflow = response_mapping.get("workflow")
+    if workflow is None:
+        raise ValueError(f"workflow [{workflow_id}] response did not include a workflow")
+
+    extract = _get_workflow_value(workflow, "extract")
+    if not isinstance(extract, Mapping):
+        raise ValueError(f"workflow [{workflow_id}] does not include extraction config")
+
+    extract_mapping = _deepcopy_mapping(
+        typing.cast(typing.Mapping[str, typing.Any], extract)
+    )
+    fallback_metadata = _workflow_metadata(extract_mapping)
+
+    template = _first_present(
+        _get_workflow_value(workflow, "template"),
+        fallback_metadata.get("template"),
+    )
+    custom_steps = _first_present(
+        _get_workflow_value(workflow, "custom_steps"),
+        fallback_metadata.get("custom_steps"),
+    )
+    output_routes = _first_present(
+        _get_workflow_value(workflow, "output_routes"),
+        fallback_metadata.get("output_routes"),
+    )
+    leaf_fields = _first_present(
+        _get_workflow_value(workflow, "leaf_fields"),
+        fallback_metadata.get("leaf_fields"),
+    )
+
+    return ExtractionDefinition(
+        extract=extract_mapping,
+        prepared=_prepared_from_workflow_extract(extract_mapping),
+        template=_normalize_template(template),
+        custom_steps=_plain_metadata_sequence(custom_steps, _CUSTOM_STEP_ALIASES),
+        output_routes=_plain_metadata_sequence(output_routes, _OUTPUT_ROUTE_ALIASES),
+        leaf_fields=_plain_metadata_sequence(leaf_fields, _LEAF_FIELD_ALIASES),
+        chunk_strategy=_get_workflow_value(workflow, "chunk_strategy"),
+        section_strategy=_get_workflow_value(workflow, "section_strategy"),
+        steps=_plain_or_none(_get_workflow_value(workflow, "steps")),
+    )
+
+
+def resolve_extraction_definition_source(
+    *,
+    definition: typing.Any = ...,
+    path: typing.Any = ...,
+    yaml_text: typing.Any = ...,
+    mapping: typing.Any = ...,
+    prepared: typing.Any = ...,
+    mapping_kind: typing.Optional[str] = None,
+) -> ExtractionDefinition:
+    if definition is not ...:
+        if mapping_kind is not None:
+            raise ValueError("mapping_kind is only valid when mapping is the selected source")
+        if not isinstance(definition, ExtractionDefinition):
+            raise TypeError("definition must be an ExtractionDefinition")
+        return definition
+
+    source_name, _source_value = _select_source(
+        path=path,
+        yaml_text=yaml_text,
+        mapping=mapping,
+        prepared=prepared,
+    )
+    if mapping_kind is not None and source_name != "mapping":
+        raise ValueError("mapping_kind is only valid when mapping is the selected source")
+
+    return load_extraction_definition_from_yaml(
+        path=path,
+        yaml_text=yaml_text,
+        mapping=mapping,
+        prepared=prepared,
+        mapping_kind=mapping_kind,
+    )
+
+
+def workflow_kwargs_from_extraction_definition(
+    definition: ExtractionDefinition,
+    *,
+    name: typing.Any = ...,
+    require_name: bool = False,
+    chunk_strategy: typing.Any = ...,
+    section_strategy: typing.Any = ...,
+    steps: typing.Any = ...,
+    request_options: typing.Any = None,
+) -> typing.Dict[str, typing.Any]:
+    if require_name and (name is ... or name is None or name == ""):
+        raise ValueError("name is required when creating an extraction workflow")
+
+    kwargs: typing.Dict[str, typing.Any] = {"extract": copy.deepcopy(definition.extract)}
+    if name is not ... and name is not None:
+        kwargs["name"] = name
+
+    template = _normalize_template(definition.template)
+    if template is not None:
+        kwargs["template"] = template
+    if definition.custom_steps is not None:
+        kwargs["custom_steps"] = copy.deepcopy(definition.custom_steps)
+    if definition.output_routes is not None:
+        kwargs["output_routes"] = copy.deepcopy(definition.output_routes)
+    if definition.leaf_fields is not None:
+        kwargs["leaf_fields"] = copy.deepcopy(definition.leaf_fields)
+
+    resolved_chunk_strategy = _resolve_defaulted_value(
+        supplied=chunk_strategy,
+        preserved=definition.chunk_strategy,
+        default="element",
+    )
+    if resolved_chunk_strategy is not None:
+        kwargs["chunk_strategy"] = resolved_chunk_strategy
+
+    resolved_section_strategy = _resolve_defaulted_value(
+        supplied=section_strategy,
+        preserved=definition.section_strategy,
+        default=None,
+    )
+    if resolved_section_strategy is not None:
+        kwargs["section_strategy"] = resolved_section_strategy
+
+    resolved_steps = _resolve_defaulted_value(
+        supplied=steps,
+        preserved=definition.steps,
+        default=None,
+    )
+    if resolved_steps is None and definition.custom_steps:
+        resolved_steps = disabled_fixed_default_steps()
+    if resolved_steps is not None:
+        kwargs["steps"] = resolved_steps
+
+    if request_options is not None:
+        kwargs["request_options"] = request_options
+
+    return kwargs
+
+
+def ensure_workflow_method_supports_kwargs(
+    method: typing.Any,
+    kwargs: typing.Mapping[str, typing.Any],
+) -> None:
+    unsupported = [
+        key for key in _UNRELEASED_WORKFLOW_KWARGS
+        if key in kwargs and not _method_accepts_keyword(method, key)
+    ]
+    if unsupported:
+        unsupported_list = ", ".join(unsupported)
+        raise RuntimeError(
+            "This GroundX SDK build cannot create or update extraction "
+            "workflows with custom workflow steps yet. Regenerate and publish "
+            "the SDK from the Fern/OpenAPI schema before using: "
+            f"{unsupported_list}."
+        )
+
+
+def disabled_fixed_default_steps() -> typing.Dict[str, None]:
+    return {field: None for field in _FIXED_DEFAULT_STEP_KEYS}
+
+
+def _definition_from_prepared(prepared: PreparedExtractionYaml) -> ExtractionDefinition:
+    extract = copy.deepcopy(prepared.persisted_workflow_extract)
+    metadata = _workflow_metadata(extract)
+    return ExtractionDefinition(
+        extract=extract,
+        prepared=prepared,
+        template=_normalize_template(metadata.get("template")),
+        custom_steps=_plain_metadata_sequence(
+            metadata.get("custom_steps"),
+            _CUSTOM_STEP_ALIASES,
+        ),
+        output_routes=_plain_metadata_sequence(
+            metadata.get("output_routes"),
+            _OUTPUT_ROUTE_ALIASES,
+        ),
+        leaf_fields=_plain_metadata_sequence(
+            metadata.get("leaf_fields"),
+            _LEAF_FIELD_ALIASES,
+        ),
+    )
+
+
+def _definition_from_workflow_extract(
+    extract: typing.Mapping[str, typing.Any],
+) -> ExtractionDefinition:
+    extract_mapping = _deepcopy_mapping(extract)
+    metadata = _workflow_metadata(extract_mapping)
+    return ExtractionDefinition(
+        extract=extract_mapping,
+        prepared=_prepared_from_workflow_extract(extract_mapping),
+        template=_normalize_template(metadata.get("template")),
+        custom_steps=_plain_metadata_sequence(
+            metadata.get("custom_steps"),
+            _CUSTOM_STEP_ALIASES,
+        ),
+        output_routes=_plain_metadata_sequence(
+            metadata.get("output_routes"),
+            _OUTPUT_ROUTE_ALIASES,
+        ),
+        leaf_fields=_plain_metadata_sequence(
+            metadata.get("leaf_fields"),
+            _LEAF_FIELD_ALIASES,
+        ),
+    )
+
+
+def _prepared_from_workflow_extract(
+    extract: typing.Mapping[str, typing.Any],
+) -> typing.Optional[PreparedExtractionYaml]:
+    if _PERSISTED_WORKFLOW_EXTRACT_KEY not in extract:
+        return None
+    return prepare_extraction_yaml(extract)
+
+
+def _select_source(**sources: typing.Any) -> typing.Tuple[str, typing.Any]:
+    selected = [(name, value) for name, value in sources.items() if value is not ...]
+    if len(selected) != 1:
+        source_names = ", ".join(sources.keys())
+        if not selected:
+            raise ValueError(f"expected exactly one source: {source_names}")
+        conflicts = ", ".join(name for name, _value in selected)
+        raise ValueError(
+            f"expected exactly one source from {source_names}; received {conflicts}"
+        )
+    return selected[0]
+
+
+def _looks_like_workflow_extract_mapping(
+    mapping: typing.Mapping[str, typing.Any],
+) -> bool:
+    workflow = mapping.get(_WORKFLOW_METADATA_KEY)
+    if not isinstance(workflow, Mapping):
+        return _PERSISTED_WORKFLOW_EXTRACT_KEY in mapping
+    workflow_mapping = typing.cast(typing.Mapping[str, typing.Any], workflow)
+    return bool(set(workflow_mapping.keys()) & _PERSISTED_WORKFLOW_METADATA_KEYS)
+
+
+def _workflow_metadata(
+    extract: typing.Mapping[str, typing.Any],
+) -> typing.Mapping[str, typing.Any]:
+    metadata = extract.get(_WORKFLOW_METADATA_KEY)
+    if isinstance(metadata, Mapping):
+        return typing.cast(typing.Mapping[str, typing.Any], metadata)
+    return {}
+
+
+def _normalize_template(value: typing.Any) -> typing.Optional[typing.Dict[str, str]]:
+    if value is None:
+        return None
+    mapping = _ensure_any_mapping(value, "template")
+    template: typing.Dict[str, str] = {}
+    for key, template_value in mapping.items():
+        if not isinstance(key, str):
+            raise ValueError("workflow template keys must be strings")
+        if not isinstance(template_value, str):
+            raise ValueError(
+                f"workflow template value for [{key}] must be a string"
+            )
+        template[key] = template_value
+    return template or None
+
+
+def _ensure_mapping(
+    value: typing.Any,
+    name: str,
+) -> typing.Mapping[str, typing.Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{name} must be a mapping")
+    return typing.cast(typing.Mapping[str, typing.Any], value)
+
+
+def _ensure_any_mapping(
+    value: typing.Any,
+    name: str,
+) -> typing.Mapping[typing.Any, typing.Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{name} must be a mapping")
+    return typing.cast(typing.Mapping[typing.Any, typing.Any], value)
+
+
+def _deepcopy_mapping(
+    value: typing.Mapping[str, typing.Any],
+) -> typing.Dict[str, typing.Any]:
+    return copy.deepcopy(dict(value))
+
+
+def _plain_sequence(value: typing.Any) -> typing.Optional[typing.Sequence[typing.Any]]:
+    if value is None:
+        return None
+    return typing.cast(typing.Sequence[typing.Any], _plain_or_none(value))
+
+
+def _plain_metadata_sequence(
+    value: typing.Any,
+    aliases: typing.Mapping[str, str],
+) -> typing.Optional[typing.Sequence[typing.Any]]:
+    sequence = _plain_sequence(value)
+    if sequence is None:
+        return None
+    return [_normalize_mapping_aliases(item, aliases) for item in sequence]
+
+
+def _plain_or_none(value: typing.Any) -> typing.Any:
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        mapping = typing.cast(typing.Mapping[typing.Any, typing.Any], value)
+        return {key: _plain_or_none(item) for key, item in mapping.items()}
+    if isinstance(value, (list, tuple)):
+        sequence = typing.cast(typing.Sequence[typing.Any], value)
+        return [_plain_or_none(item) for item in sequence]
+    if hasattr(value, "model_dump"):
+        return value.model_dump(
+            by_alias=False,
+            exclude_none=True,
+            exclude_unset=True,
+        )
+    if hasattr(value, "dict"):
+        return value.dict(by_alias=False, exclude_none=True, exclude_unset=True)
+    return copy.deepcopy(value)
+
+
+def _normalize_mapping_aliases(
+    value: typing.Any,
+    aliases: typing.Mapping[str, str],
+) -> typing.Any:
+    if isinstance(value, Mapping):
+        mapping = typing.cast(typing.Mapping[typing.Any, typing.Any], value)
+        return {
+            aliases.get(key, key): _normalize_mapping_aliases(item, aliases)
+            for key, item in mapping.items()
+        }
+    if isinstance(value, (list, tuple)):
+        sequence = typing.cast(typing.Sequence[typing.Any], value)
+        return [_normalize_mapping_aliases(item, aliases) for item in sequence]
+    return value
+
+
+def _get_workflow_value(workflow: typing.Any, name: str) -> typing.Any:
+    if isinstance(workflow, Mapping):
+        workflow_mapping = typing.cast(typing.Mapping[str, typing.Any], workflow)
+        return workflow_mapping.get(name)
+    return getattr(workflow, name, None)
+
+
+def _first_present(*values: typing.Any) -> typing.Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _resolve_defaulted_value(
+    *,
+    supplied: typing.Any,
+    preserved: typing.Any,
+    default: typing.Any,
+) -> typing.Any:
+    if supplied is not ...:
+        return supplied
+    if preserved is not None:
+        return preserved
+    return default
+
+
+def _method_accepts_keyword(method: typing.Any, key: str) -> bool:
+    try:
+        signature = inspect.signature(method)
+    except (TypeError, ValueError):
+        return False
+    for parameter in signature.parameters.values():
+        if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+        if parameter.kind in {
+            inspect.Parameter.KEYWORD_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        } and parameter.name == key:
+            return True
+    return False

--- a/src/groundx/ingest.py
+++ b/src/groundx/ingest.py
@@ -1,15 +1,18 @@
-import requests, time, typing, os
+import os
+import time
+import typing
 from pathlib import Path
-from tqdm import tqdm
 from urllib.parse import urlparse, urlunparse
 
-from .client import GroundXBase, AsyncGroundXBase
+import requests
+from .client import AsyncGroundXBase, GroundXBase
 from .core.request_options import RequestOptions
 from .csv_splitter import CSVSplitter
 from .types.document import Document
 from .types.ingest_remote_document import IngestRemoteDocument
 from .types.ingest_response import IngestResponse
 from .types.ingest_status import IngestStatus
+from tqdm import tqdm
 
 # this is used as the default value for optional parameters
 OMIT = typing.cast(typing.Any, ...)
@@ -59,6 +62,52 @@ SUFFIX_ALIASES = {
 MAX_BATCH_SIZE = 50
 MIN_BATCH_SIZE = 1
 MAX_BATCH_SIZE_BYTES = 50 * 1024 * 1024
+
+
+def _import_extraction_workflows() -> typing.Any:
+    try:
+        from .extract import workflows as extraction_workflows
+    except ImportError as exc:
+        raise ImportError(
+            "Extraction workflow helpers require the extract extra. Install it with `pip install groundx[extract]`."
+        ) from exc
+
+    return extraction_workflows
+
+
+def _select_extraction_definition_loader_source(
+    *,
+    workflow_id: typing.Any,
+    path: typing.Any,
+    yaml_text: typing.Any,
+    mapping: typing.Any,
+    prepared: typing.Any,
+    mapping_kind: typing.Optional[str],
+    request_options: typing.Optional[RequestOptions],
+) -> str:
+    yaml_sources = {
+        "path": path,
+        "yaml_text": yaml_text,
+        "mapping": mapping,
+        "prepared": prepared,
+    }
+    if workflow_id is not OMIT:
+        if mapping_kind is not None:
+            raise ValueError("mapping_kind is only valid when mapping is the selected source")
+        return "workflow_id"
+
+    selected = [name for name, value in yaml_sources.items() if value is not OMIT]
+    if len(selected) != 1:
+        source_names = ", ".join(("workflow_id", *yaml_sources.keys()))
+        if not selected:
+            raise ValueError(f"expected exactly one source: {source_names}")
+        conflicts = ", ".join(selected)
+        raise ValueError(f"expected exactly one YAML source from {source_names}; received {conflicts}")
+    if mapping_kind is not None and selected[0] != "mapping":
+        raise ValueError("mapping_kind is only valid when mapping is the selected source")
+    if request_options is not None:
+        raise ValueError("request_options is only valid when workflow_id is selected")
+    return selected[0]
 
 
 def get_presigned_url(
@@ -132,9 +181,7 @@ def prep_documents(
 
 
 def split_doc(file: Path) -> typing.List[Path]:
-    if file.is_file() and (
-        file.suffix.lower() in ALLOWED_SUFFIXES or file.suffix.lower() in SUFFIX_ALIASES
-    ):
+    if file.is_file() and (file.suffix.lower() in ALLOWED_SUFFIXES or file.suffix.lower() in SUFFIX_ALIASES):
         if file.suffix.lower() in CSV_SPLITS:
             return CSVSplitter(filepath=file).split()
         elif file.suffix.lower() in TSV_SPLITS:
@@ -144,6 +191,380 @@ def split_doc(file: Path) -> typing.List[Path]:
 
 
 class GroundX(GroundXBase):
+    def load_extraction_definition(
+        self,
+        *,
+        workflow_id: typing.Any = OMIT,
+        path: typing.Any = OMIT,
+        yaml_text: typing.Any = OMIT,
+        mapping: typing.Any = OMIT,
+        prepared: typing.Any = OMIT,
+        mapping_kind: typing.Optional[str] = None,
+        request_options: typing.Optional[RequestOptions] = None,
+    ) -> typing.Any:
+        """
+        Load an extraction definition from YAML/prepared input or an existing workflow ID.
+
+        Extraction workflow helpers require the extract extra:
+        `pip install groundx[extract]`.
+
+        Parameters
+        ----------
+        workflow_id : typing.Any
+            Existing GroundX workflow ID to load.
+        path : typing.Any
+            Path to an authored extraction YAML file. This is the common
+            application path.
+        yaml_text : typing.Any
+            Authored extraction YAML as a string.
+        mapping : typing.Any
+            Authored extraction YAML as a mapping, or an existing workflow
+            extract mapping when `mapping_kind="workflow_extract"` is set.
+        prepared : typing.Any
+            A `PreparedExtractionYaml` returned by `prepare_extraction_yaml`.
+        mapping_kind : typing.Optional[str]
+            Use `"workflow_extract"` only when `mapping` is an existing workflow
+            extract payload. Omit it for authored YAML-shaped mappings.
+        request_options : typing.Optional[RequestOptions]
+            Request-specific configuration forwarded to the generated workflow
+            client. Valid only with `workflow_id`.
+
+        Returns
+        -------
+        typing.Any
+            An `ExtractionDefinition`.
+
+        Examples
+        --------
+        >>> definition = client.load_extraction_definition(path="statement.yaml")
+        >>> existing = client.load_extraction_definition(workflow_id="workflow-id")
+
+        Notes
+        -----
+        When `workflow_id` is provided, it takes precedence over YAML/prepared
+        inputs. Otherwise pass exactly one of `path`, `yaml_text`, `mapping`, or
+        `prepared`.
+        """
+        selected = _select_extraction_definition_loader_source(
+            workflow_id=workflow_id,
+            path=path,
+            yaml_text=yaml_text,
+            mapping=mapping,
+            prepared=prepared,
+            mapping_kind=mapping_kind,
+            request_options=request_options,
+        )
+        if selected == "workflow_id":
+            return self.load_extraction_definition_from_workflow(
+                typing.cast(str, workflow_id),
+                request_options=request_options,
+            )
+        return self.load_extraction_definition_from_yaml(
+            path=path,
+            yaml_text=yaml_text,
+            mapping=mapping,
+            prepared=prepared,
+            mapping_kind=mapping_kind,
+        )
+
+    def load_extraction_definition_from_yaml(
+        self,
+        *,
+        path: typing.Any = OMIT,
+        yaml_text: typing.Any = OMIT,
+        mapping: typing.Any = OMIT,
+        prepared: typing.Any = OMIT,
+        mapping_kind: typing.Optional[str] = None,
+    ) -> typing.Any:
+        """
+        Load an extraction definition from a YAML path, YAML text, mapping, or prepared object.
+
+        Extraction workflow helpers require the extract extra:
+        `pip install groundx[extract]`.
+
+        Parameters
+        ----------
+        path : typing.Any
+            Path to an authored extraction YAML file. This is the common
+            application path.
+        yaml_text : typing.Any
+            Authored extraction YAML as a string.
+        mapping : typing.Any
+            Authored extraction YAML as a mapping, or an existing workflow
+            extract mapping when `mapping_kind="workflow_extract"` is set.
+        prepared : typing.Any
+            A `PreparedExtractionYaml` returned by `prepare_extraction_yaml`.
+        mapping_kind : typing.Optional[str]
+            Use `"workflow_extract"` only when `mapping` is an existing workflow
+            extract payload. Omit it for authored YAML-shaped mappings.
+
+        Returns
+        -------
+        typing.Any
+            An `ExtractionDefinition` containing the persisted workflow extract
+            and workflow-level settings such as template, custom steps, output
+            routes, and leaf fields.
+
+        Examples
+        --------
+        >>> definition = client.load_extraction_definition_from_yaml(path="statement.yaml")
+
+        Prefer `load_extraction_definition(...)` for new code when the source
+        may be either YAML or an existing workflow ID.
+        """
+        extraction_workflows = _import_extraction_workflows()
+        return extraction_workflows.load_extraction_definition_from_yaml(
+            path=path,
+            yaml_text=yaml_text,
+            mapping=mapping,
+            prepared=prepared,
+            mapping_kind=mapping_kind,
+        )
+
+    def load_extraction_definition_from_workflow(
+        self,
+        workflow_id: str,
+        *,
+        request_options: typing.Optional[RequestOptions] = None,
+    ) -> typing.Any:
+        """
+        Load an extraction definition from an existing workflow ID.
+
+        Extraction workflow helpers require the extract extra:
+        `pip install groundx[extract]`.
+
+        Parameters
+        ----------
+        workflow_id : str
+            Existing GroundX workflow ID.
+        request_options : typing.Optional[RequestOptions]
+            Request-specific configuration forwarded to the generated workflow
+            client.
+
+        Returns
+        -------
+        typing.Any
+            An `ExtractionDefinition` loaded from the workflow response.
+            Workflows that only contain execution-ready extract JSON return a
+            definition with `prepared=None`.
+
+        Examples
+        --------
+        >>> definition = client.load_extraction_definition_from_workflow("workflow-id")
+
+        Prefer `load_extraction_definition(workflow_id=...)` for new code when
+        the source may be either YAML or an existing workflow ID.
+
+        Notes
+        -----
+        Workflows that only contain execution-ready extract JSON return a
+        definition with `prepared=None`; the create/update payload remains
+        reusable, but authored YAML metadata is unavailable.
+        """
+        extraction_workflows = _import_extraction_workflows()
+        response = self.workflows.get(workflow_id, request_options=request_options)
+        return extraction_workflows.load_extraction_definition_from_workflow_response(
+            workflow_id,
+            response,
+        )
+
+    def create_extraction_workflow(
+        self,
+        *,
+        definition: typing.Any = OMIT,
+        path: typing.Any = OMIT,
+        yaml_text: typing.Any = OMIT,
+        mapping: typing.Any = OMIT,
+        prepared: typing.Any = OMIT,
+        mapping_kind: typing.Optional[str] = None,
+        name: typing.Optional[str] = None,
+        chunk_strategy: typing.Any = OMIT,
+        section_strategy: typing.Any = OMIT,
+        steps: typing.Any = OMIT,
+        request_options: typing.Optional[RequestOptions] = None,
+    ) -> typing.Any:
+        """
+        Create an extraction workflow from a definition or YAML/prepared source.
+
+        Extraction workflow helpers require the extract extra:
+        `pip install groundx[extract]`.
+
+        Parameters
+        ----------
+        definition : typing.Any
+            An `ExtractionDefinition` returned by an extraction definition
+            loader.
+        path : typing.Any
+            Path to an authored extraction YAML file.
+        yaml_text : typing.Any
+            Authored extraction YAML as a string.
+        mapping : typing.Any
+            Authored YAML-shaped mapping, or a workflow extract mapping when
+            `mapping_kind="workflow_extract"` is set.
+        prepared : typing.Any
+            A `PreparedExtractionYaml` returned by `prepare_extraction_yaml`.
+        mapping_kind : typing.Optional[str]
+            Use `"workflow_extract"` only when `mapping` is an existing workflow
+            extract payload.
+        name : typing.Optional[str]
+            Workflow name. Required for create.
+        chunk_strategy : typing.Any
+            Optional workflow chunk strategy override.
+        section_strategy : typing.Any
+            Optional workflow section strategy override.
+        steps : typing.Any
+            Optional fixed workflow step overlay. When omitted and the
+            definition has custom steps, fixed default extraction steps are
+            disabled.
+        request_options : typing.Optional[RequestOptions]
+            Request-specific configuration forwarded to the generated workflow
+            client.
+
+        Returns
+        -------
+        typing.Any
+            The generated workflow create response.
+
+        Examples
+        --------
+        >>> workflow = client.create_extraction_workflow(
+        ...     path="statement.yaml",
+        ...     name="statement extraction",
+        ... )
+        >>> client.workflows.add_to_id(id=bucket_id, workflow_id=workflow.workflow.workflow_id)
+
+        Notes
+        -----
+        This delegates to `client.workflows.create(...)` after loading the
+        extraction definition and copying workflow template/custom-step settings.
+        If `definition` is provided, it takes precedence over YAML/prepared
+        inputs. Otherwise pass exactly one of `path`, `yaml_text`, `mapping`, or
+        `prepared`.
+        Assign the returned workflow to a bucket, group, or account explicitly.
+        """
+        extraction_workflows = _import_extraction_workflows()
+        resolved = extraction_workflows.resolve_extraction_definition_source(
+            definition=definition,
+            path=path,
+            yaml_text=yaml_text,
+            mapping=mapping,
+            prepared=prepared,
+            mapping_kind=mapping_kind,
+        )
+        kwargs = extraction_workflows.workflow_kwargs_from_extraction_definition(
+            resolved,
+            name=name,
+            require_name=True,
+            chunk_strategy=chunk_strategy,
+            section_strategy=section_strategy,
+            steps=steps,
+            request_options=request_options,
+        )
+        extraction_workflows.ensure_workflow_method_supports_kwargs(
+            self.workflows.create,
+            kwargs,
+        )
+        return self.workflows.create(**kwargs)
+
+    def update_extraction_workflow(
+        self,
+        workflow_id: str,
+        *,
+        definition: typing.Any = OMIT,
+        path: typing.Any = OMIT,
+        yaml_text: typing.Any = OMIT,
+        mapping: typing.Any = OMIT,
+        prepared: typing.Any = OMIT,
+        mapping_kind: typing.Optional[str] = None,
+        name: typing.Any = OMIT,
+        chunk_strategy: typing.Any = OMIT,
+        section_strategy: typing.Any = OMIT,
+        steps: typing.Any = OMIT,
+        request_options: typing.Optional[RequestOptions] = None,
+    ) -> typing.Any:
+        """
+        Update an extraction workflow from a definition or YAML/prepared source.
+
+        Extraction workflow helpers require the extract extra:
+        `pip install groundx[extract]`.
+
+        Parameters
+        ----------
+        workflow_id : str
+            Existing workflow ID to update.
+        definition : typing.Any
+            An `ExtractionDefinition` returned by an extraction definition
+            loader.
+        path : typing.Any
+            Path to an authored extraction YAML file.
+        yaml_text : typing.Any
+            Authored extraction YAML as a string.
+        mapping : typing.Any
+            Authored YAML-shaped mapping, or a workflow extract mapping when
+            `mapping_kind="workflow_extract"` is set.
+        prepared : typing.Any
+            A `PreparedExtractionYaml` returned by `prepare_extraction_yaml`.
+        mapping_kind : typing.Optional[str]
+            Use `"workflow_extract"` only when `mapping` is an existing workflow
+            extract payload.
+        name : typing.Any
+            Optional workflow name to send with the full update payload.
+        chunk_strategy : typing.Any
+            Optional workflow chunk strategy override.
+        section_strategy : typing.Any
+            Optional workflow section strategy override.
+        steps : typing.Any
+            Optional fixed workflow step overlay. When omitted and the
+            definition has custom steps, fixed default extraction steps are
+            disabled.
+        request_options : typing.Optional[RequestOptions]
+            Request-specific configuration forwarded to the generated workflow
+            client.
+
+        Returns
+        -------
+        typing.Any
+            The generated workflow update response.
+
+        Examples
+        --------
+        >>> client.update_extraction_workflow(
+        ...     "workflow-id",
+        ...     path="statement.yaml",
+        ...     name="statement extraction",
+        ... )
+
+        Notes
+        -----
+        Update sends the full extraction workflow settings, not a patch. Pass
+        the YAML or definition again so custom workflow settings are preserved.
+        If `definition` is provided, it takes precedence over YAML/prepared
+        inputs. Otherwise pass exactly one of `path`, `yaml_text`, `mapping`, or
+        `prepared`.
+        """
+        extraction_workflows = _import_extraction_workflows()
+        resolved = extraction_workflows.resolve_extraction_definition_source(
+            definition=definition,
+            path=path,
+            yaml_text=yaml_text,
+            mapping=mapping,
+            prepared=prepared,
+            mapping_kind=mapping_kind,
+        )
+        kwargs = extraction_workflows.workflow_kwargs_from_extraction_definition(
+            resolved,
+            name=name,
+            chunk_strategy=chunk_strategy,
+            section_strategy=section_strategy,
+            steps=steps,
+            request_options=request_options,
+        )
+        extraction_workflows.ensure_workflow_method_supports_kwargs(
+            self.workflows.update,
+            kwargs,
+        )
+        return self.workflows.update(workflow_id, **kwargs)
+
     def ingest(
         self,
         *,
@@ -226,9 +647,7 @@ class GroundX(GroundXBase):
                 n = max(MIN_BATCH_SIZE, min(batch_size or MIN_BATCH_SIZE, max_n))
 
                 remote_batch: typing.List[IngestRemoteDocument] = []
-                ingest = IngestResponse(
-                    ingest=IngestStatus(process_id="", status="queued")
-                )
+                ingest = IngestResponse(ingest=IngestStatus(process_id="", status="queued"))
 
                 progress = float(len(remote_documents))
                 for rd in remote_documents:
@@ -267,12 +686,8 @@ class GroundX(GroundXBase):
                     fp = Path(os.path.expanduser(ld.file_path))
                     file_size = fp.stat().st_size
 
-                    if (current_batch_size + file_size > MAX_BATCH_SIZE_BYTES) or (
-                        len(local_batch) >= n
-                    ):
-                        up_docs, progress = self._process_local(
-                            local_batch, upload_api, progress, pbar
-                        )
+                    if (current_batch_size + file_size > MAX_BATCH_SIZE_BYTES) or (len(local_batch) >= n):
+                        up_docs, progress = self._process_local(local_batch, upload_api, progress, pbar)
 
                         ingest = self.documents.ingest_remote(
                             documents=up_docs,
@@ -289,9 +704,7 @@ class GroundX(GroundXBase):
                     current_batch_size += file_size
 
                 if local_batch:
-                    up_docs, progress = self._process_local(
-                        local_batch, upload_api, progress, pbar
-                    )
+                    up_docs, progress = self._process_local(local_batch, upload_api, progress, pbar)
 
                     ingest = self.documents.ingest_remote(
                         documents=up_docs,
@@ -410,9 +823,7 @@ class GroundX(GroundXBase):
             for file in files:
                 file_size = file.stat().st_size
 
-                if (current_batch_size + file_size > MAX_BATCH_SIZE_BYTES) or (
-                    len(current_batch) >= n
-                ):
+                if (current_batch_size + file_size > MAX_BATCH_SIZE_BYTES) or (len(current_batch) >= n):
                     self._upload_file_batch(
                         bucket_id,
                         current_batch,
@@ -472,9 +883,7 @@ class GroundX(GroundXBase):
             raise ValueError(f"Unsupported HTTP method: {method}")
 
         if upload_response.status_code not in (200, 201):
-            raise Exception(
-                f"Upload failed: {upload_response.status_code} - {upload_response.text}"
-            )
+            raise Exception(f"Upload failed: {upload_response.status_code} - {upload_response.text}")
 
         if "GX-HOSTED-URL" in headers:
             return headers["GX-HOSTED-URL"]
@@ -531,56 +940,30 @@ class GroundX(GroundXBase):
 
         while ingest.ingest.status not in ["complete", "error", "cancelled"]:
             time.sleep(3)
-            ingest = self.documents.get_processing_status_by_id(
-                ingest.ingest.process_id
-            )
+            ingest = self.documents.get_processing_status_by_id(ingest.ingest.process_id)
 
             if ingest.ingest.progress:
-                if (
-                    ingest.ingest.progress.processing
-                    and ingest.ingest.progress.processing.documents
-                ):
+                if ingest.ingest.progress.processing and ingest.ingest.progress.processing.documents:
                     for doc in ingest.ingest.progress.processing.documents:
-                        if (
-                            doc.status in ["complete", "error", "cancelled"]
-                            and doc.document_id not in completed_files
-                        ):
+                        if doc.status in ["complete", "error", "cancelled"] and doc.document_id not in completed_files:
                             pbar.update(0.75)
                             progress -= 0.75
                             completed_files.add(doc.document_id)
-                if (
-                    ingest.ingest.progress.complete
-                    and ingest.ingest.progress.complete.documents
-                ):
+                if ingest.ingest.progress.complete and ingest.ingest.progress.complete.documents:
                     for doc in ingest.ingest.progress.complete.documents:
-                        if (
-                            doc.status in ["complete", "error", "cancelled"]
-                            and doc.document_id not in completed_files
-                        ):
+                        if doc.status in ["complete", "error", "cancelled"] and doc.document_id not in completed_files:
                             pbar.update(0.75)
                             progress -= 0.75
                             completed_files.add(doc.document_id)
-                if (
-                    ingest.ingest.progress.cancelled
-                    and ingest.ingest.progress.cancelled.documents
-                ):
+                if ingest.ingest.progress.cancelled and ingest.ingest.progress.cancelled.documents:
                     for doc in ingest.ingest.progress.cancelled.documents:
-                        if (
-                            doc.status in ["complete", "error", "cancelled"]
-                            and doc.document_id not in completed_files
-                        ):
+                        if doc.status in ["complete", "error", "cancelled"] and doc.document_id not in completed_files:
                             pbar.update(0.75)
                             progress -= 0.75
                             completed_files.add(doc.document_id)
-                if (
-                    ingest.ingest.progress.errors
-                    and ingest.ingest.progress.errors.documents
-                ):
+                if ingest.ingest.progress.errors and ingest.ingest.progress.errors.documents:
                     for doc in ingest.ingest.progress.errors.documents:
-                        if (
-                            doc.status in ["complete", "error", "cancelled"]
-                            and doc.document_id not in completed_files
-                        ):
+                        if doc.status in ["complete", "error", "cancelled"] and doc.document_id not in completed_files:
                             pbar.update(0.75)
                             progress -= 0.75
                             completed_files.add(doc.document_id)
@@ -639,6 +1022,345 @@ class GroundX(GroundXBase):
 
 
 class AsyncGroundX(AsyncGroundXBase):
+    async def load_extraction_definition(
+        self,
+        *,
+        workflow_id: typing.Any = OMIT,
+        path: typing.Any = OMIT,
+        yaml_text: typing.Any = OMIT,
+        mapping: typing.Any = OMIT,
+        prepared: typing.Any = OMIT,
+        mapping_kind: typing.Optional[str] = None,
+        request_options: typing.Optional[RequestOptions] = None,
+    ) -> typing.Any:
+        """
+        Load an extraction definition from YAML/prepared input or an existing workflow ID.
+
+        Parameters
+        ----------
+        workflow_id : typing.Any
+            Existing GroundX workflow ID to load.
+        path : typing.Any
+            Path to an authored extraction YAML file.
+        yaml_text : typing.Any
+            Authored extraction YAML as a string.
+        mapping : typing.Any
+            Authored extraction YAML as a mapping, or an existing workflow
+            extract mapping when `mapping_kind="workflow_extract"` is set.
+        prepared : typing.Any
+            A `PreparedExtractionYaml` returned by `prepare_extraction_yaml`.
+        mapping_kind : typing.Optional[str]
+            Use `"workflow_extract"` only when `mapping` is an existing workflow
+            extract payload.
+        request_options : typing.Optional[RequestOptions]
+            Request-specific configuration forwarded to the generated workflow
+            client. Valid only with `workflow_id`.
+
+        Returns
+        -------
+        typing.Any
+            An `ExtractionDefinition`.
+
+        Examples
+        --------
+        >>> definition = await client.load_extraction_definition(path="statement.yaml")
+        >>> existing = await client.load_extraction_definition(workflow_id="workflow-id")
+
+        Notes
+        -----
+        When `workflow_id` is provided, it takes precedence over YAML/prepared
+        inputs. Otherwise pass exactly one of `path`, `yaml_text`, `mapping`, or
+        `prepared`.
+        """
+        selected = _select_extraction_definition_loader_source(
+            workflow_id=workflow_id,
+            path=path,
+            yaml_text=yaml_text,
+            mapping=mapping,
+            prepared=prepared,
+            mapping_kind=mapping_kind,
+            request_options=request_options,
+        )
+        if selected == "workflow_id":
+            return await self.load_extraction_definition_from_workflow(
+                typing.cast(str, workflow_id),
+                request_options=request_options,
+            )
+        return await self.load_extraction_definition_from_yaml(
+            path=path,
+            yaml_text=yaml_text,
+            mapping=mapping,
+            prepared=prepared,
+            mapping_kind=mapping_kind,
+        )
+
+    async def load_extraction_definition_from_yaml(
+        self,
+        *,
+        path: typing.Any = OMIT,
+        yaml_text: typing.Any = OMIT,
+        mapping: typing.Any = OMIT,
+        prepared: typing.Any = OMIT,
+        mapping_kind: typing.Optional[str] = None,
+    ) -> typing.Any:
+        """
+        Load an extraction definition from a YAML path, YAML text, mapping, or prepared object.
+
+        Parameters
+        ----------
+        path : typing.Any
+            Path to an authored extraction YAML file.
+        yaml_text : typing.Any
+            Authored extraction YAML as a string.
+        mapping : typing.Any
+            Authored extraction YAML as a mapping, or an existing workflow
+            extract mapping when `mapping_kind="workflow_extract"` is set.
+        prepared : typing.Any
+            A `PreparedExtractionYaml` returned by `prepare_extraction_yaml`.
+        mapping_kind : typing.Optional[str]
+            Use `"workflow_extract"` only when `mapping` is an existing workflow
+            extract payload.
+
+        Returns
+        -------
+        typing.Any
+            An `ExtractionDefinition`.
+
+        Examples
+        --------
+        >>> definition = await client.load_extraction_definition_from_yaml(path="statement.yaml")
+
+        Prefer `load_extraction_definition(...)` for new code when the source
+        may be either YAML or an existing workflow ID.
+        """
+        extraction_workflows = _import_extraction_workflows()
+        return extraction_workflows.load_extraction_definition_from_yaml(
+            path=path,
+            yaml_text=yaml_text,
+            mapping=mapping,
+            prepared=prepared,
+            mapping_kind=mapping_kind,
+        )
+
+    async def load_extraction_definition_from_workflow(
+        self,
+        workflow_id: str,
+        *,
+        request_options: typing.Optional[RequestOptions] = None,
+    ) -> typing.Any:
+        """
+        Load an extraction definition from an existing workflow ID.
+
+        Parameters
+        ----------
+        workflow_id : str
+            Existing GroundX workflow ID.
+        request_options : typing.Optional[RequestOptions]
+            Request-specific configuration forwarded to the generated workflow
+            client.
+
+        Returns
+        -------
+        typing.Any
+            An `ExtractionDefinition` loaded from the workflow response.
+
+        Examples
+        --------
+        >>> definition = await client.load_extraction_definition_from_workflow("workflow-id")
+
+        Prefer `load_extraction_definition(workflow_id=...)` for new code when
+        the source may be either YAML or an existing workflow ID.
+        """
+        extraction_workflows = _import_extraction_workflows()
+        response = await self.workflows.get(
+            workflow_id,
+            request_options=request_options,
+        )
+        return extraction_workflows.load_extraction_definition_from_workflow_response(
+            workflow_id,
+            response,
+        )
+
+    async def create_extraction_workflow(
+        self,
+        *,
+        definition: typing.Any = OMIT,
+        path: typing.Any = OMIT,
+        yaml_text: typing.Any = OMIT,
+        mapping: typing.Any = OMIT,
+        prepared: typing.Any = OMIT,
+        mapping_kind: typing.Optional[str] = None,
+        name: typing.Optional[str] = None,
+        chunk_strategy: typing.Any = OMIT,
+        section_strategy: typing.Any = OMIT,
+        steps: typing.Any = OMIT,
+        request_options: typing.Optional[RequestOptions] = None,
+    ) -> typing.Any:
+        """
+        Create an extraction workflow from a definition or YAML/prepared source.
+
+        Parameters
+        ----------
+        definition : typing.Any
+            An `ExtractionDefinition` returned by an extraction definition
+            loader.
+        path : typing.Any
+            Path to an authored extraction YAML file.
+        yaml_text : typing.Any
+            Authored extraction YAML as a string.
+        mapping : typing.Any
+            Authored YAML-shaped mapping, or a workflow extract mapping when
+            `mapping_kind="workflow_extract"` is set.
+        prepared : typing.Any
+            A `PreparedExtractionYaml` returned by `prepare_extraction_yaml`.
+        mapping_kind : typing.Optional[str]
+            Use `"workflow_extract"` only when `mapping` is an existing workflow
+            extract payload.
+        name : typing.Optional[str]
+            Workflow name. Required for create.
+        chunk_strategy : typing.Any
+            Optional workflow chunk strategy override.
+        section_strategy : typing.Any
+            Optional workflow section strategy override.
+        steps : typing.Any
+            Optional fixed workflow step overlay.
+        request_options : typing.Optional[RequestOptions]
+            Request-specific configuration forwarded to the generated workflow
+            client.
+
+        Returns
+        -------
+        typing.Any
+            The generated workflow create response.
+
+        Examples
+        --------
+        >>> workflow = await client.create_extraction_workflow(
+        ...     path="statement.yaml",
+        ...     name="statement extraction",
+        ... )
+
+        If `definition` is provided, it takes precedence over YAML/prepared
+        inputs. Otherwise pass exactly one of `path`, `yaml_text`, `mapping`, or
+        `prepared`.
+        """
+        extraction_workflows = _import_extraction_workflows()
+        resolved = extraction_workflows.resolve_extraction_definition_source(
+            definition=definition,
+            path=path,
+            yaml_text=yaml_text,
+            mapping=mapping,
+            prepared=prepared,
+            mapping_kind=mapping_kind,
+        )
+        kwargs = extraction_workflows.workflow_kwargs_from_extraction_definition(
+            resolved,
+            name=name,
+            require_name=True,
+            chunk_strategy=chunk_strategy,
+            section_strategy=section_strategy,
+            steps=steps,
+            request_options=request_options,
+        )
+        extraction_workflows.ensure_workflow_method_supports_kwargs(
+            self.workflows.create,
+            kwargs,
+        )
+        return await self.workflows.create(**kwargs)
+
+    async def update_extraction_workflow(
+        self,
+        workflow_id: str,
+        *,
+        definition: typing.Any = OMIT,
+        path: typing.Any = OMIT,
+        yaml_text: typing.Any = OMIT,
+        mapping: typing.Any = OMIT,
+        prepared: typing.Any = OMIT,
+        mapping_kind: typing.Optional[str] = None,
+        name: typing.Any = OMIT,
+        chunk_strategy: typing.Any = OMIT,
+        section_strategy: typing.Any = OMIT,
+        steps: typing.Any = OMIT,
+        request_options: typing.Optional[RequestOptions] = None,
+    ) -> typing.Any:
+        """
+        Update an extraction workflow from a definition or YAML/prepared source.
+
+        Parameters
+        ----------
+        workflow_id : str
+            Existing workflow ID to update.
+        definition : typing.Any
+            An `ExtractionDefinition` returned by an extraction definition
+            loader.
+        path : typing.Any
+            Path to an authored extraction YAML file.
+        yaml_text : typing.Any
+            Authored extraction YAML as a string.
+        mapping : typing.Any
+            Authored YAML-shaped mapping, or a workflow extract mapping when
+            `mapping_kind="workflow_extract"` is set.
+        prepared : typing.Any
+            A `PreparedExtractionYaml` returned by `prepare_extraction_yaml`.
+        mapping_kind : typing.Optional[str]
+            Use `"workflow_extract"` only when `mapping` is an existing workflow
+            extract payload.
+        name : typing.Any
+            Optional workflow name to send with the full update payload.
+        chunk_strategy : typing.Any
+            Optional workflow chunk strategy override.
+        section_strategy : typing.Any
+            Optional workflow section strategy override.
+        steps : typing.Any
+            Optional fixed workflow step overlay.
+        request_options : typing.Optional[RequestOptions]
+            Request-specific configuration forwarded to the generated workflow
+            client.
+
+        Returns
+        -------
+        typing.Any
+            The generated workflow update response.
+
+        Examples
+        --------
+        >>> await client.update_extraction_workflow(
+        ...     "workflow-id",
+        ...     path="statement.yaml",
+        ...     name="statement extraction",
+        ... )
+
+        Notes
+        -----
+        Update sends the full extraction workflow settings, not a patch. If
+        `definition` is provided, it takes precedence over YAML/prepared inputs.
+        Otherwise pass exactly one of `path`, `yaml_text`, `mapping`, or
+        `prepared`.
+        """
+        extraction_workflows = _import_extraction_workflows()
+        resolved = extraction_workflows.resolve_extraction_definition_source(
+            definition=definition,
+            path=path,
+            yaml_text=yaml_text,
+            mapping=mapping,
+            prepared=prepared,
+            mapping_kind=mapping_kind,
+        )
+        kwargs = extraction_workflows.workflow_kwargs_from_extraction_definition(
+            resolved,
+            name=name,
+            chunk_strategy=chunk_strategy,
+            section_strategy=section_strategy,
+            steps=steps,
+            request_options=request_options,
+        )
+        extraction_workflows.ensure_workflow_method_supports_kwargs(
+            self.workflows.update,
+            kwargs,
+        )
+        return await self.workflows.update(workflow_id, **kwargs)
+
     async def ingest(
         self,
         *,
@@ -777,9 +1499,7 @@ class AsyncGroundX(AsyncGroundXBase):
             raise ValueError(f"Unsupported HTTP method: {method}")
 
         if upload_response.status_code not in (200, 201):
-            raise Exception(
-                f"Upload failed: {upload_response.status_code} - {upload_response.text}"
-            )
+            raise Exception(f"Upload failed: {upload_response.status_code} - {upload_response.text}")
 
         if "GX-HOSTED-URL" in headers:
             return headers["GX-HOSTED-URL"]

--- a/tests/custom/test_extraction_workflow_client_exports.py
+++ b/tests/custom/test_extraction_workflow_client_exports.py
@@ -1,0 +1,167 @@
+import builtins
+import importlib
+import inspect
+import json
+import os
+import subprocess
+import sys
+import typing
+
+import httpx
+import pytest
+
+from groundx import GroundX
+
+CUSTOM_WORKFLOW_YAML = """
+workflow:
+  template:
+    "{{LANGUAGE}}": English
+    "{{LANGUAGE_UNKNOWN}}": ""
+  custom_steps:
+    - name: line_item_labels
+      level: chunk
+      kind: keys
+      required_template_keys:
+        - "{{LANGUAGE}}"
+
+line_items:
+  workflow_step: line_item_labels
+  fields:
+    description:
+      workflow_output_key: label
+      prompt:
+        instructions: Return the printed line-item description.
+        type: str
+"""
+
+
+def _request_json(request: httpx.Request) -> typing.Dict[str, typing.Any]:
+    return typing.cast(typing.Dict[str, typing.Any], json.loads(request.content.decode()))
+
+
+def test_extraction_definition_is_exported_from_extract_module() -> None:
+    from groundx.extract import ExtractionDefinition
+
+    assert ExtractionDefinition.__name__ == "ExtractionDefinition"
+
+
+def test_extraction_workflow_helpers_have_method_level_docstrings() -> None:
+    for method_name in (
+        "load_extraction_definition",
+        "load_extraction_definition_from_yaml",
+        "load_extraction_definition_from_workflow",
+        "create_extraction_workflow",
+        "update_extraction_workflow",
+    ):
+        doc = inspect.getdoc(getattr(GroundX, method_name))
+        assert doc is not None
+        assert "Parameters" in doc, method_name
+        assert "Returns" in doc, method_name
+        assert "Examples" in doc, method_name
+
+    update_doc = inspect.getdoc(GroundX.update_extraction_workflow)
+    assert update_doc is not None
+    assert "full extraction workflow settings" in update_doc
+
+
+def test_base_groundx_import_does_not_import_extract_optional_dependencies() -> None:
+    code = """
+import builtins
+
+optional_roots = {
+    "boto3",
+    "celery",
+    "dateparser",
+    "fastapi",
+    "google",
+    "gspread",
+    "minio",
+    "openai",
+    "PIL",
+    "redis",
+    "smolagents",
+    "yaml",
+}
+real_import = builtins.__import__
+
+def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+    root = name.split(".", 1)[0]
+    if name.startswith("groundx.extract") or root in optional_roots:
+        raise AssertionError(f"unexpected optional import: {name}")
+    return real_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = guarded_import
+import groundx
+from groundx import AsyncGroundX, GroundX
+assert GroundX.__name__ == "GroundX"
+assert AsyncGroundX.__name__ == "AsyncGroundX"
+"""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, ["src", env.get("PYTHONPATH", "")]))
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=os.getcwd(),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_extraction_methods_raise_install_hint_when_extract_extra_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+    extract_package = importlib.import_module("groundx.extract")
+
+    def guarded_import(
+        name: str,
+        globals: typing.Optional[typing.Dict[str, typing.Any]] = None,
+        locals: typing.Optional[typing.Dict[str, typing.Any]] = None,
+        fromlist: typing.Sequence[str] = (),
+        level: int = 0,
+    ) -> typing.Any:
+        if name.startswith("groundx.extract") or (level > 0 and name == "extract"):
+            raise ImportError("simulated missing extract extra")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    monkeypatch.delitem(sys.modules, "groundx.extract.workflows", raising=False)
+    monkeypatch.delattr(extract_package, "workflows", raising=False)
+    client = GroundX.__new__(GroundX)
+
+    with pytest.raises(ImportError, match=r"pip install groundx\[extract\]"):
+        client.load_extraction_definition_from_yaml(yaml_text=CUSTOM_WORKFLOW_YAML)
+
+
+def test_create_extraction_workflow_gates_custom_steps_until_generated_client_release() -> None:
+    captured: typing.List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "workflow": {
+                    "workflowId": "workflow-1",
+                    "name": "statement extraction",
+                }
+            },
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as httpx_client:
+        client = GroundX(
+            api_key="test-key",
+            base_url="https://api.test",
+            httpx_client=httpx_client,
+        )
+        with pytest.raises(RuntimeError, match="Regenerate and publish"):
+            client.create_extraction_workflow(
+                yaml_text=CUSTOM_WORKFLOW_YAML,
+                name="statement extraction",
+            )
+
+    assert captured == []

--- a/tests/extract/classes/test_document.py
+++ b/tests/extract/classes/test_document.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from groundx.extract.classes.document import Document, DocumentRequest
 from groundx.extract.classes.field import ExtractedField
+from groundx.extract.classes.groundx import XRayDocument
 from groundx.extract.classes.group import Group
 from groundx.extract.prompt.manager import PromptManager
 from ..prompt._fixtures import SAMPLE_YAML_1, SAMPLE_YAML_2, TestSource
@@ -234,6 +235,59 @@ class TestDocument(unittest.TestCase):
             ),
             doc.model_dump(serialize_as_any=True, exclude_none=True),
         )
+
+    def test_document_preserves_fixed_and_custom_readback_fields(self) -> None:
+        seen: typing.List[typing.Tuple[str, typing.Any]] = []
+
+        class CaptureDocument(Document):
+            def add(self, k: str, value: typing.Any) -> typing.Union[str, None]:
+                seen.append((k, value))
+                return None
+
+        source = TestSource(SAMPLE_YAML_1)
+        manager = PromptManager(cache_source=source, config_source=source)
+        xray = XRayDocument.model_validate(
+            {
+                "chunks": [
+                    {
+                        "chunkKeywords": '{"fixed_chunk":"yes"}',
+                        "sectionSummary": '{"fixed_section":"yes"}',
+                        "fileSummary": '{"fixed_file":"yes"}',
+                        "customChunkOutputs": {
+                            "line_item_labels": {
+                                "label": {"custom_chunk": "Water service"}
+                            }
+                        },
+                        "customSectionOutputs": {
+                            "section_codes": {
+                                "code": {"custom_section": "UTILITY"}
+                            }
+                        },
+                    }
+                ],
+                "customDocumentOutputs": {
+                    "document_flags": {
+                        "needs_review": {"custom_document": False}
+                    }
+                },
+                "documentPages": [],
+                "sourceUrl": "https://example.com/doc.pdf",
+            }
+        )
+
+        doc = CaptureDocument()
+        doc.load_xray(
+            req=_make_request(),
+            xray=xray,
+            prompt_manager=manager,
+        )
+
+        self.assertIn(("fixed_chunk", "yes"), seen)
+        self.assertIn(("fixed_section", "yes"), seen)
+        self.assertIn(("fixed_file", "yes"), seen)
+        self.assertIn(("custom_chunk", "Water service"), seen)
+        self.assertIn(("custom_section", "UTILITY"), seen)
+        self.assertIn(("custom_document", False), seen)
 
 
 class TestDocumentRequest(unittest.TestCase):

--- a/tests/extract/classes/test_groundx.py
+++ b/tests/extract/classes/test_groundx.py
@@ -218,6 +218,70 @@ class TestGroundX(unittest.TestCase):
             },
         )
 
+    def test_xray_loads_custom_output_maps(self) -> None:
+        xray_doc = XRayDocument.model_validate(
+            {
+                "chunks": [
+                    {
+                        "chunk": "chunk-1",
+                        "contentType": ["paragraph"],
+                        "customChunkOutputs": {
+                            "line_item_labels": {"label": "Water service"}
+                        },
+                        "customSectionOutputs": {
+                            "section_codes": {"code": "UTILITY"}
+                        },
+                    }
+                ],
+                "customDocumentOutputs": {
+                    "document_flags": {"needs_review": False}
+                },
+                "documentPages": [
+                    {
+                        "chunks": [
+                            {
+                                "chunk": "page-chunk-1",
+                                "customChunkOutputs": {
+                                    "line_item_labels": {"label": "Page local"}
+                                },
+                            }
+                        ],
+                        "height": 500,
+                        "pageNumber": 1,
+                        "pageUrl": "https://page.jpg",
+                        "width": 400,
+                    }
+                ],
+                "sourceUrl": "https://doc.pdf",
+            }
+        )
+
+        self.assertEqual(
+            xray_doc.chunks[0].customChunkOutputs,
+            {"line_item_labels": {"label": "Water service"}},
+        )
+        self.assertEqual(
+            xray_doc.chunks[0].customSectionOutputs,
+            {"section_codes": {"code": "UTILITY"}},
+        )
+        self.assertEqual(
+            xray_doc.customDocumentOutputs,
+            {"document_flags": {"needs_review": False}},
+        )
+        self.assertEqual(
+            xray_doc.documentPages[0].chunks[0].customChunkOutputs,
+            {"line_item_labels": {"label": "Page local"}},
+        )
+
+        self.assertEqual(
+            xray_doc.get_extract()["chunks"][0]["customChunkOutputs"],
+            {"line_item_labels": {"label": "Water service"}},
+        )
+        self.assertEqual(
+            xray_doc.get_extract()["customDocumentOutputs"],
+            {"document_flags": {"needs_review": False}},
+        )
+
     def test_xray_method_delegates_to_download(self) -> None:
         gx = GD(base_url="", documentID="X", taskID="Y")
 

--- a/tests/extract/prompt/test_manager.py
+++ b/tests/extract/prompt/test_manager.py
@@ -29,6 +29,34 @@ class FailingSource(TestSource):
         return None
 
 
+CUSTOM_WORKFLOW_YAML = """
+workflow:
+  template:
+    BILLING_HINT: Prefer values from the charge table.
+  custom_steps:
+    - name: line_item_labels
+      level: chunk
+      kind: keys
+      required_template_keys:
+        - BILLING_HINT
+      config:
+        all:
+          includes:
+            text: true
+
+line_items:
+  workflow_step: line_item_labels
+  fields:
+    description:
+      workflow_output_key: label
+      prompt:
+        identifiers:
+          - Description
+        instructions: Return the printed line-item description.
+        type: str
+"""
+
+
 class TestPromptManager(unittest.TestCase):
     def test_load_from_yaml_1(self) -> None:
         root = load_from_yaml(SAMPLE_YAML_1)
@@ -1507,6 +1535,317 @@ _pseudo_groups:
             prepared.workflow_group_metadata,
             {"statement_identity": {"slot": ""}},
         )
+
+    def test_prepare_extraction_yaml_accepts_custom_workflow_steps(self) -> None:
+        prepared = prepare_extraction_yaml(CUSTOM_WORKFLOW_YAML)
+
+        self.assertNotIn("workflow", prepared.groups)
+        self.assertNotIn("workflow", prepared.workflow_groups)
+        self.assertIn("line_items", prepared.groups)
+        self.assertIn("description", prepared.groups["line_items"]["fields"])
+        self.assertNotIn("workflow_step", prepared.groups["line_items"])
+        self.assertNotIn(
+            "workflow_output_key",
+            prepared.groups["line_items"]["fields"]["description"],
+        )
+
+        workflow = prepared.persisted_workflow_extract["workflow"]
+        self.assertEqual(workflow["metadata_version"], 1)
+        self.assertEqual(
+            workflow["template"],
+            {"BILLING_HINT": "Prefer values from the charge table."},
+        )
+        self.assertEqual(
+            workflow["custom_steps"],
+            [
+                {
+                    "name": "line_item_labels",
+                    "level": "chunk",
+                    "kind": "keys",
+                    "required_template_keys": ["BILLING_HINT"],
+                    "config": {
+                        "all": {
+                            "includes": {"text": True},
+                        }
+                    },
+                }
+            ],
+        )
+        self.assertEqual(
+            workflow["output_routes"],
+            [
+                {
+                    "workflow_group": "line_items",
+                    "workflow_field": "description",
+                    "final_path": "/line_items/description",
+                    "step_name": "line_item_labels",
+                    "level": "chunk",
+                    "output_map": "customChunkOutputs",
+                    "output_key": "label",
+                    "readback_path": (
+                        "/chunks/*/customChunkOutputs/line_item_labels/label"
+                    ),
+                }
+            ],
+        )
+        self.assertEqual(
+            workflow["leaf_fields"],
+            [
+                {
+                    "final_path": "/line_items/description",
+                    "workflow_group": "line_items",
+                    "workflow_field": "description",
+                    "step_name": "line_item_labels",
+                    "level": "chunk",
+                    "output_key": "label",
+                    "field_type": "str",
+                    "is_repeated": False,
+                    "repetition_scope": "none",
+                }
+            ],
+        )
+        self.assertEqual(workflow["field_counts"], {"line_item_labels": 1})
+        self.assertRegex(workflow["schema_hash"], r"^[0-9a-f]{64}$")
+
+    def test_prepare_extraction_yaml_routes_repeated_custom_fields_with_list_name(
+        self,
+    ) -> None:
+        prepared = prepare_extraction_yaml(
+            """
+workflow:
+  custom_steps:
+    - name: line_item_labels
+      level: chunk
+      kind: keys
+invoice:
+  workflow_step: line_item_labels
+  fields:
+    charges:
+      - fields:
+          description:
+            workflow_output_key: label
+            prompt:
+              instructions: Return the repeated charge description.
+              type: str
+"""
+        )
+
+        workflow = prepared.persisted_workflow_extract["workflow"]
+        self.assertEqual(
+            workflow["output_routes"][0]["final_path"],
+            "/invoice/charges/*/description",
+        )
+        self.assertEqual(
+            workflow["output_routes"][0]["workflow_field"],
+            "charges.description",
+        )
+        self.assertEqual(
+            workflow["leaf_fields"][0]["repetition_scope"],
+            "/invoice/charges/*",
+        )
+
+    def test_prepare_extraction_yaml_rejects_slot_and_workflow_step_conflict(
+        self,
+    ) -> None:
+        with self.assertRaises(ValueError) as exc:
+            prepare_extraction_yaml(
+                """
+workflow:
+  custom_steps:
+    - name: line_item_labels
+      level: chunk
+      kind: keys
+line_items:
+  slot: chunk-keys
+  workflow_step: line_item_labels
+  fields:
+    description:
+      workflow_output_key: label
+      prompt:
+        instructions: Return the description.
+        type: str
+""",
+                workflow_group_metadata_keys={"slot"},
+            )
+
+        self.assertIn("slot", str(exc.exception))
+        self.assertIn("workflow_step", str(exc.exception))
+
+    def test_prepare_extraction_yaml_rejects_reserved_workflow_final_group(
+        self,
+    ) -> None:
+        with self.assertRaises(ValueError) as exc:
+            prepare_extraction_yaml(
+                """
+workflow:
+  fields:
+    status:
+      prompt:
+        instructions: Return the workflow status.
+        type: str
+"""
+            )
+
+        self.assertIn("workflow", str(exc.exception))
+        self.assertIn("reserved", str(exc.exception).lower())
+
+    def test_prepare_extraction_yaml_rejects_invalid_custom_step_identity(
+        self,
+    ) -> None:
+        with self.assertRaises(ValueError) as exc:
+            prepare_extraction_yaml(
+                CUSTOM_WORKFLOW_YAML.replace("line_item_labels", "line-item-labels")
+            )
+
+        self.assertIn("invalid custom step name", str(exc.exception))
+        self.assertIn("line-item-labels", str(exc.exception))
+
+    def test_prepare_extraction_yaml_rejects_case_normalized_step_name(
+        self,
+    ) -> None:
+        with self.assertRaises(ValueError) as exc:
+            prepare_extraction_yaml(
+                CUSTOM_WORKFLOW_YAML.replace("line_item_labels", "LineItemLabels")
+            )
+
+        self.assertIn("invalid custom step name", str(exc.exception))
+        self.assertIn("LineItemLabels", str(exc.exception))
+
+    def test_prepare_extraction_yaml_rejects_duplicate_custom_step_name(
+        self,
+    ) -> None:
+        with self.assertRaises(ValueError) as exc:
+            prepare_extraction_yaml(
+                """
+workflow:
+  custom_steps:
+    - name: line_item_labels
+      level: chunk
+      kind: keys
+    - name: line_item_labels
+      level: chunk
+      kind: keys
+line_items:
+  workflow_step: line_item_labels
+  fields:
+    description:
+      workflow_output_key: label
+      prompt:
+        instructions: Return the description.
+        type: str
+"""
+            )
+
+        self.assertIn("duplicate custom step name", str(exc.exception))
+        self.assertIn("line_item_labels", str(exc.exception))
+
+    def test_prepare_extraction_yaml_rejects_reserved_custom_step_name(
+        self,
+    ) -> None:
+        with self.assertRaises(ValueError) as exc:
+            prepare_extraction_yaml(
+                CUSTOM_WORKFLOW_YAML.replace("line_item_labels", "chunk_keys")
+            )
+
+        self.assertIn("reserved custom step name", str(exc.exception))
+        self.assertIn("chunk_keys", str(exc.exception))
+
+    def test_prepare_extraction_yaml_rejects_missing_required_template_keys(
+        self,
+    ) -> None:
+        with self.assertRaises(ValueError) as exc:
+            prepare_extraction_yaml(
+                CUSTOM_WORKFLOW_YAML.replace(
+                    "    BILLING_HINT: Prefer values from the charge table.\n", ""
+                )
+            )
+
+        self.assertIn("missing template key", str(exc.exception))
+        self.assertIn("BILLING_HINT", str(exc.exception))
+
+    def test_prepare_extraction_yaml_rejects_custom_step_over_20_fields(
+        self,
+    ) -> None:
+        fields = "\n".join(
+            f"""    field_{idx}:
+      workflow_output_key: label_{idx}
+      prompt:
+        instructions: Return field {idx}.
+        type: str"""
+            for idx in range(21)
+        )
+
+        with self.assertRaises(ValueError) as exc:
+            prepare_extraction_yaml(
+                f"""
+workflow:
+  custom_steps:
+    - name: overloaded_fields
+      level: chunk
+      kind: keys
+line_items:
+  workflow_step: overloaded_fields
+  fields:
+{fields}
+"""
+            )
+
+        self.assertIn("overloaded_fields", str(exc.exception))
+        self.assertIn("at most 20 fields", str(exc.exception))
+
+    def test_prepare_extraction_yaml_rejects_duplicate_output_destination(
+        self,
+    ) -> None:
+        with self.assertRaises(ValueError) as exc:
+            prepare_extraction_yaml(
+                """
+workflow:
+  custom_steps:
+    - name: line_item_labels
+      level: chunk
+      kind: keys
+line_items:
+  workflow_step: line_item_labels
+  fields:
+    description:
+      workflow_output_key: label
+      prompt:
+        instructions: Return the description.
+        type: str
+    amount:
+      workflow_output_key: label
+      prompt:
+        instructions: Return the amount.
+        type: str
+"""
+            )
+
+        self.assertIn("duplicate output destination", str(exc.exception))
+        self.assertIn("line_item_labels.label", str(exc.exception))
+
+    def test_prepare_extraction_yaml_rejects_custom_step_without_routes(
+        self,
+    ) -> None:
+        with self.assertRaises(ValueError) as exc:
+            prepare_extraction_yaml(
+                """
+workflow:
+  custom_steps:
+    - name: unrouted_fields
+      level: chunk
+      kind: keys
+invoice:
+  workflow_step: unrouted_fields
+  fields:
+    account_number:
+      prompt:
+        instructions: Return the account number.
+        type: str
+"""
+            )
+
+        self.assertIn("output routes", str(exc.exception))
+        self.assertIn("workflow_output_key", str(exc.exception))
 
     def test_get_prompt_1(self) -> None:
         tsts: typing.List[typing.Dict[str, typing.Any]] = [

--- a/tests/extract/prompt/test_manager.py
+++ b/tests/extract/prompt/test_manager.py
@@ -29,6 +29,27 @@ class FailingSource(TestSource):
         return None
 
 
+class FlakyCachedSource(TestSource):
+    def __init__(self, raw: str) -> None:
+        super().__init__(raw)
+        self.fetch_calls = 0
+        self.peek_calls = 0
+        self.fail_fetch = False
+        self.fail_peek = False
+
+    def fetch(self, workflow_id: str) -> typing.Tuple[str, str]:
+        self.fetch_calls += 1
+        if self.fail_fetch:
+            raise Exception(f"fetch unavailable [{workflow_id}]")
+        return super().fetch(workflow_id)
+
+    def peek(self, workflow_id: str) -> typing.Optional[str]:
+        self.peek_calls += 1
+        if self.fail_peek:
+            raise Exception(f"peek unavailable [{workflow_id}]")
+        return super().peek(workflow_id)
+
+
 CUSTOM_WORKFLOW_YAML = """
 workflow:
   template:
@@ -571,6 +592,33 @@ Special Instructions:
             provider.prompt.instructions,
             "Return the updated provider name.",
         )
+
+    def test_cached_workflow_survives_source_peek_failure(self) -> None:
+        source = FlakyCachedSource(SAMPLE_YAML_1)
+        manager = PromptManager(cache_source=source, config_source=source)
+        self.assertEqual(source.fetch_calls, 1)
+
+        source.fail_peek = True
+        source.fail_fetch = True
+
+        fields = manager.get_fields_for_workflow()
+
+        self.assertIn("statement", fields)
+        self.assertEqual(source.fetch_calls, 1)
+
+    def test_reload_if_changed_keeps_cache_when_source_peek_fails(self) -> None:
+        source = FlakyCachedSource(SAMPLE_YAML_1)
+        manager = PromptManager(cache_source=source, config_source=source)
+        self.assertEqual(source.fetch_calls, 1)
+
+        source.fail_peek = True
+        source.fail_fetch = True
+
+        manager.reload_if_changed()
+        fields = manager.get_fields_for_workflow()
+
+        self.assertIn("statement", fields)
+        self.assertEqual(source.fetch_calls, 1)
 
     def test_prepare_extraction_yaml_with_pseudo_groups(self) -> None:
         prepared = prepare_extraction_yaml(SAMPLE_YAML_PSEUDO_GROUPS)

--- a/tests/extract/prompt/test_persisted_workflow_extract.py
+++ b/tests/extract/prompt/test_persisted_workflow_extract.py
@@ -2,6 +2,8 @@ import copy
 import json
 import typing
 
+import pytest
+
 from groundx.extract import prepare_extraction_yaml
 from groundx.extract.prompt.manager import PromptManager
 from groundx.types.workflow_request import WorkflowRequest
@@ -30,6 +32,68 @@ FINAL_GROUP_METADATA_KEYS = {
     "deregulation_status_values",
 }
 WORKFLOW_GROUP_METADATA_KEYS = {"slot"}
+
+
+def _custom_workflow_metadata() -> typing.Dict[str, typing.Any]:
+    return {
+        "metadata_version": 1,
+        "template": {
+            "BILLING_HINT": "Prefer values from the charge table.",
+        },
+        "custom_steps": [
+            {
+                "name": "line_item_labels",
+                "level": "chunk",
+                "kind": "keys",
+                "required_template_keys": ["BILLING_HINT"],
+            }
+        ],
+        "output_routes": [
+            {
+                "workflow_group": "line_items",
+                "workflow_field": "description",
+                "final_path": "/line_items/*/description",
+                "step_name": "line_item_labels",
+                "level": "chunk",
+                "output_map": "customChunkOutputs",
+                "output_key": "label",
+                "readback_path": (
+                    "/chunks/*/customChunkOutputs/line_item_labels/label"
+                ),
+            }
+        ],
+        "leaf_fields": [
+            {
+                "final_path": "/line_items/*/description",
+                "workflow_group": "line_items",
+                "workflow_field": "description",
+                "step_name": "line_item_labels",
+                "level": "chunk",
+                "output_key": "label",
+                "field_type": "str",
+                "is_repeated": True,
+                "repetition_scope": "/line_items/*",
+            }
+        ],
+        "field_counts": {"line_item_labels": 1},
+    }
+
+
+def _persisted_custom_workflow_extract() -> typing.Dict[str, typing.Any]:
+    return {
+        "line_items": {
+            "fields": {
+                "description": {
+                    "prompt": {
+                        "identifiers": ["Description"],
+                        "instructions": "Return the line item description.",
+                        "type": "str",
+                    }
+                }
+            }
+        },
+        "workflow": _custom_workflow_metadata(),
+    }
 
 
 POLICY_YAML = """
@@ -229,3 +293,78 @@ def test_legacy_yaml_persisted_extract_is_execution_shaped() -> None:
             "service_address": "/meters/service_address",
         },
     }
+
+
+def test_persisted_custom_workflow_extract_round_trips_routes_and_leaf_fields() -> None:
+    persisted = _persisted_custom_workflow_extract()
+    round_tripped = json.loads(json.dumps(persisted))
+
+    reloaded = prepare_extraction_yaml(round_tripped)
+    workflow = reloaded.persisted_workflow_extract["workflow"]
+
+    assert workflow["metadata_version"] == 1
+    assert workflow["custom_steps"] == persisted["workflow"]["custom_steps"]
+    assert workflow["output_routes"] == persisted["workflow"]["output_routes"]
+    assert workflow["leaf_fields"] == persisted["workflow"]["leaf_fields"]
+    assert workflow["leaf_fields"][0]["final_path"] == "/line_items/*/description"
+    assert workflow["leaf_fields"][0]["repetition_scope"] == "/line_items/*"
+    assert reloaded.workflow_field_paths["line_items"]["description"] == (
+        "/line_items/*/description"
+    )
+
+
+def test_persisted_custom_workflow_extract_rejects_unknown_version() -> None:
+    persisted = _persisted_custom_workflow_extract()
+    persisted["workflow"]["metadata_version"] = 2
+
+    with pytest.raises(ValueError, match="metadata_version"):
+        prepare_extraction_yaml(persisted)
+
+
+def test_persisted_custom_workflow_extract_rejects_missing_version() -> None:
+    persisted = _persisted_custom_workflow_extract()
+    del persisted["workflow"]["metadata_version"]
+
+    with pytest.raises(ValueError, match="metadata_version"):
+        prepare_extraction_yaml(persisted)
+
+
+def test_persisted_custom_workflow_extract_rejects_route_leaf_mismatch() -> None:
+    persisted = _persisted_custom_workflow_extract()
+    persisted["workflow"]["leaf_fields"][0]["final_path"] = "/line_items/*/amount"
+
+    with pytest.raises(ValueError, match="route.*leaf|leaf.*route"):
+        prepare_extraction_yaml(persisted)
+
+
+def test_persisted_custom_workflow_extract_rejects_field_count_mismatch() -> None:
+    persisted = _persisted_custom_workflow_extract()
+    persisted["workflow"]["field_counts"] = {"line_item_labels": 2}
+
+    with pytest.raises(ValueError, match="field_counts"):
+        prepare_extraction_yaml(persisted)
+
+
+def test_persisted_custom_workflow_extract_hash_is_deterministic() -> None:
+    first = _persisted_custom_workflow_extract()
+    second = _persisted_custom_workflow_extract()
+    second["workflow"]["template"] = {
+        "BILLING_HINT": "Template values are ignored by hash",
+    }
+    second["workflow"]["custom_steps"][0]["required_template_keys"] = list(
+        reversed(second["workflow"]["custom_steps"][0]["required_template_keys"])
+    )
+    second["workflow"]["output_routes"] = list(
+        reversed(second["workflow"]["output_routes"])
+    )
+    second["workflow"]["leaf_fields"] = list(reversed(second["workflow"]["leaf_fields"]))
+
+    first_hash = prepare_extraction_yaml(first).persisted_workflow_extract["workflow"][
+        "schema_hash"
+    ]
+    second_hash = prepare_extraction_yaml(second).persisted_workflow_extract["workflow"][
+        "schema_hash"
+    ]
+
+    assert first_hash == second_hash
+    assert len(first_hash) == 64

--- a/tests/extract/services/test_upload_minio.py
+++ b/tests/extract/services/test_upload_minio.py
@@ -1,15 +1,49 @@
 import unittest
+import contextlib
+import sys
+import types
+import typing
 
 from groundx.extract.services.logger import Logger
 from groundx.extract.settings.settings import ContainerSettings, ContainerUploadSettings
 from groundx.extract.services.upload_minio import MinIOClient
 
 
-class TestMinIOClient(unittest.TestCase):
-    def test_load_parse_url_1(self) -> None:
-        logger = Logger("parse_url", "debug")
+class FakeMinioResponse:
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+        self.closed = False
+        self.released = False
 
-        cl = MinIOClient(
+    def read(self) -> bytes:
+        return self.body
+
+    def close(self) -> None:
+        self.closed = True
+
+    def release_conn(self) -> None:
+        self.released = True
+
+
+class FakeMinioClient:
+    def __init__(self) -> None:
+        self.response = FakeMinioResponse(b"statement: {}")
+
+    def get_object(self, bucket: str, key: str) -> FakeMinioResponse:
+        return self.response
+
+    def stat_object(self, bucket: str, key: str) -> typing.Any:
+        return type(
+            "Stat",
+            (),
+            {"etag": "etag-1", "last_modified": None},
+        )()
+
+
+class TestMinIOClient(unittest.TestCase):
+    def _client(self) -> MinIOClient:
+        logger = Logger("parse_url", "debug")
+        return MinIOClient(
             settings=ContainerSettings(
                 broker="",
                 service="parse_url",
@@ -23,6 +57,9 @@ class TestMinIOClient(unittest.TestCase):
             ),
             logger=logger,
         )
+
+    def test_load_parse_url_1(self) -> None:
+        cl = self._client()
 
         obj = cl.parse_url("/eyelevel/layout")
         self.assertEqual(obj, "layout")
@@ -46,3 +83,59 @@ class TestMinIOClient(unittest.TestCase):
             obj,
             "layout/raw/prod/db5915cc-69ae-4cea-884e-fa029712cd16/78b97664-47ac-4363-89d9-9004938d8161/1.jpg",
         )
+
+    def test_get_object_closes_response(self) -> None:
+        cl = self._client()
+        fake = FakeMinioClient()
+        cl.client = typing.cast(typing.Any, fake)
+
+        with fake_minio_error_module():
+            body = cl.get_object("s3://eyelevel/workflows/extract/latest.yaml")
+
+        self.assertEqual(body, b"statement: {}")
+        self.assertTrue(fake.response.closed)
+        self.assertTrue(fake.response.released)
+
+    def test_get_object_and_metadata_closes_response(self) -> None:
+        cl = self._client()
+        fake = FakeMinioClient()
+        cl.client = typing.cast(typing.Any, fake)
+
+        with fake_minio_error_module():
+            body, metadata = typing.cast(
+                typing.Tuple[bytes, typing.Dict[str, str]],
+                cl.get_object_and_metadata(
+                    "s3://eyelevel/workflows/extract/latest.yaml"
+                ),
+            )
+
+        self.assertEqual(body, b"statement: {}")
+        self.assertEqual(metadata, {"ETag": "etag-1"})
+        self.assertTrue(fake.response.closed)
+        self.assertTrue(fake.response.released)
+
+
+@contextlib.contextmanager
+def fake_minio_error_module() -> typing.Iterator[None]:
+    previous_minio = sys.modules.get("minio")
+    previous_error = sys.modules.get("minio.error")
+
+    minio_module = types.ModuleType("minio")
+    error_module = types.ModuleType("minio.error")
+    setattr(error_module, "S3Error", Exception)
+    setattr(minio_module, "error", error_module)
+
+    sys.modules["minio"] = minio_module
+    sys.modules["minio.error"] = error_module
+    try:
+        yield
+    finally:
+        if previous_minio is None:
+            sys.modules.pop("minio", None)
+        else:
+            sys.modules["minio"] = previous_minio
+
+        if previous_error is None:
+            sys.modules.pop("minio.error", None)
+        else:
+            sys.modules["minio.error"] = previous_error

--- a/tests/extract/services/test_upload_s3.py
+++ b/tests/extract/services/test_upload_s3.py
@@ -1,0 +1,83 @@
+import typing
+import unittest
+
+from groundx.extract.services.logger import Logger
+from groundx.extract.services.upload_s3 import S3Client
+from groundx.extract.settings.settings import ContainerSettings, ContainerUploadSettings
+
+
+class FakeBody:
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+        self.closed = False
+
+    def read(self) -> bytes:
+        return self.body
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeS3Client:
+    def __init__(self) -> None:
+        self.body = FakeBody(b"statement: {}")
+
+    def get_object(self, Bucket: str, Key: str) -> typing.Dict[str, typing.Any]:
+        return {
+            "Body": self.body,
+            "ETag": '"etag-1"',
+        }
+
+    def head_object(self, Bucket: str, Key: str) -> typing.Dict[str, typing.Any]:
+        return {"ETag": '"etag-1"'}
+
+
+class TestS3Client(unittest.TestCase):
+    def _client(self) -> S3Client:
+        logger = Logger("s3", "debug")
+        return S3Client(
+            settings=ContainerSettings(
+                broker="",
+                service="s3",
+                upload=ContainerUploadSettings(
+                    base_domain="",
+                    bucket="eyelevel",
+                    type="",
+                    url="",
+                ),
+                workers=1,
+            ),
+            logger=logger,
+        )
+
+    def test_get_object_closes_body(self) -> None:
+        cl = self._client()
+        fake = FakeS3Client()
+        cl.client = typing.cast(typing.Any, fake)
+
+        body = cl.get_object("s3://eyelevel/workflows/extract/latest.yaml")
+
+        self.assertEqual(body, b"statement: {}")
+        self.assertTrue(fake.body.closed)
+
+    def test_get_object_and_metadata_handles_missing_last_modified(self) -> None:
+        cl = self._client()
+        fake = FakeS3Client()
+        cl.client = typing.cast(typing.Any, fake)
+
+        body, metadata = typing.cast(
+            typing.Tuple[bytes, typing.Dict[str, str]],
+            cl.get_object_and_metadata("s3://eyelevel/workflows/extract/latest.yaml"),
+        )
+
+        self.assertEqual(body, b"statement: {}")
+        self.assertEqual(metadata, {"ETag": '"etag-1"'})
+        self.assertTrue(fake.body.closed)
+
+    def test_head_object_handles_missing_last_modified(self) -> None:
+        cl = self._client()
+        cl.client = typing.cast(typing.Any, FakeS3Client())
+
+        metadata = cl.head_object("s3://eyelevel/workflows/extract/latest.yaml")
+
+        self.assertEqual(metadata, {"ETag": '"etag-1"'})

--- a/tests/extract/test_extraction_workflow_definitions.py
+++ b/tests/extract/test_extraction_workflow_definitions.py
@@ -1,0 +1,656 @@
+import typing
+from pathlib import Path
+
+import pytest
+import yaml
+
+from groundx import AsyncGroundX, GroundX
+from groundx.core.request_options import RequestOptions
+from groundx.extract import prepare_extraction_yaml
+from groundx.types import (
+    WorkflowDetail,
+    WorkflowResponse,
+    WorkflowStep,
+    WorkflowStepConfig,
+    WorkflowSteps,
+)
+
+CUSTOM_WORKFLOW_YAML = """
+workflow:
+  template:
+    "{{LANGUAGE}}": English
+    "{{LANGUAGE_UNKNOWN}}": ""
+  custom_steps:
+    - name: line_item_labels
+      level: chunk
+      kind: keys
+      required_template_keys:
+        - "{{LANGUAGE}}"
+      config:
+        all:
+          includes:
+            text: true
+
+line_items:
+  workflow_step: line_item_labels
+  fields:
+    description:
+      workflow_output_key: label
+      prompt:
+        identifiers:
+          - Description
+        instructions: Return the printed line-item description.
+        type: str
+"""
+
+
+EXECUTION_ONLY_EXTRACT = {
+    "line_items": {
+        "fields": {
+            "description": {
+                "prompt": {
+                    "identifiers": ["Description"],
+                    "instructions": "Return the printed line-item description.",
+                    "type": "str",
+                }
+            }
+        }
+    },
+    "workflow": {
+        "metadata_version": 1,
+        "template": {
+            "{{LANGUAGE}}": "English",
+            "{{LANGUAGE_UNKNOWN}}": "",
+        },
+        "custom_steps": [
+            {
+                "name": "line_item_labels",
+                "level": "chunk",
+                "kind": "keys",
+                "required_template_keys": ["{{LANGUAGE}}"],
+            }
+        ],
+        "output_routes": [
+            {
+                "workflow_group": "line_items",
+                "workflow_field": "description",
+                "final_path": "/line_items/description",
+                "step_name": "line_item_labels",
+                "level": "chunk",
+                "output_map": "customChunkOutputs",
+                "output_key": "label",
+                "readback_path": ("/chunks/*/customChunkOutputs/line_item_labels/label"),
+            }
+        ],
+        "leaf_fields": [
+            {
+                "final_path": "/line_items/description",
+                "workflow_group": "line_items",
+                "workflow_field": "description",
+                "step_name": "line_item_labels",
+                "level": "chunk",
+                "output_key": "label",
+                "field_type": "str",
+                "is_repeated": False,
+                "repetition_scope": "none",
+            }
+        ],
+    },
+}
+
+
+class RecordingWorkflows:
+    def __init__(self, response: typing.Optional[WorkflowResponse] = None) -> None:
+        self.response = response
+        self.calls: typing.List[typing.Tuple[typing.Any, ...]] = []
+
+    def create(self, **kwargs: typing.Any) -> str:
+        self.calls.append(("create", kwargs))
+        return "created"
+
+    def update(self, id: str, **kwargs: typing.Any) -> str:
+        self.calls.append(("update", id, kwargs))
+        return "updated"
+
+    def get(
+        self,
+        id: str,
+        *,
+        request_options: typing.Optional[typing.Mapping[str, typing.Any]] = None,
+    ) -> WorkflowResponse:
+        self.calls.append(("get", id, request_options))
+        if self.response is None:
+            raise AssertionError("missing workflow response")
+        return self.response
+
+
+class AsyncRecordingWorkflows:
+    def __init__(self, response: typing.Optional[WorkflowResponse] = None) -> None:
+        self.response = response
+        self.calls: typing.List[typing.Tuple[typing.Any, ...]] = []
+
+    async def create(self, **kwargs: typing.Any) -> str:
+        self.calls.append(("create", kwargs))
+        return "created"
+
+    async def update(self, id: str, **kwargs: typing.Any) -> str:
+        self.calls.append(("update", id, kwargs))
+        return "updated"
+
+    async def get(
+        self,
+        id: str,
+        *,
+        request_options: typing.Optional[typing.Mapping[str, typing.Any]] = None,
+    ) -> WorkflowResponse:
+        self.calls.append(("get", id, request_options))
+        if self.response is None:
+            raise AssertionError("missing workflow response")
+        return self.response
+
+
+def _client(workflows: RecordingWorkflows) -> GroundX:
+    client = GroundX.__new__(GroundX)
+    typing.cast(typing.Any, client)._workflows = workflows
+    return client
+
+
+def _async_client(workflows: AsyncRecordingWorkflows) -> AsyncGroundX:
+    client = AsyncGroundX.__new__(AsyncGroundX)
+    typing.cast(typing.Any, client)._workflows = workflows
+    return client
+
+
+def _step_value(value: typing.Any, field: str) -> typing.Any:
+    if isinstance(value, dict):
+        return typing.cast(typing.Dict[str, typing.Any], value)[field]
+    return getattr(value, field)
+
+
+def _model_to_alias_dict(value: typing.Any) -> typing.Dict[str, typing.Any]:
+    if isinstance(value, dict):
+        return typing.cast(typing.Dict[str, typing.Any], value)
+    if hasattr(value, "dict"):
+        return typing.cast(typing.Dict[str, typing.Any], value.dict())
+    return typing.cast(
+        typing.Dict[str, typing.Any],
+        value.model_dump(by_alias=True, exclude_none=False),
+    )
+
+
+def test_load_definition_from_yaml_path_preserves_template_and_prepared(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "statement.yaml"
+    path.write_text(CUSTOM_WORKFLOW_YAML)
+
+    definition = _client(RecordingWorkflows()).load_extraction_definition_from_yaml(path=path)
+
+    assert definition.prepared is not None
+    assert definition.extract == definition.prepared.persisted_workflow_extract
+    assert definition.template == {
+        "{{LANGUAGE}}": "English",
+        "{{LANGUAGE_UNKNOWN}}": "",
+    }
+    assert definition.custom_steps[0]["name"] == "line_item_labels"
+    assert definition.output_routes[0]["output_key"] == "label"
+    assert definition.leaf_fields[0]["field_type"] == "str"
+
+
+def test_load_extraction_definition_uses_yaml_path(tmp_path: Path) -> None:
+    path = tmp_path / "statement.yaml"
+    path.write_text(CUSTOM_WORKFLOW_YAML)
+
+    definition = _client(RecordingWorkflows()).load_extraction_definition(path=path)
+
+    assert definition.prepared is not None
+    assert definition.template == {
+        "{{LANGUAGE}}": "English",
+        "{{LANGUAGE_UNKNOWN}}": "",
+    }
+    assert definition.custom_steps[0]["name"] == "line_item_labels"
+
+
+def test_load_extraction_definition_uses_workflow_id() -> None:
+    response = WorkflowResponse(
+        workflow=WorkflowDetail(
+            workflow_id="workflow-1",
+            extract=EXECUTION_ONLY_EXTRACT,
+            template={"{{LANGUAGE}}": "English", "{{LANGUAGE_UNKNOWN}}": ""},
+        )
+    )
+    workflows = RecordingWorkflows(response)
+    request_options: RequestOptions = {"timeout_in_seconds": 1}
+
+    definition = _client(workflows).load_extraction_definition(
+        workflow_id="workflow-1",
+        request_options=request_options,
+    )
+
+    assert workflows.calls == [("get", "workflow-1", request_options)]
+    assert definition.extract == EXECUTION_ONLY_EXTRACT
+    assert definition.template["{{LANGUAGE_UNKNOWN}}"] == ""
+
+
+def test_load_extraction_definition_uses_workflow_id_before_yaml_sources(tmp_path: Path) -> None:
+    path = tmp_path / "statement.yaml"
+    path.write_text("not: [valid")
+    response = WorkflowResponse(
+        workflow=WorkflowDetail(
+            workflow_id="workflow-1",
+            extract=EXECUTION_ONLY_EXTRACT,
+            template={"{{LANGUAGE}}": "English", "{{LANGUAGE_UNKNOWN}}": ""},
+        )
+    )
+    workflows = RecordingWorkflows(response)
+    request_options: RequestOptions = {"timeout_in_seconds": 1}
+
+    definition = _client(workflows).load_extraction_definition(
+        workflow_id="workflow-1",
+        path=path,
+        request_options=request_options,
+    )
+
+    assert workflows.calls == [("get", "workflow-1", request_options)]
+    assert definition.extract == EXECUTION_ONLY_EXTRACT
+
+
+def test_load_extraction_definition_rejects_mapping_kind_with_workflow_id() -> None:
+    response = WorkflowResponse(
+        workflow=WorkflowDetail(
+            workflow_id="workflow-1",
+            extract=EXECUTION_ONLY_EXTRACT,
+        )
+    )
+
+    with pytest.raises(ValueError, match="mapping_kind"):
+        _client(RecordingWorkflows(response)).load_extraction_definition(
+            workflow_id="workflow-1",
+            mapping_kind="workflow_extract",
+        )
+
+
+def test_load_extraction_definition_rejects_missing_or_ambiguous_yaml_sources(tmp_path: Path) -> None:
+    path = tmp_path / "statement.yaml"
+    path.write_text(CUSTOM_WORKFLOW_YAML)
+
+    with pytest.raises(ValueError, match="exactly one"):
+        _client(RecordingWorkflows()).load_extraction_definition()
+    with pytest.raises(ValueError, match="exactly one"):
+        _client(RecordingWorkflows()).load_extraction_definition(
+            path=path,
+            yaml_text=CUSTOM_WORKFLOW_YAML,
+        )
+    with pytest.raises(ValueError, match="request_options"):
+        _client(RecordingWorkflows()).load_extraction_definition(
+            path=path,
+            request_options={"timeout_in_seconds": 1},
+        )
+
+
+def test_load_definition_from_mapping_defaults_to_authored_yaml() -> None:
+    mapping = typing.cast(
+        typing.Dict[str, typing.Any],
+        yaml.safe_load(CUSTOM_WORKFLOW_YAML),
+    )
+
+    definition = _client(RecordingWorkflows()).load_extraction_definition_from_yaml(mapping=mapping)
+
+    assert definition.prepared is not None
+    assert definition.template["{{LANGUAGE}}"] == "English"
+    assert definition.template["{{LANGUAGE_UNKNOWN}}"] == ""
+
+
+def test_workflow_extract_mapping_requires_explicit_kind() -> None:
+    persisted = prepare_extraction_yaml(CUSTOM_WORKFLOW_YAML).persisted_workflow_extract
+
+    client = _client(RecordingWorkflows())
+    with pytest.raises(ValueError, match="mapping_kind"):
+        client.load_extraction_definition_from_yaml(mapping=persisted)
+
+    definition = client.load_extraction_definition_from_yaml(
+        mapping=persisted,
+        mapping_kind="workflow_extract",
+    )
+
+    assert definition.extract == persisted
+    assert definition.prepared is not None
+    assert definition.template == {
+        "{{LANGUAGE}}": "English",
+        "{{LANGUAGE_UNKNOWN}}": "",
+    }
+
+
+def test_workflow_extract_without_authored_metadata_returns_no_prepared() -> None:
+    definition = _client(RecordingWorkflows()).load_extraction_definition_from_yaml(
+        mapping=EXECUTION_ONLY_EXTRACT,
+        mapping_kind="workflow_extract",
+    )
+
+    assert definition.prepared is None
+    assert definition.extract == EXECUTION_ONLY_EXTRACT
+    assert definition.template["{{LANGUAGE_UNKNOWN}}"] == ""
+    assert definition.custom_steps[0]["name"] == "line_item_labels"
+
+
+def test_template_values_must_be_strings() -> None:
+    mapping = typing.cast(
+        typing.Dict[str, typing.Any],
+        yaml.safe_load(CUSTOM_WORKFLOW_YAML),
+    )
+    mapping["workflow"]["template"]["{{LANGUAGE}}"] = ["English"]
+
+    with pytest.raises(ValueError, match=r"\{\{LANGUAGE\}\}"):
+        _client(RecordingWorkflows()).load_extraction_definition_from_yaml(mapping=mapping)
+
+
+def test_load_definition_from_workflow_preserves_top_level_workflow_fields() -> None:
+    response = WorkflowResponse(
+        workflow=WorkflowDetail(
+            workflow_id="workflow-1",
+            name="workflow name",
+            extract=EXECUTION_ONLY_EXTRACT,
+            template={"{{LANGUAGE}}": "French", "{{LANGUAGE_UNKNOWN}}": ""},
+            custom_steps=typing.cast(
+                typing.Any,
+                [
+                    {
+                        "name": "top_level_labels",
+                        "level": "chunk",
+                        "kind": "keys",
+                        "requiredTemplateKeys": ["{{LANGUAGE}}"],
+                    }
+                ],
+            ),
+            output_routes=typing.cast(
+                typing.Any,
+                [
+                    {
+                        "workflowGroup": "line_items",
+                        "workflowField": "description",
+                        "finalPath": "/line_items/description",
+                        "stepName": "top_level_labels",
+                        "level": "chunk",
+                        "outputMap": "customChunkOutputs",
+                        "outputKey": "label",
+                        "readbackPath": ("/chunks/*/customChunkOutputs/top_level_labels/label"),
+                    }
+                ],
+            ),
+            leaf_fields=typing.cast(
+                typing.Any,
+                [
+                    {
+                        "finalPath": "/line_items/description",
+                        "workflowGroup": "line_items",
+                        "workflowField": "description",
+                        "stepName": "top_level_labels",
+                        "level": "chunk",
+                        "outputKey": "label",
+                        "fieldType": "str",
+                        "isRepeated": False,
+                        "repetitionScope": "none",
+                    }
+                ],
+            ),
+            chunk_strategy="size",
+            section_strategy="page",
+            steps=WorkflowSteps(chunk_keys=WorkflowStep(all_=WorkflowStepConfig(includes={"text": True}))),
+        )
+    )
+    workflows = RecordingWorkflows(response)
+    request_options: RequestOptions = {"timeout_in_seconds": 1}
+
+    definition = _client(workflows).load_extraction_definition_from_workflow(
+        "workflow-1",
+        request_options=request_options,
+    )
+
+    assert workflows.calls == [("get", "workflow-1", request_options)]
+    assert definition.prepared is None
+    assert definition.template == {
+        "{{LANGUAGE}}": "French",
+        "{{LANGUAGE_UNKNOWN}}": "",
+    }
+    assert _step_value(definition.custom_steps[0], "name") == "top_level_labels"
+    assert _step_value(definition.custom_steps[0], "required_template_keys") == ["{{LANGUAGE}}"]
+    assert _step_value(definition.output_routes[0], "step_name") == "top_level_labels"
+    assert _step_value(definition.output_routes[0], "output_key") == "label"
+    assert _step_value(definition.leaf_fields[0], "step_name") == "top_level_labels"
+    assert _step_value(definition.leaf_fields[0], "field_type") == "str"
+    assert definition.chunk_strategy == "size"
+    assert definition.section_strategy == "page"
+    assert _step_value(definition.steps, "chunk_keys") is not None
+
+
+def test_load_definition_from_workflow_requires_extract() -> None:
+    response = WorkflowResponse(workflow=WorkflowDetail(workflow_id="workflow-1", name="workflow name"))
+
+    with pytest.raises(ValueError, match="workflow-1"):
+        _client(RecordingWorkflows(response)).load_extraction_definition_from_workflow("workflow-1")
+
+
+def test_create_and_update_use_definition_before_yaml_sources() -> None:
+    client = _client(RecordingWorkflows())
+    definition = client.load_extraction_definition_from_yaml(yaml_text=CUSTOM_WORKFLOW_YAML)
+
+    assert (
+        client.create_extraction_workflow(
+            definition=definition,
+            yaml_text="not: [valid",
+            name="statement extraction",
+        )
+        == "created"
+    )
+    assert (
+        client.update_extraction_workflow(
+            "workflow-1",
+            definition=definition,
+            yaml_text="not: [valid",
+            name="statement extraction",
+        )
+        == "updated"
+    )
+
+    assert client.workflows.calls[0][1]["extract"] == definition.extract
+    assert client.workflows.calls[1][2]["extract"] == definition.extract
+
+
+def test_create_and_update_reject_mapping_kind_with_definition() -> None:
+    client = _client(RecordingWorkflows())
+    definition = client.load_extraction_definition_from_yaml(yaml_text=CUSTOM_WORKFLOW_YAML)
+
+    with pytest.raises(ValueError, match="mapping_kind"):
+        client.create_extraction_workflow(
+            definition=definition,
+            mapping_kind="workflow_extract",
+            name="statement extraction",
+        )
+
+    with pytest.raises(ValueError, match="mapping_kind"):
+        client.update_extraction_workflow(
+            "workflow-1",
+            definition=definition,
+            mapping_kind="workflow_extract",
+            name="statement extraction",
+        )
+
+
+def test_create_and_update_reject_missing_or_ambiguous_yaml_sources() -> None:
+    client = _client(RecordingWorkflows())
+
+    with pytest.raises(ValueError, match="exactly one"):
+        client.create_extraction_workflow(name="statement extraction")
+    with pytest.raises(ValueError, match="path.*yaml_text|yaml_text.*path"):
+        client.create_extraction_workflow(
+            path="statement.yaml",
+            yaml_text=CUSTOM_WORKFLOW_YAML,
+            name="statement extraction",
+        )
+    with pytest.raises(ValueError, match="mapping_kind"):
+        client.create_extraction_workflow(
+            yaml_text=CUSTOM_WORKFLOW_YAML,
+            mapping_kind="workflow_extract",
+            name="statement extraction",
+        )
+
+
+def test_create_and_update_forward_workflow_settings_and_request_options() -> None:
+    workflows = RecordingWorkflows()
+    client = _client(workflows)
+    request_options: RequestOptions = {"timeout_in_seconds": 1}
+
+    assert (
+        client.create_extraction_workflow(
+            yaml_text=CUSTOM_WORKFLOW_YAML,
+            name="statement extraction",
+            request_options=request_options,
+        )
+        == "created"
+    )
+    assert (
+        client.update_extraction_workflow(
+            "workflow-1",
+            yaml_text=CUSTOM_WORKFLOW_YAML,
+            name="statement extraction",
+            request_options=request_options,
+        )
+        == "updated"
+    )
+
+    create_kwargs = workflows.calls[0][1]
+    update_kwargs = workflows.calls[1][2]
+
+    assert create_kwargs["name"] == "statement extraction"
+    assert create_kwargs["request_options"] is request_options
+    assert update_kwargs["name"] == "statement extraction"
+    assert update_kwargs["request_options"] is request_options
+    assert create_kwargs["template"] == {
+        "{{LANGUAGE}}": "English",
+        "{{LANGUAGE_UNKNOWN}}": "",
+    }
+    assert create_kwargs["extract"]["workflow"]["template"] == {
+        "{{LANGUAGE}}": "English",
+        "{{LANGUAGE_UNKNOWN}}": "",
+    }
+    assert create_kwargs["custom_steps"][0]["name"] == "line_item_labels"
+    assert create_kwargs["output_routes"][0]["output_key"] == "label"
+    assert create_kwargs["leaf_fields"][0]["field_type"] == "str"
+    assert update_kwargs["extract"] == create_kwargs["extract"]
+
+
+def test_create_and_update_accept_yaml_path_shortcut(tmp_path: Path) -> None:
+    path = tmp_path / "statement.yaml"
+    path.write_text(CUSTOM_WORKFLOW_YAML)
+    workflows = RecordingWorkflows()
+    client = _client(workflows)
+
+    assert (
+        client.create_extraction_workflow(
+            path=path,
+            name="statement extraction",
+        )
+        == "created"
+    )
+    assert (
+        client.update_extraction_workflow(
+            "workflow-1",
+            path=path,
+            name="statement extraction",
+        )
+        == "updated"
+    )
+
+    create_kwargs = workflows.calls[0][1]
+    update_kwargs = workflows.calls[1][2]
+    assert create_kwargs["extract"] == update_kwargs["extract"]
+    assert create_kwargs["template"] == {
+        "{{LANGUAGE}}": "English",
+        "{{LANGUAGE_UNKNOWN}}": "",
+    }
+
+
+def test_create_requires_name_but_update_can_omit_name() -> None:
+    workflows = RecordingWorkflows()
+    client = _client(workflows)
+
+    with pytest.raises(ValueError, match="name"):
+        client.create_extraction_workflow(yaml_text=CUSTOM_WORKFLOW_YAML)
+
+    assert (
+        client.update_extraction_workflow(
+            "workflow-1",
+            yaml_text=CUSTOM_WORKFLOW_YAML,
+        )
+        == "updated"
+    )
+    assert "name" not in workflows.calls[0][2]
+
+
+def test_custom_steps_disable_exact_fixed_default_overlay() -> None:
+    workflows = RecordingWorkflows()
+    client = _client(workflows)
+
+    client.create_extraction_workflow(
+        yaml_text=CUSTOM_WORKFLOW_YAML,
+        name="statement extraction",
+    )
+
+    steps = workflows.calls[0][1]["steps"]
+    assert _model_to_alias_dict(steps) == {
+        "chunk-instruct": None,
+        "chunk-keys": None,
+        "chunk-summary": None,
+        "doc-keys": None,
+        "doc-summary": None,
+        "sect-instruct": None,
+        "sect-summary": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_methods_match_sync_source_loading_and_forwarding() -> None:
+    response = WorkflowResponse(
+        workflow=WorkflowDetail(
+            workflow_id="workflow-1",
+            extract=EXECUTION_ONLY_EXTRACT,
+            template={"{{LANGUAGE}}": "English", "{{LANGUAGE_UNKNOWN}}": ""},
+        )
+    )
+    workflows = AsyncRecordingWorkflows(response)
+    client = _async_client(workflows)
+    request_options: RequestOptions = {"timeout_in_seconds": 1}
+
+    definition = await client.load_extraction_definition_from_yaml(yaml_text=CUSTOM_WORKFLOW_YAML)
+    direct_definition = await client.load_extraction_definition(yaml_text=CUSTOM_WORKFLOW_YAML)
+    workflow_definition = await client.load_extraction_definition(
+        workflow_id="workflow-1",
+        yaml_text="not: [valid",
+        request_options=request_options,
+    )
+    from_workflow = await client.load_extraction_definition_from_workflow(
+        "workflow-1",
+        request_options=request_options,
+    )
+    created = await client.create_extraction_workflow(
+        definition=definition,
+        yaml_text="not: [valid",
+        name="statement extraction",
+        request_options=request_options,
+    )
+    updated = await client.update_extraction_workflow(
+        "workflow-1",
+        definition=from_workflow,
+        yaml_text="not: [valid",
+        request_options=request_options,
+    )
+
+    assert created == "created"
+    assert updated == "updated"
+    assert workflows.calls[0] == ("get", "workflow-1", request_options)
+    assert workflows.calls[1] == ("get", "workflow-1", request_options)
+    assert workflows.calls[2][1]["request_options"] is request_options
+    assert workflows.calls[3][2]["request_options"] is request_options
+    assert workflows.calls[2][1]["template"]["{{LANGUAGE_UNKNOWN}}"] == ""
+    assert direct_definition.extract == definition.extract
+    assert workflow_definition.extract == from_workflow.extract


### PR DESCRIPTION
## Summary
Consolidates the `groundx-python` extraction workflow SDK work into one review PR.

Includes:
- the OpenSpec plan work from former #10
- the extraction workflow helper implementation from former #11
- the PromptManager/ObjectStore reliability fix from former #13

Does not include:
- the unauthorized release commit from former #12
- any version bump or release action

## Base Branch
This PR targets `codex/revert-unauthorized-groundx-python` so the diff shows all intended changes after unauthorized merges are reverted. After the revert PR is merged, this PR can be retargeted to `main`.

## Validation
- poetry run mypy .
- poetry run pytest -q tests/extract/services/test_upload_minio.py tests/extract/services/test_upload_s3.py tests/extract/prompt/test_manager.py
- poetry run pytest -rP -n auto .
- git diff --check codex/revert-unauthorized-groundx-python..HEAD