### PR TITLE
[codex] fix custom workflow persisted extract payload

### DIFF
--- a/openspec/changes/support-custom-workflow-steps/task11-e2e-checkpoint.md
+++ b/openspec/changes/support-custom-workflow-steps/task11-e2e-checkpoint.md
@@ -4,15 +4,15 @@
 
 Partially executed. Release remains blocked.
 
-Updated 2026-06-15 after cashbot-go `master` CI passed and
-`groundx==3.6.7` was published.
+Updated 2026-06-15 after deployed runtime/API guardrail retests, live ingest
+attempts, and a local SDK payload fix.
 
 ## Local Non-Live Evidence
 
 - Legacy YAML selected:
-  `/Users/benjaminfletcher/git/groundx-studio-harness-support-custom-workflow-steps/skills/groundx-extraction-workflows/examples/insurance-claim/prompt.yaml`.
+  `/Users/benjaminfletcher/git/groundx-studio-harness/skills/groundx-extraction-workflows/examples/insurance-claim/prompt.yaml`.
 - Custom-step YAML selected:
-  `/Users/benjaminfletcher/git/adp-poc-support-custom-workflow-steps/workflows/adp_401k_v1/prompt.yaml`.
+  `/Users/benjaminfletcher/git/adp-poc/workflows/adp_401k_v1/prompt.yaml`.
 - Both compiled and passed structural validation through the unpublished local
   SDK/harness worktrees.
 - Legacy compiled workflow had no custom workflow metadata.
@@ -25,6 +25,17 @@ Updated 2026-06-15 after cashbot-go `master` CI passed and
 - The synthetic ADP final JSON did not leak the custom step name.
 - The Arcadia current-wave deferral stub remains in place at
   `/Users/benjaminfletcher/git/internal-arcadia-agents/openspec/notes/support-custom-workflow-steps-deferral.md`.
+- Live smoke found that the SDK persisted authored YAML copy carried
+  authoring-only `workflow_step` / `workflow_output_key` keys into
+  `_groundx_persisted_extract`, which made the deployed layout path fail with
+  `unsupported pseudo-group keys`.
+- Local SDK fix added a regression so custom workflow `_groundx_persisted_extract`
+  is runtime-safe, keeps persisted `workflow.metadata_version: 1`, strips
+  authoring-only custom-step keys, and still reloads from persisted route/leaf
+  metadata.
+- Focused verification after the local SDK fix:
+  `poetry run pytest tests/custom/test_extraction_workflow_client_exports.py tests/extract/test_extraction_workflow_definitions.py tests/extract/prompt/test_manager.py tests/extract/prompt/test_persisted_workflow_extract.py -q`
+  passed with `93 passed, 5 subtests passed`.
 
 ## Live Workflow API Evidence
 
@@ -59,23 +70,77 @@ Using the unpublished local SDK against the deployed API:
     not acceptable release evidence.
   - Cleanup verification again found zero remaining workflows with prefix
     `codex-e2e-support-custom-workflow-steps-`.
+- Retest after final deployed cashbot-go guardrail fix:
+  - Negative 21-field oversized/spoofed workflow create returned HTTP 400 with
+    message `Invalid attribute 'workflow.outputRoutes': custom step
+    adp_f1_employer_information has 21 fields; max is 20`.
+  - Negative 21-field oversized/spoofed workflow update returned HTTP 400 with
+    the same custom-step max-field message.
+  - The temporary valid workflow used for the update test was deleted.
+
+## Live Ingest Evidence
+
+Using the local SDK against the deployed API/runtime:
+
+- Representative ADP sanitized PDF attempted:
+  `/Users/benjaminfletcher/git/adp-poc/samples/sanitized/ePlan 2A.pdf`.
+  - Workflow ID: `29f0d030-b962-477d-8383-0a05f0ba96db`
+  - Bucket ID: `29238`
+  - Process ID: `0fe08fa0-430b-40c4-9a75-8a4ee9566eff`
+  - Document ID: `b68c67fd-02bc-41e0-ad7d-577cb7a75e98`
+  - Final document status: `error`
+  - Error: `file is too large to process for this subscription level`
+  - Cleanup deleted the document, unassigned and deleted the workflow, and
+    deleted the bucket.
+- Tiny synthetic one-page ADP-style PDF smoke before the local SDK payload fix:
+  - Workflow ID: `55828d2a-c0e8-409a-8742-b60c3df2cad5`
+  - Bucket ID: `29239`
+  - Process ID: `7295167c-46d7-45e0-a597-b8b3912e0277`
+  - Document ID: `505aa0b3-eacf-446e-8390-7100f1fb3f42`
+  - X-Ray contained `customChunkOutputs` from custom ADP steps.
+  - Final extract failed with `unsupported pseudo-group keys at
+    [_pseudo_groups.adp_f10_employer_contributions_profit_sharing]:
+    ['workflow_step']`.
+  - Cleanup deleted the document, unassigned and deleted the workflow, deleted
+    the bucket, and deleted the temporary PDF.
+- Tiny synthetic one-page ADP-style PDF smoke after the local SDK payload fix:
+  - Payload check passed before create:
+    `_groundx_persisted_extract.workflow.metadata_version == 1` and the authored
+    copy contained no `workflow_step` text.
+  - Workflow ID: `d240c6bf-4ed0-4cb8-a0de-0a8ebe603fb1`
+  - Bucket ID: `29240`
+  - Process ID: `fc5bab86-aaca-413d-a2a0-d82274b7dbd5`
+  - Document ID: `6fea60f4-682a-4af2-b214-d5cc0fb0cfdf`
+  - X-Ray readback via SDK succeeded.
+  - X-Ray contained two `customChunkOutputs` containers.
+  - First observed custom output:
+    `customChunkOutputs.adp_f10_employer_contributions_profit_sharing.f116_employer_profit_sharing_type`.
+  - Route metadata mapped it to final path
+    `/employer_contributions/employer_profit_sharing_type`.
+  - Final extract failed with `[latest.yaml] is missing a statement entry`.
+  - Cleanup deleted the document, unassigned and deleted the workflow, deleted
+    the bucket, and deleted the temporary PDF.
+- Cleanup verification found zero remaining buckets and zero remaining documents
+  with the `codex-e2e-support-custom-workflow-steps-` prefix.
 
 ## Blockers
 
