### PR TITLE
[codex] Clarify extraction YAML metadata errors

### DIFF
--- a/openspec/changes/clarify-invalid-extraction-yaml-errors/proposal.md
+++ b/openspec/changes/clarify-invalid-extraction-yaml-errors/proposal.md
@@ -1,0 +1,41 @@
+# Change: Clarify Invalid Extraction YAML Errors
+
+Status: proposed
+
+## Problem
+
+`GroundX.create_extraction_workflow(path=...)` and
+`GroundX.update_extraction_workflow(path=...)` are the promoted high-level SDK
+helpers for valid extraction YAML. When a caller passes invalid in-between YAML,
+the SDK can currently surface a low-level preparation error such as
+`Expected mapping at [extraction_policy_version]`. That message does not tell
+the user whether the top-level key is supported SDK metadata, unsupported
+metadata, or a malformed extraction group, nor how to fix the YAML.
+
+This matters because Arcadia YAML may use domain-specific metadata through an
+Arcadia metadata-aware preparation path, while public SDK helpers must remain
+strict and understandable for generic users.
+
+## Goals
+
+- Keep `create_extraction_workflow(path=...)` and
+  `update_extraction_workflow(path=...)` as valid high-level helpers for valid
+  YAML.
+- Improve invalid authored-YAML errors in the hand-written extract loader so
+  unsupported top-level metadata names the offending key and the valid remedies.
+- Treat `extraction_policy_version` as supported authored extraction metadata
+  so active v1 policy YAML can be loaded by the high-level helpers while still
+  preserving the marker in the persisted workflow extract.
+- Make sync and async YAML shortcut helpers surface that same actionable error,
+  with path context when available.
+- Preserve legacy YAML behavior and domain-specific advanced metadata support
+  through explicit `prepare_extraction_yaml(..., *_metadata_keys=...)` callers.
+
+## Constraints
+
+- Do not edit Fern-generated SDK files.
+- Do not auto-register arbitrary domain-specific metadata for generic SDK
+  callers. Only `extraction_policy_version` is promoted to supported SDK
+  metadata by this change.
+- Do not weaken existing legacy YAML, custom workflow, or persisted workflow
+  extract behavior.

--- a/openspec/changes/clarify-invalid-extraction-yaml-errors/specs/extract-yaml/spec.md
+++ b/openspec/changes/clarify-invalid-extraction-yaml-errors/specs/extract-yaml/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: Prepared extraction YAML accepts persisted workflow extract mappings
+The SDK SHALL support preparing extraction definitions from either raw YAML text
+or a workflow API `extract` mapping produced by the persisted workflow extract
+surface.
+
+#### Scenario: Unsupported top-level scalar metadata fails clearly
+- **WHEN** raw authored YAML contains a top-level scalar key that is not a
+  reserved SDK key, not supported SDK metadata, and was not registered through
+  `top_level_metadata_keys`
+- **THEN** `prepare_extraction_yaml(...)` raises a `ValueError` naming the
+  offending key
+- **AND** the error explains that generic SDK top-level keys must be extraction
+  groups, reserved SDK keys, or supported SDK metadata keys
+- **AND** the error tells advanced callers to register metadata keys through
+  `top_level_metadata_keys` or convert the YAML to supported workflow metadata
+
+#### Scenario: Supported policy version metadata is preserved
+- **WHEN** raw authored YAML contains top-level
+  `extraction_policy_version: v1`
+- **THEN** `prepare_extraction_yaml(...)` succeeds without caller-specific
+  metadata registration
+- **AND** the marker is exposed in `PreparedExtractionYaml.top_level_metadata`
+- **AND** the marker is preserved in the persisted workflow extract
+
+#### Scenario: Explicit metadata registration still works
+- **WHEN** the same authored YAML is prepared with the scalar key included in
+  `top_level_metadata_keys`
+- **THEN** preparation succeeds
+- **AND** the key is exposed as top-level metadata rather than as an extraction
+  group