-- The deployed API no longer accepts the narrow invalid workflow, but the live
-  negative checks still do not prove the intended 20-field executable custom
-  step guardrail. One path disconnected without a response; the narrower path
-  returned an unrelated missing-route error. Release e2e cannot be closed until
-  the oversized/spoofed request fails with a clear custom-step field-count
-  validation error.
-- `FERN_TOKEN` / Fern org access and `NPM_TOKEN` are unavailable in the local
-  environment, so docs publish and TypeScript package publish remain blocked.
-- Live representative document ingest/extract was not run because the deployed
-  oversized-step guardrail failed first. Running ingest before that guardrail is
-  fixed would not prove release readiness.
+- The SDK payload fix is local only. It must be committed, reviewed, merged, and
+  released before published-SDK E2E can pass.
+- Live representative ADP ingest is blocked by the current account/subscription
+  limit: even the smallest sanitized representative PDF attempted here failed as
+  too large for the subscription level.
+- The deployed final-extract/layout path is still not generic. After the SDK
+  payload fix, custom-step execution and X-Ray readback worked, but final extract
+  failed because the extract agent still expected a `statement` root group.
+- Local publish credentials such as Fern org access and NPM token are not
+  available in this environment; any docs/SDK/TypeScript publish verification
+  must be done through the maintainer-owned release path.
 
 ## Required Next Step
 
-Fix or verify the deployed runtime/API validation path so oversized/spoofed
-custom-step requests fail with the intended field-count error, then rerun Task
-11 from the live negative oversized-step check onward.
+Commit the local SDK payload fix, publish the next `groundx-python` release, and
+decide whether the final-extract `statement` assumption must be fixed now or
+whether X-Ray custom-output readback is the explicitly approved deployed-path
+substitute for this release. If final extract remains required, fix that deployed
+agent/layout path before rerunning Task 11.

--- a/openspec/changes/support-custom-workflow-steps/task11-e2e-checkpoint.md
+++ b/openspec/changes/support-custom-workflow-steps/task11-e2e-checkpoint.md
@@ -5,7 +5,8 @@
 Partially executed. Release remains blocked.
 
 Updated 2026-06-15 after deployed runtime/API guardrail retests, live ingest
-attempts, a committed SDK payload fix, and a post-deploy ingest rerun.
+attempts, SDK payload/readback fixes, an Arcadia runtime guard fix, and a
+post-deploy ingest rerun.
 
 ## Local Non-Live Evidence
 
@@ -33,6 +34,12 @@ attempts, a committed SDK payload fix, and a post-deploy ingest rerun.
   is runtime-safe, keeps persisted `workflow.metadata_version: 1`, strips
   authoring-only custom-step keys, and still reloads from persisted route/leaf
   metadata.
+- Local SDK readback fix added regressions so routed custom X-Ray outputs load
+  into final YAML paths, including repeated custom outputs that should land in
+  one final row.
+- Local Arcadia runtime guard fix added a regression for custom workflows that
+  have no legacy `statement` group. Unknown flat outputs no longer crash
+  `Statement.add()` with `[latest.yaml] is missing a statement entry`.
 - Focused verification after the local SDK fix:
   `poetry run pytest tests/custom/test_extraction_workflow_client_exports.py tests/extract/test_extraction_workflow_definitions.py tests/extract/prompt/test_manager.py tests/extract/prompt/test_persisted_workflow_extract.py -q`
   passed with `93 passed, 5 subtests passed`.
@@ -152,24 +159,26 @@ Using the local SDK against the deployed API/runtime:
 ## Blockers
 
 - The SDK payload fix is committed and pushed in PR #19, but it is not merged or
-  released. Published-SDK E2E is still blocked on review, merge, and the next
-  `groundx-python` release.
+  released. The SDK readback fix is also pushed in PR #19. Published-SDK E2E is
+  still blocked on review, merge, and the next `groundx-python` release.
+- The Arcadia missing-`statement` guard is pushed in
+  `internal-arcadia-agents` PR #67, but it is not merged or deployed.
 - Live representative ADP ingest is blocked by the current account/subscription
   limit: even the smallest sanitized representative PDF attempted here failed as
   too large for the subscription level.
-- The deployed final-extract/layout path is still not generic. The corrected
-  no-`process_level` rerun reached processing and custom X-Ray readback worked,
-  but final layout/extract failed because the extract agent still expected a
-  `statement` root group.
+- The deployed final-extract/layout path has not been retested after the local
+  SDK and Arcadia fixes. The corrected no-`process_level` rerun reached
+  processing and custom X-Ray readback worked, but final layout/extract failed
+  on the then-deployed `statement` root assumption.
 - Local publish credentials such as Fern org access and NPM token are not
   available in this environment; any docs/SDK/TypeScript publish verification
   must be done through the maintainer-owned release path.
 
 ## Required Next Step
 
-Merge and release PR #19, then fix the deployed final-extract/layout
-`statement` assumption or explicitly accept custom X-Ray readback as substitute
-deployed-path evidence for this release. If representative ADP ingest remains
-subscription-blocked, use an explicitly approved small synthetic ADP PDF as the
-deployed-path substitute. Only archive the plan after the rerun either passes or
-release governance explicitly accepts substitute evidence.
+Merge and release PR #19, merge and deploy `internal-arcadia-agents` PR #67,
+then rerun the corrected `client.ingest(...)` deployed-path test with no
+`process_level`. If representative ADP ingest remains subscription-blocked, use
+an explicitly approved small synthetic ADP PDF as the deployed-path substitute.
+Only archive the plan after the rerun either passes or release governance
+explicitly accepts substitute evidence.

--- a/openspec/changes/support-custom-workflow-steps/task11-e2e-checkpoint.md
+++ b/openspec/changes/support-custom-workflow-steps/task11-e2e-checkpoint.md
@@ -120,23 +120,32 @@ Using the local SDK against the deployed API/runtime:
   - Final extract failed with `[latest.yaml] is missing a statement entry`.
   - Cleanup deleted the document, unassigned and deleted the workflow, deleted
     the bucket, and deleted the temporary PDF.
-- Post-deploy rerun after the final-extract `statement` path was reported
-  deployed did not reach document processing:
-  - The local branch payload check still passed:
+- Discarded invalid post-deploy rerun:
+  - The rerun incorrectly supplied `process_level="X-RAY"` on `Document(...)`.
+  - That value is invalid and not required for this workflow path, so the
+    resulting `document.fileData` / `document or documents` HTTP 400s are not
+    release blockers.
+- Corrected post-deploy rerun with `client.ingest(...)` and no `process_level`:
+  - Payload check passed before create:
     `_groundx_persisted_extract.workflow.metadata_version == 1` and the authored
     copy contained no `workflow_step` text.
-  - Standard `client.ingest(...)` with a normal one-page reportlab PDF uploaded
-    the file and then failed before processing with deployed HTTP 400:
-    `Required attribute 'document.fileData' is missing or empty`.
-  - Retrying with an explicit upload, a 12 second delay, and direct
-    `documents.ingest_remote(...)` failed with the same deployed HTTP 400.
-  - Generated `documents.ingest_local(...)` also did not provide a usable
-    workaround; the deployed API returned HTTP 400:
-    `Required attribute 'document or documents' is missing or empty`.
-  - Cleanup deleted each temporary bucket/workflow and temporary PDF.
+  - Workflow ID: `66f718a5-75cd-4292-ab5d-e833ecaa5349`
+  - Bucket ID: `29246`
+  - Process ID: `9d848a40-d7b9-4b13-8992-3d815d4c99c8`
+  - Document ID: `415a2fe4-daf7-4e9a-b1d4-31fb166d86a3`
+  - `client.ingest(...)` reached processing successfully.
+  - X-Ray readback via SDK succeeded.
+  - X-Ray contained two `customChunkOutputs` containers.
+  - First observed custom output:
+    `customChunkOutputs.adp_f10_employer_contributions_profit_sharing.f116_employer_profit_sharing_type`.
+  - Final document status was `error`.
+  - Final extract was unavailable; the document layout error was
+    `[latest.yaml] is missing a statement entry`.
+  - Cleanup deleted the document, unassigned and deleted the workflow, deleted
+    the bucket, and deleted the temporary PDF.
 - Cleanup verification found zero remaining buckets and zero remaining documents
   with the `codex-e2e-support-custom-workflow-steps-` prefix.
-- Post-deploy cleanup verification found zero remaining buckets, zero remaining
+- Corrected post-deploy cleanup verification found zero remaining buckets, zero remaining
   workflows, and zero remaining documents with the
   `codex-e2e-support-custom-workflow-steps-` prefix.
 
@@ -148,21 +157,19 @@ Using the local SDK against the deployed API/runtime:
 - Live representative ADP ingest is blocked by the current account/subscription
   limit: even the smallest sanitized representative PDF attempted here failed as
   too large for the subscription level.
-- The post-deploy rerun cannot verify whether the final-extract/layout
-  `statement` assumption is fixed, because ingest now fails before processing
-  with `Required attribute 'document.fileData' is missing or empty`.
-- The deployed ingest path used by the SDK helper appears incompatible with the
-  current API/runtime response path. `client.ingest(...)`,
-  `documents.ingest_remote(...)`, and generated `documents.ingest_local(...)`
-  all failed before processing a small PDF.
+- The deployed final-extract/layout path is still not generic. The corrected
+  no-`process_level` rerun reached processing and custom X-Ray readback worked,
+  but final layout/extract failed because the extract agent still expected a
+  `statement` root group.
 - Local publish credentials such as Fern org access and NPM token are not
   available in this environment; any docs/SDK/TypeScript publish verification
   must be done through the maintainer-owned release path.
 
 ## Required Next Step
 
-Merge and release PR #19, resolve the deployed ingest `document.fileData`
-failure, then rerun Task 11. If representative ADP ingest remains
+Merge and release PR #19, then fix the deployed final-extract/layout
+`statement` assumption or explicitly accept custom X-Ray readback as substitute
+deployed-path evidence for this release. If representative ADP ingest remains
 subscription-blocked, use an explicitly approved small synthetic ADP PDF as the
 deployed-path substitute. Only archive the plan after the rerun either passes or
 release governance explicitly accepts substitute evidence.

--- a/openspec/changes/support-custom-workflow-steps/task11-e2e-checkpoint.md
+++ b/openspec/changes/support-custom-workflow-steps/task11-e2e-checkpoint.md
@@ -5,7 +5,7 @@
 Partially executed. Release remains blocked.
 
 Updated 2026-06-15 after deployed runtime/API guardrail retests, live ingest
-attempts, and a local SDK payload fix.
+attempts, a committed SDK payload fix, and a post-deploy ingest rerun.
 
 ## Local Non-Live Evidence
 
@@ -120,27 +120,49 @@ Using the local SDK against the deployed API/runtime:
   - Final extract failed with `[latest.yaml] is missing a statement entry`.
   - Cleanup deleted the document, unassigned and deleted the workflow, deleted
     the bucket, and deleted the temporary PDF.
+- Post-deploy rerun after the final-extract `statement` path was reported
+  deployed did not reach document processing:
+  - The local branch payload check still passed:
+    `_groundx_persisted_extract.workflow.metadata_version == 1` and the authored
+    copy contained no `workflow_step` text.
+  - Standard `client.ingest(...)` with a normal one-page reportlab PDF uploaded
+    the file and then failed before processing with deployed HTTP 400:
+    `Required attribute 'document.fileData' is missing or empty`.
+  - Retrying with an explicit upload, a 12 second delay, and direct
+    `documents.ingest_remote(...)` failed with the same deployed HTTP 400.
+  - Generated `documents.ingest_local(...)` also did not provide a usable
+    workaround; the deployed API returned HTTP 400:
+    `Required attribute 'document or documents' is missing or empty`.
+  - Cleanup deleted each temporary bucket/workflow and temporary PDF.
 - Cleanup verification found zero remaining buckets and zero remaining documents
   with the `codex-e2e-support-custom-workflow-steps-` prefix.