--- a/openspec/changes/clarify-invalid-extraction-yaml-errors/specs/extraction-workflow-convenience/spec.md
+++ b/openspec/changes/clarify-invalid-extraction-yaml-errors/specs/extraction-workflow-convenience/spec.md
@@ -1,0 +1,77 @@
+## MODIFIED Requirements
+
+### Requirement: Python SDK exposes extraction workflow create/update helpers
+The Python SDK SHALL expose hand-written convenience helpers that create and
+update extraction workflows from `ExtractionDefinition` or authored extraction
+YAML without requiring callers to manually copy persisted workflow metadata into
+generated workflow client kwargs.
+
+#### Scenario: Workflow create YAML shortcut preserves invalid YAML context
+- **GIVEN** a local extraction YAML file with unsupported top-level metadata or
+  another structural authoring error
+- **WHEN** a caller invokes `GroundX.create_extraction_workflow(path=..., name=...)`
+- **THEN** the SDK fails before calling the workflow API
+- **AND** the error includes the YAML path or source context
+- **AND** the error preserves the actionable loader message naming the offending
+  key or malformed path
+
+#### Scenario: Workflow create YAML shortcut accepts supported policy metadata
+- **GIVEN** a local extraction YAML file with top-level
+  `extraction_policy_version: v1`
+- **WHEN** a caller invokes `GroundX.create_extraction_workflow(path=..., name=...)`
+- **THEN** the SDK loads the YAML without caller-specific metadata registration
+- **AND** the workflow API payload preserves the policy marker in `extract`
+
+#### Scenario: Workflow update YAML shortcut preserves invalid YAML context
+- **GIVEN** an existing workflow ID and a local extraction YAML file with
+  unsupported top-level metadata or another structural authoring error
+- **WHEN** a caller invokes
+  `GroundX.update_extraction_workflow(id, path=..., name=...)`
+- **THEN** the SDK fails before calling the workflow API
+- **AND** the error includes the YAML path or source context
+- **AND** the error preserves the actionable loader message naming the offending
+  key or malformed path
+
+#### Scenario: Workflow update YAML shortcut accepts supported policy metadata
+- **GIVEN** an existing workflow ID and a local extraction YAML file with
+  top-level `extraction_policy_version: v1`
+- **WHEN** a caller invokes
+  `GroundX.update_extraction_workflow(id, path=..., name=...)`
+- **THEN** the SDK loads the YAML without caller-specific metadata registration
+- **AND** the workflow API payload preserves the policy marker in `extract`
+
+#### Scenario: Async workflow create YAML shortcut preserves invalid YAML context
+- **GIVEN** a local extraction YAML file with unsupported top-level metadata or
+  another structural authoring error
+- **WHEN** a caller invokes
+  `AsyncGroundX.create_extraction_workflow(path=..., name=...)`
+- **THEN** the SDK fails before calling the workflow API
+- **AND** the error includes the YAML path or source context
+- **AND** the error preserves the actionable loader message naming the offending
+  key or malformed path
+
+#### Scenario: Async workflow create YAML shortcut accepts supported policy metadata
+- **GIVEN** a local extraction YAML file with top-level
+  `extraction_policy_version: v1`
+- **WHEN** a caller invokes
+  `AsyncGroundX.create_extraction_workflow(path=..., name=...)`
+- **THEN** the SDK loads the YAML without caller-specific metadata registration
+- **AND** the workflow API payload preserves the policy marker in `extract`
+
+#### Scenario: Async workflow update YAML shortcut preserves invalid YAML context
+- **GIVEN** an existing workflow ID and a local extraction YAML file with
+  unsupported top-level metadata or another structural authoring error
+- **WHEN** a caller invokes
+  `AsyncGroundX.update_extraction_workflow(id, path=..., name=...)`
+- **THEN** the SDK fails before calling the workflow API
+- **AND** the error includes the YAML path or source context
+- **AND** the error preserves the actionable loader message naming the offending
+  key or malformed path
+
+#### Scenario: Async workflow update YAML shortcut accepts supported policy metadata
+- **GIVEN** an existing workflow ID and a local extraction YAML file with
+  top-level `extraction_policy_version: v1`
+- **WHEN** a caller invokes
+  `AsyncGroundX.update_extraction_workflow(id, path=..., name=...)`
+- **THEN** the SDK loads the YAML without caller-specific metadata registration
+- **AND** the workflow API payload preserves the policy marker in `extract`