+- Post-deploy cleanup verification found zero remaining buckets, zero remaining
+  workflows, and zero remaining documents with the
+  `codex-e2e-support-custom-workflow-steps-` prefix.
 
 ## Blockers
 
-- The SDK payload fix is local only. It must be committed, reviewed, merged, and
-  released before published-SDK E2E can pass.
+- The SDK payload fix is committed and pushed in PR #19, but it is not merged or
+  released. Published-SDK E2E is still blocked on review, merge, and the next
+  `groundx-python` release.
 - Live representative ADP ingest is blocked by the current account/subscription
   limit: even the smallest sanitized representative PDF attempted here failed as
   too large for the subscription level.
-- The deployed final-extract/layout path is still not generic. After the SDK
-  payload fix, custom-step execution and X-Ray readback worked, but final extract
-  failed because the extract agent still expected a `statement` root group.
+- The post-deploy rerun cannot verify whether the final-extract/layout
+  `statement` assumption is fixed, because ingest now fails before processing
+  with `Required attribute 'document.fileData' is missing or empty`.
+- The deployed ingest path used by the SDK helper appears incompatible with the
+  current API/runtime response path. `client.ingest(...)`,
+  `documents.ingest_remote(...)`, and generated `documents.ingest_local(...)`
+  all failed before processing a small PDF.
 - Local publish credentials such as Fern org access and NPM token are not
   available in this environment; any docs/SDK/TypeScript publish verification
   must be done through the maintainer-owned release path.
 
 ## Required Next Step
 
-Commit the local SDK payload fix, publish the next `groundx-python` release, and
-decide whether the final-extract `statement` assumption must be fixed now or
-whether X-Ray custom-output readback is the explicitly approved deployed-path
-substitute for this release. If final extract remains required, fix that deployed
-agent/layout path before rerunning Task 11.
+Merge and release PR #19, resolve the deployed ingest `document.fileData`
+failure, then rerun Task 11. If representative ADP ingest remains
+subscription-blocked, use an explicitly approved small synthetic ADP PDF as the
+deployed-path substitute. Only archive the plan after the rerun either passes or
+release governance explicitly accepts substitute evidence.

--- a/openspec/changes/support-custom-workflow-steps/tasks.md
+++ b/openspec/changes/support-custom-workflow-steps/tasks.md
@@ -746,8 +746,10 @@ Status: partially executed and blocked. Evidence is recorded in
       non-live substitute evidence approved to unblock release.
 - [ ] Adversarial review: confirm the test proves the deployed path, not only
       local compile. Current adversarial finding: custom-step execution and X-Ray
-      readback are deployed-path proven, but final extract still fails on a
-      deployed `statement`-root assumption and representative ADP ingest is
+      readback are deployed-path proven from the earlier synthetic run, but the
+      post-deploy rerun cannot reach processing because deployed ingest now
+      returns `Required attribute 'document.fileData' is missing or empty` for
+      the SDK upload/remote-ingest path. Representative ADP ingest is still
       blocked by subscription limits.
 
 ## Task 12: Closeout

--- a/openspec/changes/support-custom-workflow-steps/tasks.md
+++ b/openspec/changes/support-custom-workflow-steps/tasks.md
@@ -746,11 +746,11 @@ Status: partially executed and blocked. Evidence is recorded in
       non-live substitute evidence approved to unblock release.
 - [ ] Adversarial review: confirm the test proves the deployed path, not only
       local compile. Current adversarial finding: custom-step execution and X-Ray
-      readback are deployed-path proven from the earlier synthetic run, but the
-      post-deploy rerun cannot reach processing because deployed ingest now
-      returns `Required attribute 'document.fileData' is missing or empty` for
-      the SDK upload/remote-ingest path. Representative ADP ingest is still
-      blocked by subscription limits.
+      readback are deployed-path proven. The corrected post-deploy rerun used
+      `client.ingest(...)` without `process_level`, reached processing, and
+      read custom outputs from X-Ray, but final layout/extract still failed on
+      the deployed `statement`-root assumption. Representative ADP ingest is
+      still blocked by subscription limits.
 
 ## Task 12: Closeout
 

--- a/openspec/changes/support-custom-workflow-steps/tasks.md
+++ b/openspec/changes/support-custom-workflow-steps/tasks.md
@@ -723,18 +723,16 @@ Status: partially executed and blocked. Evidence is recorded in
       are unavailable, record blocked-release status or the explicitly reviewed
       non-live substitute evidence approved by release governance.
 - [ ] Retrieve X-Ray and final extract output.
-- [ ] Confirm custom step outputs are visible in X-Ray under the chosen shape.
+- [x] Confirm custom step outputs are visible in X-Ray under the chosen shape.
 - [x] Confirm custom output route metadata maps the X-Ray/readback value to the
       expected final JSON field.
 - [x] Confirm final JSON uses only user-facing YAML group/value names.
-- [ ] Confirm old persisted workflow extracts and legacy YAML continue to load or
+- [x] Confirm old persisted workflow extracts and legacy YAML continue to load or
       fail with the documented compatibility behavior.
-- [ ] Confirm direct workflow create/update rejects spoofed, caller-only, or
+- [x] Confirm direct workflow create/update rejects spoofed, caller-only, or
       mismatched field-count metadata for an oversized custom step.
-      Blocked: the deployed API accepted an oversized/spoofed custom-step
-      workflow and the test workflow was immediately deleted. This remains
-      blocked until the Cashbot runtime/API guardrail in PR #1493 is merged and
-      deployed.
+      Verified after deployment: create and update both return HTTP 400 with the
+      clear `has 21 fields; max is 20` custom-step guardrail error.
 - [ ] Confirm Arcadia default path works for legacy YAML.
 - [x] Confirm Arcadia custom field-action implementation is deferred to the
       follow-on `reconcile_fields`/`qa_fields`/`save_fields` plan.
@@ -747,7 +745,10 @@ Status: partially executed and blocked. Evidence is recorded in
 - [ ] Confirm live deployed-path E2E passed, or record the explicitly reviewed
       non-live substitute evidence approved to unblock release.
 - [ ] Adversarial review: confirm the test proves the deployed path, not only
-      local compile.
+      local compile. Current adversarial finding: custom-step execution and X-Ray
+      readback are deployed-path proven, but final extract still fails on a
+      deployed `statement`-root assumption and representative ADP ingest is
+      blocked by subscription limits.
 
 ## Task 12: Closeout
 

--- a/openspec/changes/support-custom-workflow-steps/tasks.md
+++ b/openspec/changes/support-custom-workflow-steps/tasks.md
@@ -749,8 +749,11 @@ Status: partially executed and blocked. Evidence is recorded in
       readback are deployed-path proven. The corrected post-deploy rerun used
       `client.ingest(...)` without `process_level`, reached processing, and
       read custom outputs from X-Ray, but final layout/extract still failed on
-      the deployed `statement`-root assumption. Representative ADP ingest is
-      still blocked by subscription limits.
+      the then-deployed `statement`-root assumption. Local SDK route-readback
+      and Arcadia missing-`statement` guard fixes are pushed in PR #19 and
+      `internal-arcadia-agents` PR #67; final deployed rerun is pending after
+      merge/release/deploy. Representative ADP ingest is still blocked by
+      subscription limits.
 
 ## Task 12: Closeout
 

--- a/src/groundx/extract/classes/document.py
+++ b/src/groundx/extract/classes/document.py
@@ -17,6 +17,7 @@ from .element import Element
 from .field import ExtractedField
 from .groundx import GroundXDocument, XRayDocument
 from .group import Group
+from .prompt import Prompt
 from PIL import Image
 from pydantic import (
     BaseModel,
@@ -43,6 +44,13 @@ class Document(Group):
     _logger: typing.Optional[Logger] = PrivateAttr(default=None)
     _prompt_manager: typing.Optional[PromptManager] = PrivateAttr(default=None)
     _upload: typing.Optional[Upload] = PrivateAttr(default=None)
+    _custom_output_route_cache: typing.Dict[
+        typing.Tuple[str, str],
+        typing.Dict[
+            typing.Tuple[str, str],
+            typing.List[typing.Mapping[str, typing.Any]],
+        ],
+    ] = PrivateAttr(default_factory=dict)
 
     @model_validator(mode="after")
     def _inject_context(self, info: ValidationInfo) -> "Document":
@@ -393,10 +401,12 @@ class Document(Group):
         if not custom_outputs:
             return
 
+        route_index = self.custom_output_route_index(source)
         for step_name, outputs in custom_outputs.items():
             if not isinstance(outputs, dict):
                 continue
 
+            repeated_rows: typing.Dict[typing.Tuple[str, ...], Group] = {}
             output_mapping = typing.cast(typing.Dict[str, typing.Any], outputs)
             for output_key, value in output_mapping.items():
                 data: typing.Any = value
@@ -405,6 +415,19 @@ class Document(Group):
                         data = json.loads(clean_json(data))
                     except json.JSONDecodeError:
                         pass
+
+                routes = route_index.get((step_name, output_key), [])
+                if routes:
+                    for route in routes:
+                        err = self.add_custom_output_route(
+                            route, data, repeated_rows
+                        )
+                        if err:
+                            raise Exception(
+                                f"\n\ninit {source} error for "
+                                f"[{step_name}.{output_key}]:\n\t{err}\n"
+                            )
+                    continue
 
                 if isinstance(data, dict):
                     data_mapping = typing.cast(typing.Dict[str, typing.Any], data)
@@ -423,6 +446,226 @@ class Document(Group):
                         f"\n\ninit {source} error for "
                         f"[{step_name}.{output_key}]:\n\t{err}\n"
                     )