--- a/openspec/changes/clarify-invalid-extraction-yaml-errors/tasks.md
+++ b/openspec/changes/clarify-invalid-extraction-yaml-errors/tasks.md
@@ -1,0 +1,118 @@
+# Clarify Invalid Extraction YAML Errors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:test-driven-development` for each code task and `superpowers:verification-before-completion` before closeout. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make invalid extraction YAML fail with actionable errors while preserving `create_extraction_workflow(path=...)` for valid YAML.
+
+**Architecture:** Keep all changes in the hand-written extract surfaces. `prepare_extraction_yaml(...)` owns structural YAML validation and message quality; workflow definition loaders and create/update helpers should preserve and add path/source context without replacing the root cause.
+
+**Tech Stack:** Python, pytest, GroundX hand-written extract SDK, OpenSpec.
+
+---
+
+## Files
+
+- Modify: `/Users/benjaminfletcher/git/groundx-python/src/groundx/extract/prompt/utility.py`
+- Modify: `/Users/benjaminfletcher/git/groundx-python/src/groundx/extract/workflows.py`
+- Test: `/Users/benjaminfletcher/git/groundx-python/tests/extract/prompt/test_manager.py`
+- Test: `/Users/benjaminfletcher/git/groundx-python/tests/extract/test_extraction_workflow_definitions.py`
+- Test: `/Users/benjaminfletcher/git/groundx-python/tests/custom/test_extraction_workflow_client_exports.py`
+
+## Task 1: Add Failing Loader Error Tests
+
+- [x] Add a regression where raw YAML starts with unsupported top-level scalar
+      metadata:
+
+  ```yaml
+  unsupported_policy_version: v1
+  statement:
+    fields:
+      account_number:
+        prompt: Extract account number.
+  ```
+
+  Expected error: names `unsupported_policy_version`, explains that generic SDK
+  top-level keys must be extraction groups, reserved keys, or supported SDK
+  metadata keys, and tells advanced callers to register metadata keys or convert
+  to supported workflow YAML.
+
+- [x] Add a positive regression proving
+      `extraction_policy_version: v1` succeeds as supported SDK metadata and is
+      preserved in `PreparedExtractionYaml.top_level_metadata`.
+
+- [x] Run:
+
+  ```bash
+  poetry run pytest tests/extract/prompt/test_manager.py -q
+  ```
+
+  Expected before implementation: the new negative test fails because the error
+  is still low-level.
+
+## Task 2: Improve Hand-Written Extract Loader Errors
+
+- [x] Update `src/groundx/extract/prompt/utility.py` so top-level non-mapping
+      keys that are not reserved keys, supported SDK metadata keys, or
+      registered metadata keys fail with an actionable `ValueError`.
+
+- [x] Keep nested mapping errors strict and preserve existing messages where
+      they already identify the correct malformed nested path.
+
+- [x] Run:
+
+  ```bash
+  poetry run pytest tests/extract/prompt/test_manager.py -q
+  ```
+
+  Expected: new loader error tests pass and existing prompt loader tests pass.
+
+## Task 3: Preserve Error Context Through YAML Shortcut Helpers
+
+- [x] Add regressions for sync
+      `GroundX.create_extraction_workflow(path=..., name=...)` and
+      `GroundX.update_extraction_workflow(id, path=..., name=...)` using an
+      invalid YAML temp file.
+
+- [x] Add sync regressions proving the same helpers accept
+      `extraction_policy_version: v1` and preserve it in the workflow `extract`
+      payload.
+
+- [x] Add matching async regressions for
+      `AsyncGroundX.create_extraction_workflow(path=..., name=...)` and
+      `AsyncGroundX.update_extraction_workflow(id, path=..., name=...)` using an
+      invalid YAML temp file.
+
+- [x] Add async regressions proving the same helpers accept
+      `extraction_policy_version: v1` and preserve it in the workflow `extract`
+      payload.
+
+- [x] Expected error: includes the YAML path or source context plus the
+      actionable offending key message from the loader.
+
+- [x] Update `src/groundx/extract/workflows.py` only as needed to preserve the
+      root cause and add path/source context. No `src/groundx/ingest.py` change
+      was required because those public helpers delegate to the shared workflow
+      loader.
+
+- [x] Run:
+
+  ```bash
+  poetry run pytest tests/extract/test_extraction_workflow_definitions.py tests/custom/test_extraction_workflow_client_exports.py -q
+  ```
+
+  Expected: YAML shortcut error tests pass and existing helper tests pass.
+
+## Task 4: Final SDK Verification
+
+- [x] Run:
+
+  ```bash
+  OPENSPEC_TELEMETRY=0 npx -y @fission-ai/openspec@1.3.1 validate clarify-invalid-extraction-yaml-errors --strict --json
+  poetry run pytest tests/extract/prompt/test_manager.py tests/extract/test_extraction_workflow_definitions.py tests/custom/test_extraction_workflow_client_exports.py -q
+  poetry run mypy .
+  poetry run pytest -rP -n auto .
+  git diff --check
+  ```
+
+- [x] Adversarially review that the SDK still promotes `path=` for valid YAML
+      and only improves the invalid YAML failure mode.