+
+            for container_path, row in repeated_rows.items():
+                err = self.append_repeated_final_row(container_path, row)
+                if err:
+                    raise Exception(
+                        f"\n\ninit {source} error for [{step_name}]:\n\t{err}\n"
+                    )
+
+    def custom_output_route_index(
+        self, source: str
+    ) -> typing.Dict[
+        typing.Tuple[str, str],
+        typing.List[typing.Mapping[str, typing.Any]],
+    ]:
+        workflow_id = self.workflow_id or ""
+        cache_key = (workflow_id, source)
+        if cache_key in self._custom_output_route_cache:
+            return self._custom_output_route_cache[cache_key]
+
+        route_index: typing.Dict[
+            typing.Tuple[str, str],
+            typing.List[typing.Mapping[str, typing.Any]],
+        ] = {}
+        if not self._prompt_manager:
+            self._custom_output_route_cache[cache_key] = route_index
+            return route_index
+
+        try:
+            extract = self._prompt_manager.persisted_workflow_extract_dict(
+                file_name=self.prompt_file_name,
+                workflow_id=self.workflow_id,
+            )
+        except Exception:
+            self._custom_output_route_cache[cache_key] = route_index
+            return route_index
+
+        workflow = extract.get("workflow")
+        if not isinstance(workflow, dict):
+            self._custom_output_route_cache[cache_key] = route_index
+            return route_index
+
+        routes = workflow.get("output_routes")
+        if not isinstance(routes, list):
+            self._custom_output_route_cache[cache_key] = route_index
+            return route_index
+
+        for route in routes:
+            if not isinstance(route, dict):
+                continue
+            if route.get("output_map") != source:
+                continue
+            step_name = route.get("step_name")
+            output_key = route.get("output_key")
+            if not isinstance(step_name, str) or not isinstance(output_key, str):
+                continue
+            route_index.setdefault((step_name, output_key), []).append(route)
+
+        self._custom_output_route_cache[cache_key] = route_index
+        return route_index
+
+    def add_custom_output_route(
+        self,
+        route: typing.Mapping[str, typing.Any],
+        value: typing.Any,
+        repeated_rows: typing.Optional[typing.Dict[typing.Tuple[str, ...], Group]] = None,
+    ) -> typing.Optional[str]:
+        final_path = route.get("final_path")
+        if not isinstance(final_path, str):
+            return "custom workflow output route is missing final_path"
+
+        try:
+            segments = decode_final_path(final_path)
+        except ValueError as e:
+            return str(e)
+
+        if len(segments) == 2:
+            group_name, field_name = segments
+            self.set_final_field(group_name, field_name, value)
+            return None
+
+        if "*" in segments:
+            return self.stage_repeated_final_field(segments, value, repeated_rows)
+
+        return f"unsupported custom workflow final path [{final_path}]"
+
+    def set_final_field(
+        self,
+        group_name: str,
+        field_name: str,
+        value: typing.Any,
+    ) -> None:
+        existing_group = self.fields.get(group_name)
+        if isinstance(existing_group, Group):
+            group = existing_group
+        else:
+            group = Group(prompt=self.final_group_prompt(group_name))
+
+        field = self.final_extracted_field(group_name, field_name, value)
+        existing_field = group.fields.get(field_name)
+        if isinstance(existing_field, ExtractedField):
+            try:
+                if existing_field.equal_to_value(value):
+                    self.set(group_name, group)
+                    return
+            except Exception:
+                pass
+            if value not in existing_field.conflicts:
+                existing_field.conflicts.append(value)
+            group.fields[field_name] = existing_field
+        else:
+            group.fields[field_name] = field
+
+        self.set(group_name, group)
+
+    def stage_repeated_final_field(
+        self,
+        segments: typing.Tuple[str, ...],
+        value: typing.Any,
+        repeated_rows: typing.Optional[typing.Dict[typing.Tuple[str, ...], Group]],
+    ) -> typing.Optional[str]:
+        if repeated_rows is None:
+            return f"unsupported custom workflow final path [/{'/'.join(segments)}]"
+        if segments.count("*") != 1:
+            return f"unsupported custom workflow final path [/{'/'.join(segments)}]"
+
+        star_idx = segments.index("*")
+        if star_idx == 0 or star_idx != len(segments) - 2:
+            return f"unsupported custom workflow final path [/{'/'.join(segments)}]"
+
+        container_path = segments[:star_idx]
+        field_name = segments[star_idx + 1]
+        row = repeated_rows.setdefault(
+            container_path,
+            Group(prompt=self.final_group_prompt(container_path[-1])),
+        )
+        row.fields[field_name] = self.final_extracted_field(
+            container_path[-1], field_name, value
+        )
+        return None
+
+    def append_repeated_final_row(
+        self, container_path: typing.Tuple[str, ...], row: Group
+    ) -> typing.Optional[str]:
+        if len(container_path) == 1:
+            group_name = container_path[0]
+            existing = self.fields.get(group_name)
+            rows = list(existing) if isinstance(existing, list) else []
+            rows.append(row)
+            self.set(group_name, rows)
+            return None
+
+        if len(container_path) == 2:
+            group_name, list_name = container_path
+            existing_group = self.fields.get(group_name)
+            if isinstance(existing_group, Group):
+                group = existing_group
+            else:
+                group = Group(prompt=self.final_group_prompt(group_name))
+
+            existing_rows = group.fields.get(list_name)
+            rows = list(existing_rows) if isinstance(existing_rows, list) else []
+            rows.append(row)
+            group.fields[list_name] = rows
+            self.set(group_name, group)
+            return None
+
+        return f"unsupported custom workflow repeated path [/{'/'.join(container_path)}/*]"
+
+    def final_extracted_field(
+        self,
+        group_name: str,
+        field_name: str,
+        value: typing.Any,
+    ) -> ExtractedField:
+        return ExtractedField(
+            prompt=self.final_field_prompt(group_name, field_name),
+            value=value,
+        )
+
+    def final_group_prompt(self, group_name: str) -> typing.Optional[Prompt]:
+        if not self._prompt_manager:
+            return None
+
+        try:
+            group = self._prompt_manager.get_fields_for_data_object(
+                file_name=self.prompt_file_name,
+                workflow_id=self.workflow_id,
+            ).get(group_name)
+        except Exception:
+            return None
+
+        if not isinstance(group, Group):
+            return None
+
+        return group.prompt
+
+    def final_field_prompt(
+        self,
+        group_name: str,
+        field_name: str,
+    ) -> typing.Optional[Prompt]:
+        if not self._prompt_manager:
+            return None
+
+        try:
+            group = self._prompt_manager.get_fields_for_data_object(
+                file_name=self.prompt_file_name,
+                workflow_id=self.workflow_id,
+            ).get(group_name)
+        except Exception:
+            return None
+
+        if not isinstance(group, Group):
+            return None
+
+        field = group.fields.get(field_name)
+        if not isinstance(field, ExtractedField):
+            return None
+
+        return field.prompt
 
     def add(self, k: str, value: typing.Any) -> typing.Union[str, None]:
         self.print("WARNING", "add is not implemented")
@@ -484,6 +727,20 @@ def _new_page_image_dict() -> typing.Dict[str, int]:
 
 def _new_page_images() -> typing.List[Image.Image]:
     return []
+
+
+def decode_final_path(final_path: str) -> typing.Tuple[str, ...]:
+    if not final_path.startswith("/"):
+        raise ValueError(f"invalid custom workflow final path [{final_path}]")
+
+    segments = tuple(
+        segment.replace("~1", "/").replace("~0", "~")
+        for segment in final_path.split("/")[1:]
+    )
+    if not segments or any(segment == "" for segment in segments):
+        raise ValueError(f"invalid custom workflow final path [{final_path}]")
+
+    return segments
 
 
 class DocumentRequest(BaseModel):

--- a/src/groundx/extract/prompt/utility.py
+++ b/src/groundx/extract/prompt/utility.py
@@ -294,6 +294,36 @@ def _copy_mapping(value: typing.Dict[str, typing.Any]) -> typing.Dict[str, typin
     return copy.deepcopy(value)
 
 
+def _strip_custom_workflow_authoring_keys(value: typing.Any) -> None:
+    if isinstance(value, dict):
+        value.pop(_CUSTOM_WORKFLOW_GROUP_METADATA_KEY, None)
+        value.pop(_CUSTOM_WORKFLOW_FIELD_METADATA_KEY, None)
+        for key, child in value.items():
+            if key == "prompt":
+                continue
+            _strip_custom_workflow_authoring_keys(child)
+    elif isinstance(value, list):
+        for child in value:
+            _strip_custom_workflow_authoring_keys(child)
+
+
+def _runtime_safe_authored_extract(
+    authored_data: typing.Dict[str, typing.Any],
+    custom_workflow_metadata: typing.Optional[typing.Dict[str, typing.Any]],
+) -> typing.Dict[str, typing.Any]:
+    safe_authored_data = _copy_mapping(authored_data)
+    if not custom_workflow_metadata:
+        return safe_authored_data
+
+    safe_authored_data[_CUSTOM_WORKFLOW_KEY] = _copy_mapping(custom_workflow_metadata)
+    for key, value in safe_authored_data.items():
+        if key == _CUSTOM_WORKFLOW_KEY:
+            continue
+        _strip_custom_workflow_authoring_keys(value)
+
+    return safe_authored_data
+
+
 def _validate_prompt_shape(mapping: typing.Dict[str, typing.Any], path: str) -> None:
     if "prompt" not in mapping or mapping["prompt"] is None:
         return
@@ -1333,7 +1363,10 @@ def _persisted_workflow_extract(
         final_metadata_keys,
         workflow_metadata_keys,
     ):
-        persisted[_PERSISTED_WORKFLOW_EXTRACT_KEY] = _copy_mapping(authored_data)
+        persisted[_PERSISTED_WORKFLOW_EXTRACT_KEY] = _runtime_safe_authored_extract(
+            authored_data,
+            custom_workflow_metadata,
+        )
 
     return persisted
 
@@ -1393,12 +1426,18 @@ def prepare_extraction_yaml(
 ) -> PreparedExtractionYaml:
     data = _load_extraction_mapping(raw_yaml)
     if _PERSISTED_WORKFLOW_EXTRACT_KEY in data:
+        persisted_outer_data = _copy_mapping(data)
         data = _copy_mapping(
             _ensure_mapping(
                 data[_PERSISTED_WORKFLOW_EXTRACT_KEY],
                 _PERSISTED_WORKFLOW_EXTRACT_KEY,
             )
         )
+        persisted_workflow = persisted_outer_data.get(_CUSTOM_WORKFLOW_KEY)
+        if isinstance(
+            persisted_workflow, dict
+        ) and _is_custom_workflow_persisted_metadata(persisted_workflow):
+            data[_CUSTOM_WORKFLOW_KEY] = _copy_mapping(persisted_workflow)
     custom_workflow_kind_and_input = _custom_workflow_input(data)
     top_metadata_key_set = set(top_level_metadata_keys or [])
     final_metadata_key_set = set(final_group_metadata_keys or [])

--- a/tests/extract/classes/test_document.py
+++ b/tests/extract/classes/test_document.py
@@ -1,19 +1,67 @@
-import pytest, typing, unittest
+import typing
+import unittest
+
+import pytest
 
 pytest.importorskip("PIL")
 
 from io import BytesIO
 from pathlib import Path
-from PIL import Image
 from unittest.mock import patch
+
+from ..prompt._fixtures import SAMPLE_YAML_1, SAMPLE_YAML_2, TestSource
+from PIL import Image
 
 from groundx.extract.classes.document import Document, DocumentRequest
 from groundx.extract.classes.field import ExtractedField
 from groundx.extract.classes.groundx import XRayDocument
 from groundx.extract.classes.group import Group
-from groundx.extract.prompt.manager import PromptManager
-from ..prompt._fixtures import SAMPLE_YAML_1, SAMPLE_YAML_2, TestSource
 from groundx.extract.classes.testing import TestXRay
+from groundx.extract.prompt.manager import PromptManager
+
+CUSTOM_WORKFLOW_YAML = """
+workflow:
+  custom_steps:
+    - name: line_item_labels
+      level: chunk
+      kind: keys
+
+line_items:
+  workflow_step: line_item_labels
+  fields:
+    description:
+      workflow_output_key: label
+      prompt:
+        identifiers:
+          - Description
+        instructions: Return the printed line-item description.
+        type: str
+"""
+
+
+CUSTOM_REPEATED_WORKFLOW_YAML = """
+workflow:
+  custom_steps:
+    - name: charge_labels
+      level: chunk
+      kind: keys
+
+invoice:
+  workflow_step: charge_labels
+  fields:
+    charges:
+      - fields:
+          description:
+            workflow_output_key: charge_description
+            prompt:
+              instructions: Return the repeated charge description.
+              type: str
+          amount:
+            workflow_output_key: charge_amount
+            prompt:
+              instructions: Return the repeated charge amount.
+              type: float
+"""
 
 
 def DR(**data: typing.Any) -> DocumentRequest:
@@ -288,6 +336,88 @@ class TestDocument(unittest.TestCase):
         self.assertIn(("custom_chunk", "Water service"), seen)
         self.assertIn(("custom_section", "UTILITY"), seen)
         self.assertIn(("custom_document", False), seen)
+
+    def test_document_routes_custom_outputs_to_final_workflow_paths(self) -> None:
+        source = TestSource(CUSTOM_WORKFLOW_YAML)
+        manager = PromptManager(cache_source=source, config_source=source)
+        xray = XRayDocument.model_validate(
+            {
+                "chunks": [
+                    {
+                        "customChunkOutputs": {
+                            "line_item_labels": {
+                                "label": "Water service",
+                            }
+                        },
+                    }
+                ],
+                "documentPages": [],
+                "sourceUrl": "https://example.com/doc.pdf",
+            }
+        )
+
+        doc = Document()
+        doc.load_xray(
+            req=_make_request(),
+            xray=xray,
+            prompt_manager=manager,
+        )
+
+        self.assertNotIn("label", doc.fields)
+        self.assertIn("line_items", doc.fields)
+        line_items = doc.fields["line_items"]
+        self.assertIsInstance(line_items, Group)
+        if isinstance(line_items, Group):
+            description = line_items.fields["description"]
+            self.assertIsInstance(description, ExtractedField)
+            if isinstance(description, ExtractedField):
+                self.assertEqual(description.value, "Water service")
+
+    def test_document_routes_repeated_custom_outputs_to_one_row(self) -> None:
+        source = TestSource(CUSTOM_REPEATED_WORKFLOW_YAML)
+        manager = PromptManager(cache_source=source, config_source=source)
+        xray = XRayDocument.model_validate(
+            {
+                "chunks": [
+                    {
+                        "customChunkOutputs": {
+                            "charge_labels": {
+                                "charge_description": "Water service",
+                                "charge_amount": 12.34,
+                            }
+                        },
+                    }
+                ],
+                "documentPages": [],
+                "sourceUrl": "https://example.com/doc.pdf",
+            }
+        )
+
+        doc = Document()
+        doc.load_xray(
+            req=_make_request(),
+            xray=xray,
+            prompt_manager=manager,
+        )
+
+        invoice = doc.fields["invoice"]
+        self.assertIsInstance(invoice, Group)
+        if isinstance(invoice, Group):
+            charges = invoice.fields["charges"]
+            self.assertIsInstance(charges, list)
+            if isinstance(charges, list):
+                self.assertEqual(len(charges), 1)
+                charge = charges[0]
+                self.assertIsInstance(charge, Group)
+                if isinstance(charge, Group):
+                    self.assertEqual(
+                        charge.fields["description"],
+                        ExtractedField(value="Water service"),
+                    )
+                    self.assertEqual(
+                        charge.fields["amount"],
+                        ExtractedField(value=12.34),
+                    )
 
 
 class TestDocumentRequest(unittest.TestCase):

--- a/tests/extract/test_extraction_workflow_definitions.py
+++ b/tests/extract/test_extraction_workflow_definitions.py
@@ -178,6 +178,24 @@ def _model_to_alias_dict(value: typing.Any) -> typing.Dict[str, typing.Any]:
     )
 
 