--- a/src/groundx/extract/prompt/utility.py
+++ b/src/groundx/extract/prompt/utility.py
@@ -29,6 +29,7 @@ _RESERVED_TOP_LEVEL_KEYS = {
     _PERSISTED_WORKFLOW_EXTRACT_KEY,
     _CUSTOM_WORKFLOW_KEY,
 }
+_SUPPORTED_TOP_LEVEL_METADATA_KEYS = {"extraction_policy_version"}
 _PSEUDO_GROUP_BODY_KEYS = {"prompt", "fields"}
 _PSEUDO_FIELD_KEYS = {"path"}
 _CUSTOM_STEP_NAME_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
@@ -276,6 +277,17 @@ def _ensure_mapping(value: typing.Any, path: str) -> typing.Dict[str, typing.Any
         raise ValueError(f"Expected mapping at [{path}], got {type(value)}")
 
     return typing.cast(typing.Dict[str, typing.Any], value)
+
+
+def _raise_unsupported_top_level_metadata(key: str) -> typing.NoReturn:
+    raise ValueError(
+        f"unsupported top-level metadata [{key}]; generic SDK top-level keys "
+        "must be extraction groups with mapping values, reserved SDK keys, or "
+        "supported SDK metadata keys. "
+        "If this key is domain-specific metadata, register it with "
+        "top_level_metadata_keys. Otherwise convert it to supported workflow "
+        "metadata before using the generic extraction workflow helpers."
+    )
 
 
 def _ensure_fields_mapping(
@@ -1439,7 +1451,8 @@ def prepare_extraction_yaml(
         ) and _is_custom_workflow_persisted_metadata(persisted_workflow):
             data[_CUSTOM_WORKFLOW_KEY] = _copy_mapping(persisted_workflow)
     custom_workflow_kind_and_input = _custom_workflow_input(data)
-    top_metadata_key_set = set(top_level_metadata_keys or [])
+    top_metadata_key_set = set(_SUPPORTED_TOP_LEVEL_METADATA_KEYS)
+    top_metadata_key_set.update(top_level_metadata_keys or [])
     final_metadata_key_set = set(final_group_metadata_keys or [])
     workflow_metadata_key_set = set(workflow_group_metadata_keys or [])
     effective_workflow_metadata_key_set = workflow_metadata_key_set | {
@@ -1471,6 +1484,8 @@ def prepare_extraction_yaml(
     final_group_metadata: typing.Dict[str, typing.Dict[str, typing.Any]] = {}
     final_workflow_metadata: typing.Dict[str, typing.Dict[str, typing.Any]] = {}
     for group_name, raw_group in raw_groups.items():
+        if not isinstance(raw_group, dict):
+            _raise_unsupported_top_level_metadata(group_name)
         group = _ensure_mapping(raw_group, group_name)
         group, final_metadata = _split_metadata(group, final_metadata_key_set)
         group, workflow_metadata = _split_metadata(

--- a/src/groundx/extract/workflows.py
+++ b/src/groundx/extract/workflows.py
@@ -92,12 +92,19 @@ def load_extraction_definition_from_yaml(
         raise ValueError("mapping_kind is only valid when mapping is the selected source")
 
     if source_name == "path":
-        raw_yaml = Path(source_value).read_text(encoding="utf-8")
-        prepared_value = prepare_extraction_yaml(raw_yaml)
+        source_path = Path(source_value)
+        raw_yaml = source_path.read_text(encoding="utf-8")
+        prepared_value = _prepare_extraction_yaml_with_context(
+            raw_yaml,
+            f"path [{source_path}]",
+        )
         return _definition_from_prepared(prepared_value)
 
     if source_name == "yaml_text":
-        prepared_value = prepare_extraction_yaml(source_value)
+        prepared_value = _prepare_extraction_yaml_with_context(
+            source_value,
+            "yaml_text",
+        )
         return _definition_from_prepared(prepared_value)
 
     if source_name == "prepared":
@@ -121,7 +128,10 @@ def load_extraction_definition_from_yaml(
                 "mapping looks like an existing workflow extract; pass "
                 "mapping_kind='workflow_extract' to load it explicitly"
             )
-        prepared_value = prepare_extraction_yaml(mapping_value)
+        prepared_value = _prepare_extraction_yaml_with_context(
+            mapping_value,
+            "mapping",
+        )
         return _definition_from_prepared(prepared_value)
 
     raise AssertionError(f"unsupported source {source_name}")
@@ -344,6 +354,16 @@ def _prepared_from_workflow_extract(
     if _PERSISTED_WORKFLOW_EXTRACT_KEY not in extract:
         return None
     return prepare_extraction_yaml(extract)
+
+
+def _prepare_extraction_yaml_with_context(
+    source: typing.Union[str, typing.Mapping[str, typing.Any]],
+    context: str,
+) -> PreparedExtractionYaml:
+    try:
+        return prepare_extraction_yaml(source)
+    except ValueError as exc:
+        raise ValueError(f"failed to load extraction YAML from {context}: {exc}") from exc
 
 
 def _select_source(**sources: typing.Any) -> typing.Tuple[str, typing.Any]:

--- a/tests/extract/prompt/test_manager.py
+++ b/tests/extract/prompt/test_manager.py
@@ -802,6 +802,48 @@ _pseudo_groups:
             {"statement_identity": {"slot": "chunk-instruct"}},
         )
 
+    def test_prepare_extraction_yaml_rejects_unsupported_top_level_scalar_metadata(
+        self,
+    ) -> None:
+        with self.assertRaises(ValueError) as exc:
+            prepare_extraction_yaml(
+                """
+unsupported_policy_version: v1
+statement:
+  fields:
+    account_number:
+      prompt:
+        instructions: Return the account number.
+        type: str
+"""
+            )
+
+        message = str(exc.exception)
+        self.assertIn("unsupported top-level metadata [unsupported_policy_version]", message)
+        self.assertIn("top_level_metadata_keys", message)
+        self.assertIn("workflow metadata", message)
+
+    def test_prepare_extraction_yaml_accepts_supported_policy_version_metadata(
+        self,
+    ) -> None:
+        prepared = prepare_extraction_yaml(
+            """
+extraction_policy_version: v1
+statement:
+  fields:
+    account_number:
+      prompt:
+        instructions: Return the account number.
+        type: str
+"""
+        )
+
+        self.assertEqual(
+            prepared.top_level_metadata,
+            {"extraction_policy_version": "v1"},
+        )
+        self.assertIn("statement", prepared.groups)
+
     def test_prepare_extraction_yaml_identity_route_map_for_legacy_yaml(self) -> None:
         prepared = prepare_extraction_yaml(SAMPLE_YAML_1)
 

--- a/tests/extract/test_extraction_workflow_definitions.py
+++ b/tests/extract/test_extraction_workflow_definitions.py
@@ -43,6 +43,26 @@ line_items:
         type: str
 """
 
+INVALID_TOP_LEVEL_METADATA_YAML = """
+unsupported_policy_version: v1
+statement:
+  fields:
+    account_number:
+      prompt:
+        instructions: Return the account number.
+        type: str
+"""
+
+POLICY_METADATA_YAML = """
+extraction_policy_version: v1
+statement:
+  fields:
+    account_number:
+      prompt:
+        instructions: Return the account number.
+        type: str
+"""
+
 
 EXECUTION_ONLY_EXTRACT = {
     "line_items": {
@@ -610,6 +630,103 @@ def test_create_and_update_accept_yaml_path_shortcut(tmp_path: Path) -> None:
     }
 
 
+def test_create_and_update_yaml_path_errors_include_source_context(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "statement.yaml"
+    path.write_text(INVALID_TOP_LEVEL_METADATA_YAML)
+    workflows = RecordingWorkflows()
+    client = _client(workflows)
+
+    with pytest.raises(ValueError) as create_exc:
+        client.create_extraction_workflow(
+            path=path,
+            name="statement extraction",
+        )
+
+    create_message = str(create_exc.value)
+    assert str(path) in create_message
+    assert "unsupported top-level metadata [unsupported_policy_version]" in create_message
+    assert "top_level_metadata_keys" in create_message
+
+    with pytest.raises(ValueError) as update_exc:
+        client.update_extraction_workflow(
+            "workflow-1",
+            path=path,
+            name="statement extraction",
+        )
+
+    update_message = str(update_exc.value)
+    assert str(path) in update_message
+    assert "unsupported top-level metadata [unsupported_policy_version]" in update_message
+    assert "top_level_metadata_keys" in update_message
+    assert workflows.calls == []
+
+
+@pytest.mark.asyncio
+async def test_async_create_and_update_yaml_path_accept_supported_policy_metadata(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "statement.yaml"
+    path.write_text(POLICY_METADATA_YAML)
+    workflows = AsyncRecordingWorkflows()
+    client = _async_client(workflows)
+
+    assert (
+        await client.create_extraction_workflow(
+            path=path,
+            name="statement extraction",
+        )
+        == "created"
+    )
+    assert (
+        await client.update_extraction_workflow(
+            "workflow-1",
+            path=path,
+            name="statement extraction",
+        )
+        == "updated"
+    )
+
+    create_extract = workflows.calls[0][1]["extract"]
+    update_extract = workflows.calls[1][2]["extract"]
+    assert create_extract == update_extract
+    assert (
+        create_extract["_groundx_persisted_extract"]["extraction_policy_version"]
+        == "v1"
+    )
+
+
+def test_create_and_update_yaml_path_accept_supported_policy_metadata(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "statement.yaml"
+    path.write_text(POLICY_METADATA_YAML)
+    workflows = RecordingWorkflows()
+    client = _client(workflows)
+
+    assert (
+        client.create_extraction_workflow(
+            path=path,
+            name="statement extraction",
+        )
+        == "created"
+    )
+    assert (
+        client.update_extraction_workflow(
+            "workflow-1",
+            path=path,
+            name="statement extraction",
+        )
+        == "updated"
+    )
+
+    create_extract = workflows.calls[0][1]["extract"]
+    update_extract = workflows.calls[1][2]["extract"]
+    assert create_extract == update_extract
+    assert create_extract["_groundx_persisted_extract"]["extraction_policy_version"] == "v1"
+
+
 def test_create_requires_name_but_update_can_omit_name() -> None:
     workflows = RecordingWorkflows()
     client = _client(workflows)
@@ -694,3 +811,37 @@ async def test_async_methods_match_sync_source_loading_and_forwarding() -> None:
     assert workflows.calls[2][1]["template"]["{{LANGUAGE_UNKNOWN}}"] == ""
     assert direct_definition.extract == definition.extract
     assert workflow_definition.extract == from_workflow.extract
+
+
+@pytest.mark.asyncio
+async def test_async_create_and_update_yaml_path_errors_include_source_context(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "statement.yaml"
+    path.write_text(INVALID_TOP_LEVEL_METADATA_YAML)
+    workflows = AsyncRecordingWorkflows()
+    client = _async_client(workflows)
+
+    with pytest.raises(ValueError) as create_exc:
+        await client.create_extraction_workflow(
+            path=path,
+            name="statement extraction",
+        )
+
+    create_message = str(create_exc.value)
+    assert str(path) in create_message
+    assert "unsupported top-level metadata [unsupported_policy_version]" in create_message
+    assert "top_level_metadata_keys" in create_message
+
+    with pytest.raises(ValueError) as update_exc:
+        await client.update_extraction_workflow(
+            "workflow-1",
+            path=path,
+            name="statement extraction",
+        )
+
+    update_message = str(update_exc.value)
+    assert str(path) in update_message
+    assert "unsupported top-level metadata [unsupported_policy_version]" in update_message
+    assert "top_level_metadata_keys" in update_message
+    assert workflows.calls == []


### PR DESCRIPTION
Linear: AGE-150

Summary:
- Treat `extraction_policy_version: v1` as supported extraction YAML metadata.
- Add clearer errors for unsupported top-level YAML metadata.
- Cover sync and async workflow helper paths.

Validation:
- `poetry run mypy .`
- `poetry run pytest -rP -n auto .`
- OpenSpec validation passed.