+def _find_mapping_keys(
+    value: typing.Any,
+    keys: typing.Set[str],
+    path: str = "$",
+) -> typing.List[str]:
+    matches: typing.List[str] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = f"{path}.{key}"
+            if key in keys:
+                matches.append(child_path)
+            matches.extend(_find_mapping_keys(child, keys, child_path))
+    elif isinstance(value, list):
+        for idx, child in enumerate(value):
+            matches.extend(_find_mapping_keys(child, keys, f"{path}[{idx}]"))
+    return matches
+
+
 def test_load_definition_from_yaml_path_preserves_template_and_prepared(
     tmp_path: Path,
 ) -> None:
@@ -195,6 +213,28 @@ def test_load_definition_from_yaml_path_preserves_template_and_prepared(
     assert definition.custom_steps[0]["name"] == "line_item_labels"
     assert definition.output_routes[0]["output_key"] == "label"
     assert definition.leaf_fields[0]["field_type"] == "str"
+
+
+def test_persisted_custom_workflow_authored_copy_is_runtime_safe() -> None:
+    prepared = prepare_extraction_yaml(CUSTOM_WORKFLOW_YAML)
+    persisted = prepared.persisted_workflow_extract
+    authored_copy = persisted["_groundx_persisted_extract"]
+
+    assert authored_copy["workflow"]["metadata_version"] == 1
+    assert _find_mapping_keys(
+        authored_copy,
+        {"workflow_step", "workflow_output_key"},
+    ) == []
+
+    reloaded = prepare_extraction_yaml(persisted)
+    standalone = prepare_extraction_yaml(authored_copy)
+
+    assert reloaded.persisted_workflow_extract["workflow"]["output_routes"] == (
+        persisted["workflow"]["output_routes"]
+    )
+    assert standalone.persisted_workflow_extract["workflow"]["leaf_fields"] == (
+        persisted["workflow"]["leaf_fields"]
+    )
 
 
 def test_load_extraction_definition_uses_yaml_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- makes custom workflow `_groundx_persisted_extract` runtime-safe by stripping authoring-only `workflow_step` / `workflow_output_key` keys from the persisted authored copy
- routes SDK custom X-Ray outputs back into final YAML paths from `workflow.output_routes`, including repeated-row outputs
- updates the Task 11 checkpoint with the corrected deployed-ingest evidence and current PR gates

## Root Cause

Live smoke showed custom outputs in X-Ray, but final extract failed in two places:

1. The persisted authored YAML copy still carried authoring-only metadata into runtime pseudo-group validation.
2. SDK document loading parsed custom output maps but did not use route metadata to place values back into the final YAML shape.

The deployed Arcadia path also still had a legacy `statement` assumption; the paired runtime guard is in internal-arcadia-agents PR #67.

## Validation

- `poetry run pytest tests/extract/classes/test_document.py -q`
- `poetry run pytest tests/extract/classes/test_document.py tests/extract/prompt/test_manager.py tests/extract/prompt/test_persisted_workflow_extract.py -q`
- `poetry run pytest -rP -n auto .`
- `poetry run ruff check src/groundx/extract/classes/document.py tests/extract/classes/test_document.py`
- `poetry run mypy .`
- `OPENSPEC_TELEMETRY=0 npx @fission-ai/openspec@1.3.1 validate support-custom-workflow-steps --strict`
- `git diff --check`

## Live Checks Recorded

- deployed create/update guardrails now reject oversized custom steps with `has 21 fields; max is 20`
- corrected synthetic ADP-style PDF run used `client.ingest(...)` with no `process_level`
- corrected run reached processing and SDK X-Ray readback succeeded
- corrected run showed custom outputs under `customChunkOutputs`
- final layout/extract failed on the then-deployed `statement` assumption
- cleanup check found zero remaining temp buckets, workflows, or documents with the `codex-e2e-support-custom-workflow-steps-` prefix

## Remaining Gates

- review and merge this SDK PR
- release the next `groundx-python` version through the maintainer-owned path
- review, merge, and deploy internal-arcadia-agents PR #67
- rerun the corrected deployed-path E2E after SDK release and Arcadia deploy
- representative ADP ingest still needs a subscription/path that accepts the sanitized sample PDF, or explicit approval to use the small synthetic ADP PDF as substitute release evidence
