### PR TITLE
[codex] Support v1 extraction workflow definitions

### DIFF
--- a/src/groundx/extract/prompt/utility.py
+++ b/src/groundx/extract/prompt/utility.py
@@ -18,6 +18,7 @@ _CUSTOM_WORKFLOW_GROUP_METADATA_KEY = "workflow_step"
 _CUSTOM_WORKFLOW_FIELD_METADATA_KEY = "workflow_output_key"
 _CUSTOM_WORKFLOW_METADATA_VERSION = 1
 _CUSTOM_WORKFLOW_MAX_FIELDS = 20
+_CUSTOM_WORKFLOW_AGENT_CHAIN_KEY = "agent_chain"
 _CUSTOM_WORKFLOW_OUTPUT_MAPS = {
     "chunk": "customChunkOutputs",
     "section": "customSectionOutputs",
@@ -29,7 +30,30 @@ _RESERVED_TOP_LEVEL_KEYS = {
     _PERSISTED_WORKFLOW_EXTRACT_KEY,
     _CUSTOM_WORKFLOW_KEY,
 }
-_SUPPORTED_TOP_LEVEL_METADATA_KEYS = {"extraction_policy_version"}
+_EXTRACTION_POLICY_VERSION_KEY = "extraction_policy_version"
+_SUPPORTED_TOP_LEVEL_METADATA_KEYS = {_EXTRACTION_POLICY_VERSION_KEY}
+_SUPPORTED_FINAL_GROUP_METADATA_KEYS = {
+    "always_check_attrs",
+    "conflict_attrs",
+    "deregulation_status_values",
+    "equivalent_service_types",
+    "exclude_dict_attrs",
+    "explanation_attrs",
+    "fill_rules",
+    "final_value_aliases",
+    "match_attrs",
+    "not_required_service_types",
+    "partial_pair_attrs",
+    "passthrough",
+    "passthrough_attrs",
+    "passthrough_pair_attrs",
+    "remaining_attrs",
+    "required_any_attrs",
+    "required_attrs",
+    "unique_attrs",
+}
+_UNSUPPORTED_TOP_LEVEL_KEYS = {"domain"}
+_UNSUPPORTED_WORKFLOW_GROUP_KEYS = {"slot"}
 _PSEUDO_GROUP_BODY_KEYS = {"prompt", "fields"}
 _PSEUDO_FIELD_KEYS = {"path"}
 _CUSTOM_STEP_NAME_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
@@ -99,11 +123,16 @@ _CUSTOM_WORKFLOW_RESERVED_NAMES = {
     "sect-keys",
     "sect-summary",
 }
-_CUSTOM_WORKFLOW_AUTHORING_KEYS = {"template", "custom_steps"}
+_CUSTOM_WORKFLOW_AUTHORING_KEYS = {
+    "template",
+    "custom_steps",
+    _CUSTOM_WORKFLOW_AGENT_CHAIN_KEY,
+}
 _CUSTOM_WORKFLOW_PERSISTED_KEYS = {
     "metadata_version",
     "template",
     "custom_steps",
+    _CUSTOM_WORKFLOW_AGENT_CHAIN_KEY,
     "output_routes",
     "leaf_fields",
     "field_counts",
@@ -283,11 +312,73 @@ def _raise_unsupported_top_level_metadata(key: str) -> typing.NoReturn:
     raise ValueError(
         f"unsupported top-level metadata [{key}]; generic SDK top-level keys "
         "must be extraction groups with mapping values, reserved SDK keys, or "
-        "supported SDK metadata keys. "
-        "If this key is domain-specific metadata, register it with "
-        "top_level_metadata_keys. Otherwise convert it to supported workflow "
+        "supported SDK metadata keys. Convert it to supported workflow "
         "metadata before using the generic extraction workflow helpers."
     )
+
+
+def _reject_unsupported_authored_keys(data: typing.Dict[str, typing.Any]) -> None:
+    for key in _UNSUPPORTED_TOP_LEVEL_KEYS:
+        if key in data:
+            raise ValueError(
+                f"top-level [{key}] is not supported in extraction YAML; "
+                "use extraction_policy_version: v1 with workflow metadata, or "
+                "pure legacy statement/meters/charges YAML"
+            )
+
+
+def _reject_unsupported_workflow_group_keys(
+    mapping: typing.Dict[str, typing.Any],
+    path: str,
+) -> None:
+    for key in _UNSUPPORTED_WORKFLOW_GROUP_KEYS:
+        if key in mapping:
+            raise ValueError(
+                f"[{key}] is not supported at [{path}]; use group-level "
+                f"[{_CUSTOM_WORKFLOW_GROUP_METADATA_KEY}] in "
+                "extraction_policy_version: v1 YAML"
+            )
+
+
+def _validate_policy_version(
+    data: typing.Dict[str, typing.Any],
+    has_new_yaml_features: bool,
+    *,
+    has_persisted_workflow_metadata: bool = False,
+) -> None:
+    has_version = _EXTRACTION_POLICY_VERSION_KEY in data
+    if has_persisted_workflow_metadata:
+        if has_version and data.get(_EXTRACTION_POLICY_VERSION_KEY) != "v1":
+            raise ValueError("extraction_policy_version must be v1")
+        return
+
+    if has_new_yaml_features:
+        if data.get(_EXTRACTION_POLICY_VERSION_KEY) != "v1":
+            raise ValueError(
+                "new extraction workflow YAML must set "
+                "extraction_policy_version: v1"
+            )
+        return
+
+    if has_version:
+        raise ValueError(
+            "pure legacy extraction YAML must not declare "
+            "extraction_policy_version"
+        )
+
+
+def _has_supported_policy_metadata(data: typing.Dict[str, typing.Any]) -> bool:
+    for key, value in data.items():
+        if key in _RESERVED_TOP_LEVEL_KEYS or key in _SUPPORTED_TOP_LEVEL_METADATA_KEYS:
+            continue
+        if isinstance(value, dict) and set(value) & _SUPPORTED_FINAL_GROUP_METADATA_KEYS:
+            return True
+    return False
+
+
+def _has_persisted_workflow_metadata(data: typing.Dict[str, typing.Any]) -> bool:
+    workflow = data.get(_CUSTOM_WORKFLOW_KEY)
+    return isinstance(workflow, dict) and "metadata_version" in workflow
 
 
 def _ensure_fields_mapping(
@@ -666,6 +757,15 @@ def _normalize_workflow_template(value: typing.Any) -> typing.Dict[str, str]:
         normalized[key] = raw_value
 
     return normalized
+
+
+def _normalize_agent_chain(value: typing.Any) -> typing.Optional[typing.Any]:
+    if value is None:
+        return None
+    if not isinstance(value, (dict, list)):
+        raise ValueError(f"{_CUSTOM_WORKFLOW_KEY}.agent_chain must be a mapping or list")
+
+    return copy.deepcopy(value)
 
 
 def _valid_custom_workflow_kind(level: str, kind: str) -> bool:
@@ -1148,6 +1248,11 @@ def _normalize_persisted_custom_workflow_metadata(
         metadata["template"] = template
     if field_counts:
         metadata["field_counts"] = field_counts
+    agent_chain = _normalize_agent_chain(
+        workflow.get(_CUSTOM_WORKFLOW_AGENT_CHAIN_KEY)
+    )
+    if agent_chain is not None:
+        metadata[_CUSTOM_WORKFLOW_AGENT_CHAIN_KEY] = agent_chain
 
     schema_hash = _custom_workflow_schema_hash(metadata)
     caller_schema_hash = workflow.get("schema_hash")
@@ -1177,9 +1282,10 @@ def _collect_custom_workflow_routes(
             field_items = typing.cast(typing.List[typing.Any], field_value)
             for item in field_items:
                 item_mapping = _ensure_mapping(item, field_path)
-                nested_step = item_mapping.pop(
-                    _CUSTOM_WORKFLOW_GROUP_METADATA_KEY, step_name
-                )
+                if _CUSTOM_WORKFLOW_GROUP_METADATA_KEY in item_mapping:
+                    raise ValueError(
+                        f"field-level workflow_step is not supported at [{field_path}]"
+                    )
                 if "fields" in item_mapping:
                     item_fields = _ensure_fields_mapping(
                         item_mapping.get("fields"), f"{field_path}.fields"
@@ -1187,7 +1293,7 @@ def _collect_custom_workflow_routes(
                     nested_routes, nested_leaves = _collect_custom_workflow_routes(
                         item_fields,
                         group_name,
-                        typing.cast(typing.Optional[str], nested_step),
+                        step_name,
                         steps_by_name,
                         (*prefix, field_name, "*"),
                     )
@@ -1199,18 +1305,21 @@ def _collect_custom_workflow_routes(
             continue
 
         field_mapping = typing.cast(typing.Dict[str, typing.Any], field_value)
-        nested_step = field_mapping.pop(_CUSTOM_WORKFLOW_GROUP_METADATA_KEY, step_name)
+        if _CUSTOM_WORKFLOW_GROUP_METADATA_KEY in field_mapping:
+            raise ValueError(
+                f"field-level workflow_step is not supported at [{field_path}]"
+            )
         output_key_raw = field_mapping.pop(_CUSTOM_WORKFLOW_FIELD_METADATA_KEY, None)
         if output_key_raw is not None:
-            if not nested_step:
+            if not step_name:
                 raise ValueError(
                     f"field [{field_path}] declares workflow_output_key without workflow_step"
                 )
-            if not isinstance(nested_step, str):
+            if not isinstance(step_name, str):
                 raise ValueError(f"workflow_step for [{field_path}] must be a string")
-            step = steps_by_name.get(nested_step)
+            step = steps_by_name.get(step_name)
             if step is None:
-                raise ValueError(f"unknown custom step [{nested_step}]")
+                raise ValueError(f"unknown custom step [{step_name}]")
             output_key = _validate_output_key(
                 output_key_raw,
                 f"{field_path}.{_CUSTOM_WORKFLOW_FIELD_METADATA_KEY}",
@@ -1223,19 +1332,19 @@ def _collect_custom_workflow_routes(
                 "workflow_group": group_name,
                 "workflow_field": workflow_field,
                 "final_path": final_path,
-                "step_name": nested_step,
+                "step_name": step_name,
                 "level": level,
                 "output_map": _custom_workflow_output_map(level),
                 "output_key": output_key,
                 "readback_path": _custom_workflow_readback_path(
-                    level, nested_step, output_key
+                    level, step_name, output_key
                 ),
             }
             leaf = {
                 "final_path": final_path,
                 "workflow_group": group_name,
                 "workflow_field": workflow_field,
-                "step_name": nested_step,
+                "step_name": step_name,
                 "level": level,
                 "output_key": output_key,
                 "field_type": _field_type(field_mapping),
@@ -1252,7 +1361,7 @@ def _collect_custom_workflow_routes(
             nested_routes, nested_leaves = _collect_custom_workflow_routes(
                 nested_fields,
                 group_name,
-                typing.cast(typing.Optional[str], nested_step),
+                step_name,
                 steps_by_name,
                 (*prefix, field_name),
             )
@@ -1262,7 +1371,7 @@ def _collect_custom_workflow_routes(
             nested_routes, nested_leaves = _collect_custom_workflow_routes(
                 field_mapping,
                 group_name,
-                typing.cast(typing.Optional[str], nested_step),
+                step_name,
                 steps_by_name,
                 (*prefix, field_name),
             )
@@ -1272,10 +1381,85 @@ def _collect_custom_workflow_routes(
     return routes, leaves
 
 
+def _collect_pseudo_custom_workflow_routes(
+    group_name: str,
+    group: typing.Dict[str, typing.Any],
+    step_name: typing.Optional[str],
+    steps_by_name: typing.Dict[str, typing.Dict[str, typing.Any]],
+    workflow_field_paths: typing.Dict[str, str],
+) -> typing.Tuple[
+    typing.List[typing.Dict[str, typing.Any]],
+    typing.List[typing.Dict[str, typing.Any]],
+]:
+    if not step_name:
+        return [], []
+    if not isinstance(step_name, str):
+        raise ValueError(f"workflow_step for pseudo group [{group_name}] must be a string")
+    step = steps_by_name.get(step_name)
+    if step is None:
+        raise ValueError(f"unknown custom step [{step_name}]")
+
+    routes: typing.List[typing.Dict[str, typing.Any]] = []
+    leaves: typing.List[typing.Dict[str, typing.Any]] = []
+    fields = _ensure_fields_mapping(group.get("fields"), f"{group_name}.fields")
+    for workflow_field, field_value in fields.items():
+        field_path = f"{group_name}.{workflow_field}"
+        if not isinstance(field_value, dict):
+            continue
+        field_mapping = typing.cast(typing.Dict[str, typing.Any], field_value)
+        if _CUSTOM_WORKFLOW_GROUP_METADATA_KEY in field_mapping:
+            raise ValueError(
+                f"field-level workflow_step is not supported at [{field_path}]"
+            )
+        if _CUSTOM_WORKFLOW_FIELD_METADATA_KEY in field_mapping:
+            raise ValueError(
+                f"pseudo-routed field [{field_path}] cannot declare "
+                f"{_CUSTOM_WORKFLOW_FIELD_METADATA_KEY}; use the pseudo field key"
+            )
+        output_key = _validate_output_key(workflow_field, field_path)
+        final_path = workflow_field_paths.get(workflow_field)
+        if final_path is None:
+            raise ValueError(
+                f"pseudo group [{group_name}] has no final path for [{workflow_field}]"
+            )
+        level = typing.cast(str, step["level"])
+        route = {
+            "workflow_group": group_name,
+            "workflow_field": workflow_field,
+            "final_path": final_path,
+            "step_name": step_name,
+            "level": level,
+            "output_map": _custom_workflow_output_map(level),
+            "output_key": output_key,
+            "readback_path": _custom_workflow_readback_path(
+                level, step_name, output_key
+            ),
+        }
+        leaf = {
+            "final_path": final_path,
+            "workflow_group": group_name,
+            "workflow_field": workflow_field,
+            "step_name": step_name,
+            "level": level,
+            "output_key": output_key,
+            "field_type": _field_type(field_mapping),
+            "is_repeated": "*" in _parse_pointer_segments(final_path, field_path),
+            "repetition_scope": _repetition_scope(
+                _parse_pointer_segments(final_path, field_path)
+            ),
+        }
+        routes.append(route)
+        leaves.append(leaf)
+
+    return routes, leaves
+
+
 def _build_authored_custom_workflow_metadata(
     workflow: typing.Dict[str, typing.Any],
-    groups: typing.Dict[str, typing.Dict[str, typing.Any]],
-    final_workflow_metadata: typing.Dict[str, typing.Dict[str, typing.Any]],
+    workflow_groups: typing.Dict[str, typing.Dict[str, typing.Any]],
+    workflow_group_metadata: typing.Dict[str, typing.Dict[str, typing.Any]],
+    workflow_field_paths: typing.Dict[str, typing.Dict[str, str]],
+    pseudo_group_names: typing.Set[str],
 ) -> typing.Dict[str, typing.Any]:
     template = _normalize_workflow_template(workflow.get("template"))
     custom_steps, steps_by_name = _normalize_custom_workflow_steps(
@@ -1286,17 +1470,28 @@ def _build_authored_custom_workflow_metadata(
 
     routes: typing.List[typing.Dict[str, typing.Any]] = []
     leaves: typing.List[typing.Dict[str, typing.Any]] = []
-    for group_name, group in groups.items():
-        group_step = final_workflow_metadata.get(group_name, {}).get(
+    for group_name, group in workflow_groups.items():
+        group_step = workflow_group_metadata.get(group_name, {}).get(
             _CUSTOM_WORKFLOW_GROUP_METADATA_KEY
         )
+        if group_step and group_step not in steps_by_name:
+            raise ValueError(f"unknown custom step [{group_step}]")
         fields = _ensure_fields_mapping(group.get("fields"), f"{group_name}.fields")
-        group_routes, group_leaves = _collect_custom_workflow_routes(
-            fields,
-            group_name,
-            typing.cast(typing.Optional[str], group_step),
-            steps_by_name,
-        )
+        if group_name in pseudo_group_names:
+            group_routes, group_leaves = _collect_pseudo_custom_workflow_routes(
+                group_name,
+                group,
+                typing.cast(typing.Optional[str], group_step),
+                steps_by_name,
+                workflow_field_paths.get(group_name, {}),
+            )
+        else:
+            group_routes, group_leaves = _collect_custom_workflow_routes(
+                fields,
+                group_name,
+                typing.cast(typing.Optional[str], group_step),
+                steps_by_name,
+            )
         routes.extend(group_routes)
         leaves.extend(group_leaves)
 
@@ -1316,6 +1511,11 @@ def _build_authored_custom_workflow_metadata(
         metadata["template"] = template
     if field_counts:
         metadata["field_counts"] = field_counts
+    agent_chain = _normalize_agent_chain(
+        workflow.get(_CUSTOM_WORKFLOW_AGENT_CHAIN_KEY)
+    )
+    if agent_chain is not None:
+        metadata[_CUSTOM_WORKFLOW_AGENT_CHAIN_KEY] = agent_chain
     metadata["schema_hash"] = _custom_workflow_schema_hash(metadata)
     return metadata
 
@@ -1451,9 +1651,25 @@ def prepare_extraction_yaml(
         ) and _is_custom_workflow_persisted_metadata(persisted_workflow):
             data[_CUSTOM_WORKFLOW_KEY] = _copy_mapping(persisted_workflow)
     custom_workflow_kind_and_input = _custom_workflow_input(data)
+    is_persisted_custom_workflow = (
+        custom_workflow_kind_and_input is not None
+        and custom_workflow_kind_and_input[0] == "persisted"
+    )
+    _reject_unsupported_authored_keys(data)
+    has_persisted_workflow_metadata = _has_persisted_workflow_metadata(data)
+    _validate_policy_version(
+        data,
+        bool(
+            (custom_workflow_kind_and_input and not is_persisted_custom_workflow)
+            or "_pseudo_groups" in data
+            or _has_supported_policy_metadata(data)
+        ),
+        has_persisted_workflow_metadata=has_persisted_workflow_metadata,
+    )
     top_metadata_key_set = set(_SUPPORTED_TOP_LEVEL_METADATA_KEYS)
     top_metadata_key_set.update(top_level_metadata_keys or [])
-    final_metadata_key_set = set(final_group_metadata_keys or [])
+    final_metadata_key_set = set(_SUPPORTED_FINAL_GROUP_METADATA_KEYS)
+    final_metadata_key_set.update(final_group_metadata_keys or [])
     workflow_metadata_key_set = set(workflow_group_metadata_keys or [])
     effective_workflow_metadata_key_set = workflow_metadata_key_set | {
         _CUSTOM_WORKFLOW_GROUP_METADATA_KEY
@@ -1487,15 +1703,11 @@ def prepare_extraction_yaml(
         if not isinstance(raw_group, dict):
             _raise_unsupported_top_level_metadata(group_name)
         group = _ensure_mapping(raw_group, group_name)
+        _reject_unsupported_workflow_group_keys(group, group_name)
         group, final_metadata = _split_metadata(group, final_metadata_key_set)
         group, workflow_metadata = _split_metadata(
             group, effective_workflow_metadata_key_set
         )
-        if "slot" in workflow_metadata and _CUSTOM_WORKFLOW_GROUP_METADATA_KEY in workflow_metadata:
-            raise ValueError(
-                f"group [{group_name}] cannot declare both [slot] and "
-                f"[{_CUSTOM_WORKFLOW_GROUP_METADATA_KEY}]"
-            )
         group = _compose_group_fields(group_name, group, defs)
         _validate_group_shape(group, group_name)
         groups[group_name] = group
@@ -1506,6 +1718,7 @@ def prepare_extraction_yaml(
             final_workflow_metadata[group_name] = workflow_metadata
 
     custom_workflow_metadata: typing.Optional[typing.Dict[str, typing.Any]] = None
+    custom_workflow_authoring_input: typing.Optional[typing.Dict[str, typing.Any]] = None
     if custom_workflow_kind_and_input:
         custom_workflow_kind, custom_workflow_input = custom_workflow_kind_and_input
         if custom_workflow_kind == "persisted":
@@ -1513,11 +1726,7 @@ def prepare_extraction_yaml(
                 custom_workflow_input
             )
         else:
-            custom_workflow_metadata = _build_authored_custom_workflow_metadata(
-                custom_workflow_input,
-                groups,
-                final_workflow_metadata,
-            )
+            custom_workflow_authoring_input = custom_workflow_input
 
     raw_pseudo_groups: typing.Dict[str, typing.Any] = {}
     if "_pseudo_groups" in data:
@@ -1536,6 +1745,10 @@ def prepare_extraction_yaml(
 
         pseudo_group = _ensure_mapping(
             raw_pseudo_group, f"_pseudo_groups.{pseudo_group_name}"
+        )
+        _reject_unsupported_workflow_group_keys(
+            pseudo_group,
+            f"_pseudo_groups.{pseudo_group_name}",
         )
         pseudo_group, explicit_workflow_metadata = _split_metadata(
             pseudo_group, effective_workflow_metadata_key_set
@@ -1567,6 +1780,10 @@ def prepare_extraction_yaml(
         ] = {}
 
         for workflow_field_name, raw_pseudo_field in pseudo_fields.items():
+            _validate_output_key(
+                workflow_field_name,
+                f"_pseudo_groups.{pseudo_group_name}.fields.{workflow_field_name}",
+            )
             pseudo_field = _ensure_mapping(
                 raw_pseudo_field,
                 f"_pseudo_groups.{pseudo_group_name}.fields.{workflow_field_name}",
@@ -1600,6 +1817,11 @@ def prepare_extraction_yaml(
                 groups,
                 final_field_path,
             )
+            if _CUSTOM_WORKFLOW_FIELD_METADATA_KEY in final_field:
+                raise ValueError(
+                    f"pseudo-routed final field [{final_pointer}] cannot declare "
+                    f"{_CUSTOM_WORKFLOW_FIELD_METADATA_KEY}; use the pseudo field key"
+                )
             routed_final_paths[final_pointer] = final_field_path
             parent_paths.add(parent_path)
             parent_groups[parent_path] = parent_group
@@ -1643,6 +1865,17 @@ def prepare_extraction_yaml(
     if not pseudo_groups:
         workflow_groups = _copy_mapping(groups)
         workflow_field_paths = _build_identity_route_map(groups)
+        workflow_group_metadata = _copy_mapping(final_workflow_metadata)
+        if custom_workflow_authoring_input is not None:
+            custom_workflow_metadata = _build_authored_custom_workflow_metadata(
+                custom_workflow_authoring_input,
+                workflow_groups,
+                workflow_group_metadata,
+                workflow_field_paths,
+                set(),
+            )
+            _strip_custom_workflow_authoring_keys(groups)
+            _strip_custom_workflow_authoring_keys(workflow_groups)
         _apply_custom_workflow_field_paths(
             workflow_field_paths,
             custom_workflow_metadata,
@@ -1662,7 +1895,7 @@ def prepare_extraction_yaml(
             ),
             top_level_metadata=top_level_metadata,
             final_group_metadata=final_group_metadata,
-            workflow_group_metadata=_copy_mapping(final_workflow_metadata),
+            workflow_group_metadata=workflow_group_metadata,
         )
 
     residual_groups = _copy_mapping(groups)
@@ -1685,6 +1918,20 @@ def prepare_extraction_yaml(
         workflow_field_paths,
         custom_workflow_metadata,
     )
+    if custom_workflow_authoring_input is not None:
+        custom_workflow_metadata = _build_authored_custom_workflow_metadata(
+            custom_workflow_authoring_input,
+            workflow_groups,
+            workflow_group_metadata,
+            workflow_field_paths,
+            set(pseudo_groups.keys()),
+        )
+        _strip_custom_workflow_authoring_keys(groups)
+        _strip_custom_workflow_authoring_keys(workflow_groups)
+        _apply_custom_workflow_field_paths(
+            workflow_field_paths,
+            custom_workflow_metadata,
+        )
 
     return PreparedExtractionYaml(
         groups=groups,

--- a/src/groundx/extract/prompt/utility.py
+++ b/src/groundx/extract/prompt/utility.py
@@ -24,6 +24,25 @@ _CUSTOM_WORKFLOW_OUTPUT_MAPS = {
     "section": "customSectionOutputs",
     "document": "customDocumentOutputs",
 }
+_CUSTOM_WORKFLOW_AGENT_CHAIN_AGENT_TASKS = frozenset(
+    {
+        "reconcile_charges",
+        "reconcile_meters",
+        "reconcile_statement",
+        "qa_meters",
+        "qa_statement",
+    }
+)
+_CUSTOM_WORKFLOW_AGENT_CHAIN_SAVE_TASKS = frozenset(
+    {
+        "save_charges",
+        "save_meters",
+        "save_statement",
+    }
+)
+_CUSTOM_WORKFLOW_AGENT_CHAIN_SUPPORTED_TASKS = (
+    _CUSTOM_WORKFLOW_AGENT_CHAIN_AGENT_TASKS | _CUSTOM_WORKFLOW_AGENT_CHAIN_SAVE_TASKS
+)
 _RESERVED_TOP_LEVEL_KEYS = {
     "_defs",
     "_pseudo_groups",
@@ -759,13 +778,190 @@ def _normalize_workflow_template(value: typing.Any) -> typing.Dict[str, str]:
     return normalized
 
 
-def _normalize_agent_chain(value: typing.Any) -> typing.Optional[typing.Any]:
+def _normalize_agent_chain(
+    value: typing.Any,
+    workflow_groups: typing.Optional[typing.Set[str]] = None,
+) -> typing.Optional[typing.Any]:
     if value is None:
         return None
-    if not isinstance(value, (dict, list)):
-        raise ValueError(f"{_CUSTOM_WORKFLOW_KEY}.agent_chain must be a mapping or list")
+    if not isinstance(value, list):
+        raise ValueError(f"{_CUSTOM_WORKFLOW_KEY}.agent_chain must be a list")
+    if not value:
+        raise ValueError(f"{_CUSTOM_WORKFLOW_KEY}.agent_chain must be a non-empty list")
 
+    _validate_agent_chain(value, workflow_groups or set())
     return copy.deepcopy(value)
+
+
+def _validate_agent_chain(
+    raw_chain: typing.List[typing.Any],
+    workflow_groups: typing.Set[str],
+) -> None:
+    first_stage = raw_chain[0]
+    if not isinstance(first_stage, dict) or set(first_stage.keys()) != {"parallel"}:
+        raise ValueError(
+            f"{_CUSTOM_WORKFLOW_KEY}.agent_chain must start with a parallel stage"
+        )
+
+    has_save = False
+    serial_start_index = 1
+    for stage_index, raw_stage in enumerate(raw_chain):
+        if isinstance(raw_stage, str):
+            _validate_agent_chain_task(
+                raw_stage,
+                f"{_CUSTOM_WORKFLOW_KEY}.agent_chain[{stage_index}]",
+            )
+            if raw_stage in _CUSTOM_WORKFLOW_AGENT_CHAIN_SAVE_TASKS:
+                has_save = True
+            continue
+
+        if not isinstance(raw_stage, dict) or set(raw_stage.keys()) != {"parallel"}:
+            raise ValueError(
+                f"{_CUSTOM_WORKFLOW_KEY}.agent_chain stages must be task strings or "
+                "{parallel: [...]}"
+            )
+        if stage_index != 0:
+            raise ValueError(
+                "workflow.agent_chain parallel stages after the first stage are not supported"
+            )
+
+        raw_branches = raw_stage["parallel"]
+        if not isinstance(raw_branches, list) or not raw_branches:
+            raise ValueError(
+                f"{_CUSTOM_WORKFLOW_KEY}.agent_chain parallel stage must have branches"
+            )
+
+        branch_terminal_saves: typing.List[bool] = []
+        branch_suffixes: typing.List[str] = []
+
+        for branch_index, raw_branch in enumerate(raw_branches):
+            path = (
+                f"{_CUSTOM_WORKFLOW_KEY}.agent_chain"
+                f"[{stage_index}].parallel[{branch_index}]"
+            )
+            if not isinstance(raw_branch, dict):
+                raise ValueError(f"{path} must be a mapping")
+            if set(raw_branch.keys()) != {"group", "chain"}:
+                raise ValueError(f"{path} must contain only group and chain")
+
+            group = raw_branch["group"]
+            if not isinstance(group, str) or not group:
+                raise ValueError(f"{path}.group must be a non-empty string")
+            if group not in workflow_groups:
+                raise ValueError(f"{path}.group [{group}] is not a workflow group")
+
+            chain = raw_branch["chain"]
+            if not isinstance(chain, list) or not chain:
+                raise ValueError(f"{path}.chain must be a non-empty list")
+            parsed_chain = [
+                _validate_agent_chain_task(task, f"{path}.chain")
+                for task in chain
+            ]
+            if any(
+                task in _CUSTOM_WORKFLOW_AGENT_CHAIN_SAVE_TASKS
+                for task in parsed_chain[:-1]
+            ):
+                raise ValueError(f"{path}.chain save task must be last")
+            suffixes = {_agent_chain_task_suffix(task) for task in parsed_chain}
+            if len(suffixes) != 1:
+                raise ValueError(f"{path}.chain must use one processing suffix")
+            branch_suffixes.append(suffixes.pop())
+            branch_terminal_saves.append(
+                parsed_chain[-1] in _CUSTOM_WORKFLOW_AGENT_CHAIN_SAVE_TASKS
+            )
+
+        terminal_save = _agent_chain_following_save_task(raw_chain, stage_index)
+        if any(branch_terminal_saves):
+            has_save = True
+            serial_start_index = stage_index + 1
+            if terminal_save is not None:
+                raise ValueError(
+                    "workflow.agent_chain parallel branch save tasks cannot be "
+                    "combined with a following top-level save task"
+                )
+            if not all(branch_terminal_saves):
+                raise ValueError(
+                    "workflow.agent_chain parallel branches must either all end in "
+                    "save tasks or all use the following top-level save task"
+                )
+        elif terminal_save is None:
+            raise ValueError(
+                "workflow.agent_chain parallel branches must end in a save task or "
+                "be followed by one top-level save task"
+            )
+        else:
+            serial_start_index = stage_index + 2
+            terminal_suffix = _agent_chain_task_suffix(terminal_save)
+            for suffix in branch_suffixes:
+                if suffix != terminal_suffix:
+                    raise ValueError(
+                        "workflow.agent_chain parallel branch processing suffix "
+                        "must match following save task"
+                    )
+
+    if not has_save:
+        raise ValueError(f"{_CUSTOM_WORKFLOW_KEY}.agent_chain must include a save task")
+    _validate_agent_chain_serial_tasks(raw_chain, serial_start_index)
+
+
+def _validate_agent_chain_serial_tasks(
+    raw_chain: typing.List[typing.Any],
+    start_index: int,
+) -> None:
+    stage_index = start_index
+    while stage_index < len(raw_chain):
+        path = f"{_CUSTOM_WORKFLOW_KEY}.agent_chain[{stage_index}]"
+        task = _validate_agent_chain_task(raw_chain[stage_index], path)
+        if task in _CUSTOM_WORKFLOW_AGENT_CHAIN_SAVE_TASKS:
+            raise ValueError(
+                f"{path} top-level save task [{task}] must follow a matching "
+                "top-level agent task"
+            )
+
+        expected_save = f"save_{_agent_chain_task_suffix(task)}"
+        next_index = stage_index + 1
+        if next_index >= len(raw_chain):
+            raise ValueError(
+                f"{path} top-level agent task [{task}] must be followed by "
+                f"matching save task [{expected_save}]"
+            )
+
+        next_path = f"{_CUSTOM_WORKFLOW_KEY}.agent_chain[{next_index}]"
+        next_task = _validate_agent_chain_task(raw_chain[next_index], next_path)
+        if next_task != expected_save:
+            raise ValueError(
+                f"{path} top-level agent task [{task}] must be followed by "
+                f"matching save task [{expected_save}]"
+            )
+        stage_index += 2
+
+
+def _validate_agent_chain_task(task: typing.Any, path: str) -> str:
+    if not isinstance(task, str) or not task:
+        raise ValueError(f"{path} task must be a non-empty string")
+    if task not in _CUSTOM_WORKFLOW_AGENT_CHAIN_SUPPORTED_TASKS:
+        raise ValueError(f"{path} contains unsupported task [{task}]")
+    return task
+
+
+def _agent_chain_following_save_task(
+    raw_chain: typing.List[typing.Any],
+    stage_index: int,
+) -> typing.Optional[str]:
+    next_index = stage_index + 1
+    if next_index >= len(raw_chain):
+        return None
+    raw_next = raw_chain[next_index]
+    if (
+        isinstance(raw_next, str)
+        and raw_next in _CUSTOM_WORKFLOW_AGENT_CHAIN_SAVE_TASKS
+    ):
+        return raw_next
+    return None
+
+
+def _agent_chain_task_suffix(task: str) -> str:
+    return task.rsplit("_", 1)[-1]
 
 
 def _valid_custom_workflow_kind(level: str, kind: str) -> bool:
@@ -1249,7 +1445,8 @@ def _normalize_persisted_custom_workflow_metadata(
     if field_counts:
         metadata["field_counts"] = field_counts
     agent_chain = _normalize_agent_chain(
-        workflow.get(_CUSTOM_WORKFLOW_AGENT_CHAIN_KEY)
+        workflow.get(_CUSTOM_WORKFLOW_AGENT_CHAIN_KEY),
+        {route["workflow_group"] for route in routes},
     )
     if agent_chain is not None:
         metadata[_CUSTOM_WORKFLOW_AGENT_CHAIN_KEY] = agent_chain
@@ -1512,7 +1709,8 @@ def _build_authored_custom_workflow_metadata(
     if field_counts:
         metadata["field_counts"] = field_counts
     agent_chain = _normalize_agent_chain(
-        workflow.get(_CUSTOM_WORKFLOW_AGENT_CHAIN_KEY)
+        workflow.get(_CUSTOM_WORKFLOW_AGENT_CHAIN_KEY),
+        set(workflow_groups.keys()),
     )
     if agent_chain is not None:
         metadata[_CUSTOM_WORKFLOW_AGENT_CHAIN_KEY] = agent_chain

--- a/src/groundx/extract/workflows.py
+++ b/src/groundx/extract/workflows.py
@@ -12,6 +12,7 @@ _WORKFLOW_METADATA_KEY = "workflow"
 _WORKFLOW_EXTRACT_MAPPING_KIND = "workflow_extract"
 _AUTHORED_YAML_MAPPING_KIND = "authored_yaml"
 _PERSISTED_WORKFLOW_METADATA_KEYS = {
+    "agent_chain",
     "metadata_version",
     "output_routes",
     "leaf_fields",

--- a/tests/custom/test_extraction_workflow_client_exports.py
+++ b/tests/custom/test_extraction_workflow_client_exports.py
@@ -13,6 +13,8 @@ import pytest
 from groundx import GroundX
 
 CUSTOM_WORKFLOW_YAML = """
+extraction_policy_version: v1
+
 workflow:
   template:
     "{{LANGUAGE}}": English

--- a/tests/extract/classes/test_document.py
+++ b/tests/extract/classes/test_document.py
@@ -20,6 +20,8 @@ from groundx.extract.classes.testing import TestXRay
 from groundx.extract.prompt.manager import PromptManager
 
 CUSTOM_WORKFLOW_YAML = """
+extraction_policy_version: v1
+
 workflow:
   custom_steps:
     - name: line_item_labels
@@ -40,6 +42,8 @@ line_items:
 
 
 CUSTOM_REPEATED_WORKFLOW_YAML = """
+extraction_policy_version: v1
+
 workflow:
   custom_steps:
     - name: charge_labels

--- a/tests/extract/prompt/_fixtures.py
+++ b/tests/extract/prompt/_fixtures.py
@@ -82,6 +82,8 @@ statement:
 """
 
 SAMPLE_YAML_PSEUDO_GROUPS = """
+extraction_policy_version: v1
+
 statement:
   prompt:
     instructions: Extract statement-level fields for the final statement object.

--- a/tests/extract/prompt/fixtures/extraction_yaml_contract_v1.expected.json
+++ b/tests/extract/prompt/fixtures/extraction_yaml_contract_v1.expected.json
@@ -123,27 +123,27 @@
         }
       },
       "workflow": {
-        "agent_chain": {
-          "parallel": [
-            {
-              "chain": [
-                "reconcile_statement",
-                "qa_statement"
-              ],
-              "group": "statement_identity"
-            },
-            {
-              "chain": [
-                "reconcile_statement",
-                "qa_statement"
-              ],
-              "group": "statement_totals"
-            }
-          ],
-          "then": [
-            "save_statement"
-          ]
-        },
+        "agent_chain": [
+          {
+            "parallel": [
+              {
+                "chain": [
+                  "reconcile_statement",
+                  "qa_statement"
+                ],
+                "group": "statement_identity"
+              },
+              {
+                "chain": [
+                  "reconcile_statement",
+                  "qa_statement"
+                ],
+                "group": "statement_totals"
+              }
+            ]
+          },
+          "save_statement"
+        ],
         "custom_steps": [
           {
             "kind": "keys",
@@ -272,27 +272,27 @@
       }
     },
     "workflow": {
-      "agent_chain": {
-        "parallel": [
-          {
-            "chain": [
-              "reconcile_statement",
-              "qa_statement"
-            ],
-            "group": "statement_identity"
-          },
-          {
-            "chain": [
-              "reconcile_statement",
-              "qa_statement"
-            ],
-            "group": "statement_totals"
-          }
-        ],
-        "then": [
-          "save_statement"
-        ]
-      },
+      "agent_chain": [
+        {
+          "parallel": [
+            {
+              "chain": [
+                "reconcile_statement",
+                "qa_statement"
+              ],
+              "group": "statement_identity"
+            },
+            {
+              "chain": [
+                "reconcile_statement",
+                "qa_statement"
+              ],
+              "group": "statement_totals"
+            }
+          ]
+        },
+        "save_statement"
+      ],
       "custom_steps": [
         {
           "kind": "keys",

--- a/tests/extract/prompt/fixtures/extraction_yaml_contract_v1.expected.json
+++ b/tests/extract/prompt/fixtures/extraction_yaml_contract_v1.expected.json
@@ -1,0 +1,486 @@
+{
+  "final_group_metadata": {
+    "statement": {
+      "explanation_attrs": [
+        "statement_explanation"
+      ],
+      "final_value_aliases": {
+        "total_amount_due": "amount_due"
+      }
+    }
+  },
+  "groups": {
+    "statement": {
+      "fields": {
+        "account_number": {
+          "prompt": {
+            "description": "Account number printed on the statement.",
+            "identifiers": [
+              "Account Number"
+            ],
+            "instructions": "Return the account number exactly as printed.",
+            "type": "str"
+          }
+        },
+        "late_fee": {
+          "prompt": {
+            "description": "Late fee.",
+            "identifiers": [
+              "Late Fee"
+            ],
+            "instructions": "Return the late fee as a number.",
+            "type": "float"
+          }
+        },
+        "total_amount_due": {
+          "prompt": {
+            "description": "Total amount due.",
+            "identifiers": [
+              "Total Amount Due"
+            ],
+            "instructions": "Return the total amount due as a number.",
+            "type": "float"
+          }
+        }
+      },
+      "prompt": {
+        "instructions": "Extract statement fields."
+      }
+    }
+  },
+  "persisted_workflow_extract": {
+    "_groundx_persisted_extract": {
+      "_defs": {
+        "identity_fields": {
+          "fields": {
+            "account_number": {
+              "prompt": {
+                "description": "Account number printed on the statement.",
+                "identifiers": [
+                  "Account Number"
+                ],
+                "instructions": "Return the account number exactly as printed.",
+                "type": "str"
+              }
+            }
+          }
+        }
+      },
+      "_pseudo_groups": {
+        "statement_identity": {
+          "fields": {
+            "account_number": {
+              "path": "/statement/account_number"
+            }
+          }
+        },
+        "statement_totals": {
+          "fields": {
+            "total_amount_due": {
+              "path": "/statement/total_amount_due"
+            }
+          },
+          "prompt": {
+            "instructions": "Extract only statement total fields."
+          }
+        }
+      },
+      "extraction_policy_version": "v1",
+      "statement": {
+        "explanation_attrs": [
+          "statement_explanation"
+        ],
+        "fields": {
+          "late_fee": {
+            "prompt": {
+              "description": "Late fee.",
+              "identifiers": [
+                "Late Fee"
+              ],
+              "instructions": "Return the late fee as a number.",
+              "type": "float"
+            }
+          },
+          "total_amount_due": {
+            "prompt": {
+              "description": "Total amount due.",
+              "identifiers": [
+                "Total Amount Due"
+              ],
+              "instructions": "Return the total amount due as a number.",
+              "type": "float"
+            }
+          }
+        },
+        "final_value_aliases": {
+          "total_amount_due": "amount_due"
+        },
+        "include": [
+          "identity_fields"
+        ],
+        "prompt": {
+          "instructions": "Extract statement fields."
+        }
+      },
+      "workflow": {
+        "agent_chain": {
+          "parallel": [
+            {
+              "chain": [
+                "reconcile_statement",
+                "qa_statement"
+              ],
+              "group": "statement_identity"
+            },
+            {
+              "chain": [
+                "reconcile_statement",
+                "qa_statement"
+              ],
+              "group": "statement_totals"
+            }
+          ],
+          "then": [
+            "save_statement"
+          ]
+        },
+        "custom_steps": [
+          {
+            "kind": "keys",
+            "level": "chunk",
+            "name": "statement_identity_fields",
+            "required_template_keys": [
+              "{{LANGUAGE}}"
+            ]
+          },
+          {
+            "kind": "instruct",
+            "level": "chunk",
+            "name": "statement_total_fields"
+          }
+        ],
+        "field_counts": {
+          "statement_identity_fields": 1,
+          "statement_total_fields": 1
+        },
+        "leaf_fields": [
+          {
+            "field_type": "str",
+            "final_path": "/statement/account_number",
+            "is_repeated": false,
+            "level": "chunk",
+            "output_key": "account_number",
+            "repetition_scope": "none",
+            "step_name": "statement_identity_fields",
+            "workflow_field": "account_number",
+            "workflow_group": "statement_identity"
+          },
+          {
+            "field_type": "float",
+            "final_path": "/statement/total_amount_due",
+            "is_repeated": false,
+            "level": "chunk",
+            "output_key": "total_amount_due",
+            "repetition_scope": "none",
+            "step_name": "statement_total_fields",
+            "workflow_field": "total_amount_due",
+            "workflow_group": "statement_totals"
+          }
+        ],
+        "metadata_version": 1,
+        "output_routes": [
+          {
+            "final_path": "/statement/account_number",
+            "level": "chunk",
+            "output_key": "account_number",
+            "output_map": "customChunkOutputs",
+            "readback_path": "/chunks/*/customChunkOutputs/statement_identity_fields/account_number",
+            "step_name": "statement_identity_fields",
+            "workflow_field": "account_number",
+            "workflow_group": "statement_identity"
+          },
+          {
+            "final_path": "/statement/total_amount_due",
+            "level": "chunk",
+            "output_key": "total_amount_due",
+            "output_map": "customChunkOutputs",
+            "readback_path": "/chunks/*/customChunkOutputs/statement_total_fields/total_amount_due",
+            "step_name": "statement_total_fields",
+            "workflow_field": "total_amount_due",
+            "workflow_group": "statement_totals"
+          }
+        ],
+        "schema_hash": "04a77e329e4aae879257af53f91985548198935b0f0c83071c348bdc7267e9cb",
+        "template": {
+          "{{LANGUAGE_UNKNOWN}}": "",
+          "{{LANGUAGE}}": "English"
+        }
+      }
+    },
+    "statement": {
+      "fields": {
+        "late_fee": {
+          "prompt": {
+            "description": "Late fee.",
+            "identifiers": [
+              "Late Fee"
+            ],
+            "instructions": "Return the late fee as a number.",
+            "type": "float"
+          }
+        }
+      },
+      "prompt": {
+        "instructions": "Extract statement fields."
+      }
+    },
+    "statement_identity": {
+      "fields": {
+        "account_number": {
+          "prompt": {
+            "attr_name": "account_number",
+            "description": "Account number printed on the statement.",
+            "identifiers": [
+              "Account Number"
+            ],
+            "instructions": "Return the account number exactly as printed.",
+            "type": "str"
+          }
+        }
+      },
+      "prompt": {
+        "attr_name": "statement_identity",
+        "instructions": "Extract statement fields."
+      }
+    },
+    "statement_totals": {
+      "fields": {
+        "total_amount_due": {
+          "prompt": {
+            "attr_name": "total_amount_due",
+            "description": "Total amount due.",
+            "identifiers": [
+              "Total Amount Due"
+            ],
+            "instructions": "Return the total amount due as a number.",
+            "type": "float"
+          }
+        }
+      },
+      "prompt": {
+        "instructions": "Extract only statement total fields."
+      }
+    },
+    "workflow": {
+      "agent_chain": {
+        "parallel": [
+          {
+            "chain": [
+              "reconcile_statement",
+              "qa_statement"
+            ],
+            "group": "statement_identity"
+          },
+          {
+            "chain": [
+              "reconcile_statement",
+              "qa_statement"
+            ],
+            "group": "statement_totals"
+          }
+        ],
+        "then": [
+          "save_statement"
+        ]
+      },
+      "custom_steps": [
+        {
+          "kind": "keys",
+          "level": "chunk",
+          "name": "statement_identity_fields",
+          "required_template_keys": [
+            "{{LANGUAGE}}"
+          ]
+        },
+        {
+          "kind": "instruct",
+          "level": "chunk",
+          "name": "statement_total_fields"
+        }
+      ],
+      "field_counts": {
+        "statement_identity_fields": 1,
+        "statement_total_fields": 1
+      },
+      "leaf_fields": [
+        {
+          "field_type": "str",
+          "final_path": "/statement/account_number",
+          "is_repeated": false,
+          "level": "chunk",
+          "output_key": "account_number",
+          "repetition_scope": "none",
+          "step_name": "statement_identity_fields",
+          "workflow_field": "account_number",
+          "workflow_group": "statement_identity"
+        },
+        {
+          "field_type": "float",
+          "final_path": "/statement/total_amount_due",
+          "is_repeated": false,
+          "level": "chunk",
+          "output_key": "total_amount_due",
+          "repetition_scope": "none",
+          "step_name": "statement_total_fields",
+          "workflow_field": "total_amount_due",
+          "workflow_group": "statement_totals"
+        }
+      ],
+      "metadata_version": 1,
+      "output_routes": [
+        {
+          "final_path": "/statement/account_number",
+          "level": "chunk",
+          "output_key": "account_number",
+          "output_map": "customChunkOutputs",
+          "readback_path": "/chunks/*/customChunkOutputs/statement_identity_fields/account_number",
+          "step_name": "statement_identity_fields",
+          "workflow_field": "account_number",
+          "workflow_group": "statement_identity"
+        },
+        {
+          "final_path": "/statement/total_amount_due",
+          "level": "chunk",
+          "output_key": "total_amount_due",
+          "output_map": "customChunkOutputs",
+          "readback_path": "/chunks/*/customChunkOutputs/statement_total_fields/total_amount_due",
+          "step_name": "statement_total_fields",
+          "workflow_field": "total_amount_due",
+          "workflow_group": "statement_totals"
+        }
+      ],
+      "schema_hash": "04a77e329e4aae879257af53f91985548198935b0f0c83071c348bdc7267e9cb",
+      "template": {
+        "{{LANGUAGE_UNKNOWN}}": "",
+        "{{LANGUAGE}}": "English"
+      }
+    }
+  },
+  "pseudo_groups": {
+    "statement_identity": {
+      "fields": {
+        "account_number": {
+          "prompt": {
+            "attr_name": "account_number",
+            "description": "Account number printed on the statement.",
+            "identifiers": [
+              "Account Number"
+            ],
+            "instructions": "Return the account number exactly as printed.",
+            "type": "str"
+          }
+        }
+      },
+      "prompt": {
+        "attr_name": "statement_identity",
+        "instructions": "Extract statement fields."
+      }
+    },
+    "statement_totals": {
+      "fields": {
+        "total_amount_due": {
+          "prompt": {
+            "attr_name": "total_amount_due",
+            "description": "Total amount due.",
+            "identifiers": [
+              "Total Amount Due"
+            ],
+            "instructions": "Return the total amount due as a number.",
+            "type": "float"
+          }
+        }
+      },
+      "prompt": {
+        "instructions": "Extract only statement total fields."
+      }
+    }
+  },
+  "top_level_metadata": {
+    "extraction_policy_version": "v1"
+  },
+  "workflow_field_paths": {
+    "statement": {
+      "late_fee": "/statement/late_fee"
+    },
+    "statement_identity": {
+      "account_number": "/statement/account_number"
+    },
+    "statement_totals": {
+      "total_amount_due": "/statement/total_amount_due"
+    }
+  },
+  "workflow_group_metadata": {
+    "statement_identity": {
+      "workflow_step": "statement_identity_fields"
+    },
+    "statement_totals": {
+      "workflow_step": "statement_total_fields"
+    }
+  },
+  "workflow_groups": {
+    "statement": {
+      "fields": {
+        "late_fee": {
+          "prompt": {
+            "description": "Late fee.",
+            "identifiers": [
+              "Late Fee"
+            ],
+            "instructions": "Return the late fee as a number.",
+            "type": "float"
+          }
+        }
+      },
+      "prompt": {
+        "instructions": "Extract statement fields."
+      }
+    },
+    "statement_identity": {
+      "fields": {
+        "account_number": {
+          "prompt": {
+            "attr_name": "account_number",
+            "description": "Account number printed on the statement.",
+            "identifiers": [
+              "Account Number"
+            ],
+            "instructions": "Return the account number exactly as printed.",
+            "type": "str"
+          }
+        }
+      },
+      "prompt": {
+        "attr_name": "statement_identity",
+        "instructions": "Extract statement fields."
+      }
+    },
+    "statement_totals": {
+      "fields": {
+        "total_amount_due": {
+          "prompt": {
+            "attr_name": "total_amount_due",
+            "description": "Total amount due.",
+            "identifiers": [
+              "Total Amount Due"
+            ],
+            "instructions": "Return the total amount due as a number.",
+            "type": "float"
+          }
+        }
+      },
+      "prompt": {
+        "instructions": "Extract only statement total fields."
+      }
+    }
+  }
+}

--- a/tests/extract/prompt/fixtures/extraction_yaml_contract_v1.yaml
+++ b/tests/extract/prompt/fixtures/extraction_yaml_contract_v1.yaml
@@ -14,17 +14,16 @@ workflow:
       level: chunk
       kind: instruct
   agent_chain:
-    parallel:
-      - group: statement_identity
-        chain:
-          - reconcile_statement
-          - qa_statement
-      - group: statement_totals
-        chain:
-          - reconcile_statement
-          - qa_statement
-    then:
-      - save_statement
+    - parallel:
+        - group: statement_identity
+          chain:
+            - reconcile_statement
+            - qa_statement
+        - group: statement_totals
+          chain:
+            - reconcile_statement
+            - qa_statement
+    - save_statement
 
 _defs:
   identity_fields:

--- a/tests/extract/prompt/fixtures/extraction_yaml_contract_v1.yaml
+++ b/tests/extract/prompt/fixtures/extraction_yaml_contract_v1.yaml
@@ -1,0 +1,78 @@
+extraction_policy_version: v1
+
+workflow:
+  template:
+    "{{LANGUAGE}}": English
+    "{{LANGUAGE_UNKNOWN}}": ""
+  custom_steps:
+    - name: statement_identity_fields
+      level: chunk
+      kind: keys
+      required_template_keys:
+        - "{{LANGUAGE}}"
+    - name: statement_total_fields
+      level: chunk
+      kind: instruct
+  agent_chain:
+    parallel:
+      - group: statement_identity
+        chain:
+          - reconcile_statement
+          - qa_statement
+      - group: statement_totals
+        chain:
+          - reconcile_statement
+          - qa_statement
+    then:
+      - save_statement
+
+_defs:
+  identity_fields:
+    fields:
+      account_number:
+        prompt:
+          description: Account number printed on the statement.
+          identifiers:
+            - Account Number
+          instructions: Return the account number exactly as printed.
+          type: str
+
+statement:
+  prompt:
+    instructions: Extract statement fields.
+  final_value_aliases:
+    total_amount_due: amount_due
+  explanation_attrs:
+    - statement_explanation
+  include:
+    - identity_fields
+  fields:
+    total_amount_due:
+      prompt:
+        description: Total amount due.
+        identifiers:
+          - Total Amount Due
+        instructions: Return the total amount due as a number.
+        type: float
+    late_fee:
+      prompt:
+        description: Late fee.
+        identifiers:
+          - Late Fee
+        instructions: Return the late fee as a number.
+        type: float
+
+_pseudo_groups:
+  statement_identity:
+    workflow_step: statement_identity_fields
+    fields:
+      account_number:
+        path: /statement/account_number
+
+  statement_totals:
+    workflow_step: statement_total_fields
+    prompt:
+      instructions: Extract only statement total fields.
+    fields:
+      total_amount_due:
+        path: /statement/total_amount_due

--- a/tests/extract/prompt/test_manager.py
+++ b/tests/extract/prompt/test_manager.py
@@ -51,6 +51,8 @@ class FlakyCachedSource(TestSource):
 
 
 CUSTOM_WORKFLOW_YAML = """
+extraction_policy_version: v1
+
 workflow:
   template:
     BILLING_HINT: Prefer values from the charge table.
@@ -427,7 +429,7 @@ Special Instructions:
             "_groundx_persisted_extract": {
                 "extraction_policy_version": "v1",
                 "statement": {
-                    "slot": "chunk-instruct",
+                    "workflow_step": "chunk-instruct",
                     "fields": {
                         "provider_name": {
                             "prompt": {
@@ -440,7 +442,7 @@ Special Instructions:
                 },
                 "_pseudo_groups": {
                     "statement_identity": {
-                        "slot": "chunk-instruct",
+                        "workflow_step": "chunk-instruct",
                         "fields": {
                             "provider_name": {
                                 "path": "/statement/provider_name",
@@ -474,7 +476,7 @@ Special Instructions:
             default_file_name="wf-1",
             default_workflow_id="wf-1",
             top_level_metadata_keys={"extraction_policy_version"},
-            workflow_group_metadata_keys={"slot"},
+            workflow_group_metadata_keys={"workflow_step"},
         )
 
         fields = manager.get_fields_for_workflow(workflow_id="wf-1")
@@ -564,9 +566,6 @@ Special Instructions:
             top_level_metadata_keys={"extraction_policy_version"},
         )
 
-        workflow_extract["_groundx_persisted_extract"][
-            "extraction_policy_version"
-        ] = "v2"
         workflow_extract["statement_identity"]["fields"]["provider_name"]["prompt"][
             "instructions"
         ] = "Return the updated provider name."
@@ -579,7 +578,7 @@ Special Instructions:
         self.assertGreaterEqual(workflows.requested_ids.count("wf-1"), 2)
         self.assertEqual(
             manager.top_level_metadata(workflow_id="wf-1"),
-            {"extraction_policy_version": "v2"},
+            {"extraction_policy_version": "v1"},
         )
         provider = manager.group_field(
             "statement_identity",
@@ -765,9 +764,10 @@ Special Instructions:
 
     def test_manager_exposes_prepared_metadata_surfaces(self) -> None:
         raw = """
-domain: invoice
+extraction_policy_version: v1
+
 statement:
-  slot: chunk-instruct
+  workflow_step: chunk-instruct
   unique_attrs:
     - account_number
   fields:
@@ -787,19 +787,18 @@ _pseudo_groups:
         manager = PromptManager(
             cache_source=source,
             config_source=source,
-            top_level_metadata_keys={"domain"},
             final_group_metadata_keys={"unique_attrs"},
-            workflow_group_metadata_keys={"slot"},
+            workflow_group_metadata_keys={"workflow_step"},
         )
 
-        self.assertEqual(manager.top_level_metadata(), {"domain": "invoice"})
+        self.assertEqual(manager.top_level_metadata(), {"extraction_policy_version": "v1"})
         self.assertEqual(
             manager.final_group_metadata(),
             {"statement": {"unique_attrs": ["account_number"]}},
         )
         self.assertEqual(
             manager.workflow_group_metadata(),
-            {"statement_identity": {"slot": "chunk-instruct"}},
+            {"statement_identity": {"workflow_step": "chunk-instruct"}},
         )
 
     def test_prepare_extraction_yaml_rejects_unsupported_top_level_scalar_metadata(
@@ -820,7 +819,6 @@ statement:
 
         message = str(exc.exception)
         self.assertIn("unsupported top-level metadata [unsupported_policy_version]", message)
-        self.assertIn("top_level_metadata_keys", message)
         self.assertIn("workflow metadata", message)
 
     def test_prepare_extraction_yaml_accepts_supported_policy_version_metadata(
@@ -830,6 +828,8 @@ statement:
             """
 extraction_policy_version: v1
 statement:
+  final_value_aliases:
+    account_number: account_number
   fields:
     account_number:
       prompt:
@@ -879,6 +879,8 @@ statement:
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 """
+extraction_policy_version: v1
+
 statement:
   fields:
     account_number:
@@ -905,6 +907,8 @@ _pseudo_groups:
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 """
+extraction_policy_version: v1
+
 statement:
   fields:
     account_number:
@@ -929,6 +933,8 @@ _pseudo_groups:
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 """
+extraction_policy_version: v1
+
 statement:
   fields:
     account_number:
@@ -955,6 +961,8 @@ _pseudo_groups:
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 """
+extraction_policy_version: v1
+
 statement:
   fields:
     account_number:
@@ -977,6 +985,8 @@ _pseudo_groups:
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 """
+extraction_policy_version: v1
+
 _defs:
   identity_fields:
     fields:
@@ -1024,6 +1034,8 @@ statement:
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 """
+extraction_policy_version: v1
+
 customer:
   fields:
     customer_name:
@@ -1055,6 +1067,8 @@ _pseudo_groups:
     def test_prepare_extraction_yaml_composes_defs_fields_only(self) -> None:
         prepared = prepare_extraction_yaml(
             """
+extraction_policy_version: v1
+
 _defs:
   identity_fields:
     fields:
@@ -1123,13 +1137,14 @@ _pseudo_groups:
     def test_prepare_extraction_yaml_separates_metadata_surfaces(self) -> None:
         prepared = prepare_extraction_yaml(
             """
-domain: invoice
+extraction_policy_version: v1
+
 statement:
-  slot: chunk-instruct
+  workflow_step: chunk-instruct
   unique_attrs:
     - account_number
-  pipeline:
-    reconcile: reconcile-statement
+  final_value_aliases:
+    account_number: account_number
   fields:
     account_number:
       prompt:
@@ -1149,42 +1164,46 @@ _pseudo_groups:
       account_number:
         path: /statement/account_number
   statement_totals:
-    slot: chunk-keys
+    workflow_step: chunk-keys
     fields:
       total_amount_due:
         path: /statement/total_amount_due
 """,
-            top_level_metadata_keys={"domain"},
-            final_group_metadata_keys={"unique_attrs", "pipeline"},
-            workflow_group_metadata_keys={"slot"},
+            final_group_metadata_keys={"unique_attrs", "final_value_aliases"},
+            workflow_group_metadata_keys={"workflow_step"},
         )
 
-        self.assertEqual(prepared.top_level_metadata, {"domain": "invoice"})
+        self.assertEqual(
+            prepared.top_level_metadata,
+            {"extraction_policy_version": "v1"},
+        )
         self.assertEqual(
             prepared.final_group_metadata,
             {
                 "statement": {
                     "unique_attrs": ["account_number"],
-                    "pipeline": {"reconcile": "reconcile-statement"},
+                    "final_value_aliases": {"account_number": "account_number"},
                 }
             },
         )
         self.assertEqual(
             prepared.workflow_group_metadata,
             {
-                "statement_identity": {"slot": "chunk-instruct"},
-                "statement_totals": {"slot": "chunk-keys"},
+                "statement_identity": {"workflow_step": "chunk-instruct"},
+                "statement_totals": {"workflow_step": "chunk-keys"},
             },
         )
-        self.assertNotIn("slot", prepared.groups["statement"])
+        self.assertNotIn("workflow_step", prepared.groups["statement"])
         self.assertNotIn("unique_attrs", prepared.workflow_groups["statement_identity"])
         self.assertFalse(hasattr(prepared, "pseudo_group_metadata"))
 
-    def test_prepare_extraction_yaml_resolves_slot_positive_cases(self) -> None:
+    def test_prepare_extraction_yaml_resolves_workflow_step_positive_cases(self) -> None:
         prepared = prepare_extraction_yaml(
             """
+extraction_policy_version: v1
+
 statement:
-  slot: chunk-instruct
+  workflow_step: chunk-instruct
   fields:
     account_number:
       prompt:
@@ -1199,7 +1218,7 @@ statement:
         instructions: Return the total amount due.
         type: float
 customer:
-  slot: chunk-summary
+  workflow_step: chunk-summary
   fields:
     customer_name:
       prompt:
@@ -1208,7 +1227,7 @@ customer:
         instructions: Return the customer name.
         type: str
 service_address:
-  slot: chunk-summary
+  workflow_step: chunk-summary
   fields:
     street:
       prompt:
@@ -1230,7 +1249,7 @@ _pseudo_groups:
       account_number:
         path: /statement/account_number
   statement_totals:
-    slot: chunk-keys
+    workflow_step: chunk-keys
     fields:
       total_amount_due:
         path: /statement/total_amount_due
@@ -1243,24 +1262,26 @@ _pseudo_groups:
       service_street:
         path: /service_address/street
 """,
-            workflow_group_metadata_keys={"slot"},
+            workflow_group_metadata_keys={"workflow_step"},
         )
 
         self.assertEqual(
             prepared.workflow_group_metadata,
             {
-                "statement_identity": {"slot": "chunk-instruct"},
-                "statement_totals": {"slot": "chunk-keys"},
-                "customer_packet": {"slot": "chunk-summary"},
+                "statement_identity": {"workflow_step": "chunk-instruct"},
+                "statement_totals": {"workflow_step": "chunk-keys"},
+                "customer_packet": {"workflow_step": "chunk-summary"},
             },
         )
 
-    def test_prepare_extraction_yaml_rejects_ambiguous_slot_inheritance(self) -> None:
+    def test_prepare_extraction_yaml_rejects_ambiguous_workflow_step_inheritance(self) -> None:
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 """
+extraction_policy_version: v1
+
 customer:
-  slot: chunk-instruct
+  workflow_step: chunk-instruct
   fields:
     customer_name:
       prompt:
@@ -1269,7 +1290,7 @@ customer:
         instructions: Return the customer name.
         type: str
 service_address:
-  slot: chunk-summary
+  workflow_step: chunk-summary
   fields:
     street:
       prompt:
@@ -1287,19 +1308,21 @@ _pseudo_groups:
       service_street:
         path: /service_address/street
 """,
-                workflow_group_metadata_keys={"slot"},
+                workflow_group_metadata_keys={"workflow_step"},
             )
 
-        self.assertIn("explicit [slot] is required", str(exc.exception))
+        self.assertIn("explicit [workflow_step] is required", str(exc.exception))
 
-    def test_prepare_extraction_yaml_rejects_partially_missing_slot_inheritance(
+    def test_prepare_extraction_yaml_rejects_partially_missing_workflow_step_inheritance(
         self,
     ) -> None:
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 """
+extraction_policy_version: v1
+
 customer:
-  slot: chunk-instruct
+  workflow_step: chunk-instruct
   fields:
     customer_name:
       prompt:
@@ -1325,10 +1348,10 @@ _pseudo_groups:
       service_street:
         path: /service_address/street
 """,
-                workflow_group_metadata_keys={"slot"},
+                workflow_group_metadata_keys={"workflow_step"},
             )
 
-        self.assertIn("explicit [slot] is required", str(exc.exception))
+        self.assertIn("explicit [workflow_step] is required", str(exc.exception))
 
     def test_prepare_extraction_yaml_preserves_ordinary_aliases_by_deep_copy(
         self,
@@ -1385,6 +1408,8 @@ statement: &statement
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 """
+extraction_policy_version: v1
+
 statement:
   fields:
     account_number:
@@ -1407,6 +1432,8 @@ _pseudo_groups:
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 """
+extraction_policy_version: v1
+
 statement:
   fields:
     account_number:
@@ -1469,6 +1496,8 @@ statement:
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 """
+extraction_policy_version: v1
+
 statement:
   fields:
     account_number:
@@ -1497,6 +1526,8 @@ _pseudo_groups:
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 """
+extraction_policy_version: v1
+
 statement:
   fields:
     account_number:
@@ -1568,13 +1599,15 @@ statement:
             str(exc.exception),
         )
 
-    def test_prepare_extraction_yaml_treats_pseudo_slot_null_as_unset(
+    def test_prepare_extraction_yaml_treats_pseudo_workflow_step_null_as_unset(
         self,
     ) -> None:
         prepared = prepare_extraction_yaml(
             """
+extraction_policy_version: v1
+
 statement:
-  slot: chunk-instruct
+  workflow_step: chunk-instruct
   fields:
     account_number:
       prompt:
@@ -1584,26 +1617,28 @@ statement:
         type: str
 _pseudo_groups:
   statement_identity:
-    slot:
+    workflow_step:
     fields:
       account_number:
         path: /statement/account_number
 """,
-            workflow_group_metadata_keys={"slot"},
+            workflow_group_metadata_keys={"workflow_step"},
         )
 
         self.assertEqual(
             prepared.workflow_group_metadata,
-            {"statement_identity": {"slot": "chunk-instruct"}},
+            {"statement_identity": {"workflow_step": "chunk-instruct"}},
         )
 
-    def test_prepare_extraction_yaml_preserves_empty_string_slot(
+    def test_prepare_extraction_yaml_preserves_empty_string_workflow_step(
         self,
     ) -> None:
         prepared = prepare_extraction_yaml(
             """
+extraction_policy_version: v1
+
 statement:
-  slot: chunk-instruct
+  workflow_step: chunk-instruct
   fields:
     account_number:
       prompt:
@@ -1613,17 +1648,17 @@ statement:
         type: str
 _pseudo_groups:
   statement_identity:
-    slot: ""
+    workflow_step: ""
     fields:
       account_number:
         path: /statement/account_number
 """,
-            workflow_group_metadata_keys={"slot"},
+            workflow_group_metadata_keys={"workflow_step"},
         )
 
         self.assertEqual(
             prepared.workflow_group_metadata,
-            {"statement_identity": {"slot": ""}},
+            {"statement_identity": {"workflow_step": ""}},
         )
 
     def test_prepare_extraction_yaml_accepts_custom_workflow_steps(self) -> None:
@@ -1702,6 +1737,8 @@ _pseudo_groups:
     ) -> None:
         prepared = prepare_extraction_yaml(
             """
+extraction_policy_version: v1
+
 workflow:
   custom_steps:
     - name: line_item_labels
@@ -1734,12 +1771,14 @@ invoice:
             "/invoice/charges/*",
         )
 
-    def test_prepare_extraction_yaml_rejects_slot_and_workflow_step_conflict(
+    def test_prepare_extraction_yaml_rejects_slot_metadata(
         self,
     ) -> None:
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 """
+extraction_policy_version: v1
+
 workflow:
   custom_steps:
     - name: line_item_labels
@@ -1755,7 +1794,7 @@ line_items:
         instructions: Return the description.
         type: str
 """,
-                workflow_group_metadata_keys={"slot"},
+                workflow_group_metadata_keys={"workflow_step"},
             )
 
         self.assertIn("slot", str(exc.exception))
@@ -1767,6 +1806,8 @@ line_items:
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 """
+extraction_policy_version: v1
+
 workflow:
   fields:
     status:
@@ -1807,6 +1848,8 @@ workflow:
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 """
+extraction_policy_version: v1
+
 workflow:
   custom_steps:
     - name: line_item_labels
@@ -1868,6 +1911,8 @@ line_items:
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 f"""
+extraction_policy_version: v1
+
 workflow:
   custom_steps:
     - name: overloaded_fields
@@ -1889,6 +1934,8 @@ line_items:
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 """
+extraction_policy_version: v1
+
 workflow:
   custom_steps:
     - name: line_item_labels
@@ -1919,6 +1966,8 @@ line_items:
         with self.assertRaises(ValueError) as exc:
             prepare_extraction_yaml(
                 """
+extraction_policy_version: v1
+
 workflow:
   custom_steps:
     - name: unrouted_fields

--- a/tests/extract/prompt/test_persisted_workflow_extract.py
+++ b/tests/extract/prompt/test_persisted_workflow_extract.py
@@ -31,7 +31,7 @@ FINAL_GROUP_METADATA_KEYS = {
     "passthrough_pair_attrs",
     "deregulation_status_values",
 }
-WORKFLOW_GROUP_METADATA_KEYS = {"slot"}
+WORKFLOW_GROUP_METADATA_KEYS = {"workflow_step"}
 
 
 def _custom_workflow_metadata() -> typing.Dict[str, typing.Any]:
@@ -100,7 +100,7 @@ POLICY_YAML = """
 extraction_policy_version: v1
 
 statement:
-  slot: chunk-instruct
+  workflow_step: chunk-instruct
   final_value_aliases:
     amount_due: total_due
   fill_rules:
@@ -132,7 +132,7 @@ statement:
         type: str
 
 meters:
-  slot: chunk-summary
+  workflow_step: chunk-summary
   always_check_attrs:
     - meter_number
   conflict_attrs:
@@ -171,7 +171,7 @@ meters:
         type: str
 
 charges:
-  slot: chunk-keys
+  workflow_step: chunk-keys
   always_check_attrs:
     - charge_description_as_printed
   match_attrs:
@@ -197,7 +197,7 @@ charges:
 
 _pseudo_groups:
   statement_identity:
-    slot: chunk-keys
+    workflow_step: chunk-keys
     fields:
       account_number:
         path: /statement/account_number
@@ -238,7 +238,7 @@ def test_persisted_workflow_extract_round_trips_authored_metadata() -> None:
         "charge_explanation"
     ]
     assert reloaded.workflow_group_metadata["statement_identity"] == {
-        "slot": "chunk-keys"
+        "workflow_step": "chunk-keys"
     }
     assert reloaded.workflow_field_paths["statement_identity"] == {
         "account_number": "/statement/account_number"

--- a/tests/extract/prompt/test_yaml_contract_v1.py
+++ b/tests/extract/prompt/test_yaml_contract_v1.py
@@ -91,6 +91,181 @@ def test_create_update_persist_agent_chain_only_inside_extract() -> None:
         )
 
 
+def test_agent_chain_rejects_map_shape() -> None:
+    raw = """
+extraction_policy_version: v1
+
+workflow:
+  custom_steps:
+    - name: statement_fields
+      level: chunk
+      kind: instruct
+  agent_chain:
+    parallel:
+      - group: statement
+        chain: [reconcile_statement, qa_statement]
+    then:
+      - save_statement
+
+statement:
+  workflow_step: statement_fields
+  fields:
+    account_number:
+      workflow_output_key: account_number
+      prompt:
+        instructions: Return the account number.
+        type: str
+"""
+
+    with pytest.raises(ValueError, match="workflow.agent_chain must be a list"):
+        prepare_extraction_yaml(raw)
+
+
+def test_agent_chain_rejects_chain_without_initial_parallel_stage() -> None:
+    raw = """
+extraction_policy_version: v1
+
+workflow:
+  custom_steps:
+    - name: statement_fields
+      level: chunk
+      kind: instruct
+  agent_chain:
+    - save_statement
+
+statement:
+  workflow_step: statement_fields
+  fields:
+    account_number:
+      workflow_output_key: account_number
+      prompt:
+        instructions: Return the account number.
+        type: str
+"""
+
+    with pytest.raises(
+        ValueError,
+        match="workflow.agent_chain must start with a parallel stage",
+    ):
+        prepare_extraction_yaml(raw)
+
+
+def test_agent_chain_rejects_unknown_group_and_task() -> None:
+    unknown_group = """
+extraction_policy_version: v1
+
+workflow:
+  custom_steps:
+    - name: statement_fields
+      level: chunk
+      kind: instruct
+  agent_chain:
+    - parallel:
+        - group: missing
+          chain: [reconcile_statement, qa_statement]
+    - save_statement
+
+statement:
+  workflow_step: statement_fields
+  fields:
+    account_number:
+      workflow_output_key: account_number
+      prompt:
+        instructions: Return the account number.
+        type: str
+"""
+
+    with pytest.raises(ValueError, match="missing.*is not a workflow group"):
+        prepare_extraction_yaml(unknown_group)
+
+    unknown_task = unknown_group.replace(
+        "reconcile_statement", "unknown_task"
+    ).replace("missing", "statement")
+    with pytest.raises(ValueError, match="unsupported task"):
+        prepare_extraction_yaml(unknown_task)
+
+
+def test_agent_chain_rejects_branch_save_plus_top_level_save() -> None:
+    raw = """
+extraction_policy_version: v1
+
+workflow:
+  custom_steps:
+    - name: statement_fields
+      level: chunk
+      kind: instruct
+  agent_chain:
+    - parallel:
+        - group: statement
+          chain: [reconcile_statement, qa_statement, save_statement]
+    - save_statement
+
+statement:
+  workflow_step: statement_fields
+  fields:
+    account_number:
+      workflow_output_key: account_number
+      prompt:
+        instructions: Return the account number.
+        type: str
+"""
+
+    with pytest.raises(
+        ValueError,
+        match="parallel branch save tasks cannot be combined",
+    ):
+        prepare_extraction_yaml(raw)
+
+
+def test_agent_chain_rejects_invalid_top_level_serial_task_pairs() -> None:
+    base = """
+extraction_policy_version: v1
+
+workflow:
+  custom_steps:
+    - name: statement_fields
+      level: chunk
+      kind: instruct
+  agent_chain:
+{agent_chain}
+
+statement:
+  workflow_step: statement_fields
+  fields:
+    account_number:
+      workflow_output_key: account_number
+      prompt:
+        instructions: Return the account number.
+        type: str
+"""
+    cases = [
+        """
+    - parallel:
+        - group: statement
+          chain: [reconcile_statement, qa_statement, save_statement]
+    - reconcile_charges
+""",
+        """
+    - parallel:
+        - group: statement
+          chain: [reconcile_statement, qa_statement, save_statement]
+    - reconcile_charges
+    - save_statement
+""",
+        """
+    - parallel:
+        - group: statement
+          chain: [reconcile_statement, qa_statement]
+    - save_statement
+    - reconcile_charges
+""",
+    ]
+
+    for agent_chain in cases:
+        with pytest.raises(ValueError, match="top-level agent task"):
+            prepare_extraction_yaml(base.format(agent_chain=agent_chain))
+
+
 def test_slot_and_domain_are_rejected_even_with_metadata_escape_hatches() -> None:
     raw = """
 domain: invoice

--- a/tests/extract/prompt/test_yaml_contract_v1.py
+++ b/tests/extract/prompt/test_yaml_contract_v1.py
@@ -1,0 +1,216 @@
+import json
+from pathlib import Path
+import typing
+
+import pytest
+
+from groundx import GroundX
+from groundx.extract import prepare_extraction_yaml
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+CONTRACT_YAML = FIXTURE_DIR / "extraction_yaml_contract_v1.yaml"
+EXPECTED_JSON = FIXTURE_DIR / "extraction_yaml_contract_v1.expected.json"
+
+
+class RecordingWorkflows:
+    def __init__(self, response: typing.Any = None) -> None:
+        self.response = response
+        self.calls: typing.List[typing.Tuple[typing.Any, ...]] = []
+
+    def create(self, **kwargs: typing.Any) -> str:
+        self.calls.append(("create", kwargs))
+        return "created"
+
+    def update(self, id: str, **kwargs: typing.Any) -> str:
+        self.calls.append(("update", id, kwargs))
+        return "updated"
+
+
+def _client(workflows: RecordingWorkflows) -> GroundX:
+    client = GroundX.__new__(GroundX)
+    typing.cast(typing.Any, client)._workflows = workflows
+    return client
+
+
+def test_contract_fixture_compiles_to_expected_payload() -> None:
+    prepared = prepare_extraction_yaml(CONTRACT_YAML.read_text())
+    observed = {
+        "groups": prepared.groups,
+        "workflow_groups": prepared.workflow_groups,
+        "pseudo_groups": prepared.pseudo_groups,
+        "workflow_field_paths": prepared.workflow_field_paths,
+        "top_level_metadata": prepared.top_level_metadata,
+        "final_group_metadata": prepared.final_group_metadata,
+        "workflow_group_metadata": prepared.workflow_group_metadata,
+        "persisted_workflow_extract": prepared.persisted_workflow_extract,
+    }
+
+    assert observed == json.loads(EXPECTED_JSON.read_text())
+
+
+def test_pseudo_groups_create_custom_workflow_routes_and_preserve_agent_chain() -> None:
+    prepared = prepare_extraction_yaml(CONTRACT_YAML.read_text())
+    workflow = prepared.persisted_workflow_extract["workflow"]
+    authored = prepared.persisted_workflow_extract["_groundx_persisted_extract"]
+
+    assert workflow["agent_chain"] == authored["workflow"]["agent_chain"]
+    assert [route["workflow_group"] for route in workflow["output_routes"]] == [
+        "statement_identity",
+        "statement_totals",
+    ]
+    assert [route["output_key"] for route in workflow["output_routes"]] == [
+        "account_number",
+        "total_amount_due",
+    ]
+    assert [route["final_path"] for route in workflow["output_routes"]] == [
+        "/statement/account_number",
+        "/statement/total_amount_due",
+    ]
+    assert "workflow_step" not in authored["_pseudo_groups"]["statement_identity"]
+    assert "workflow_output_key" not in json.dumps(authored)
+
+
+def test_create_update_persist_agent_chain_only_inside_extract() -> None:
+    workflows = RecordingWorkflows()
+    client = _client(workflows)
+
+    client.create_extraction_workflow(path=CONTRACT_YAML, name="statement extraction")
+    client.update_extraction_workflow(
+        "workflow-1",
+        path=CONTRACT_YAML,
+        name="statement extraction",
+    )
+
+    create_kwargs = workflows.calls[0][1]
+    update_kwargs = workflows.calls[1][2]
+    for kwargs in (create_kwargs, update_kwargs):
+        assert "agent_chain" not in kwargs
+        assert kwargs["extract"]["workflow"]["agent_chain"] == (
+            kwargs["extract"]["_groundx_persisted_extract"]["workflow"]["agent_chain"]
+        )
+
+
+def test_slot_and_domain_are_rejected_even_with_metadata_escape_hatches() -> None:
+    raw = """
+domain: invoice
+statement:
+  slot: chunk-instruct
+  fields:
+    account_number:
+      prompt:
+        instructions: Return the account number.
+        type: str
+"""
+
+    with pytest.raises(ValueError, match="domain"):
+        prepare_extraction_yaml(
+            raw,
+            top_level_metadata_keys={"domain"},
+            workflow_group_metadata_keys={"slot"},
+        )
+
+
+def test_pure_legacy_yaml_rejects_extraction_policy_version() -> None:
+    raw = """
+extraction_policy_version: v1
+statement:
+  fields:
+    account_number:
+      prompt:
+        instructions: Return the account number.
+        type: str
+"""
+
+    with pytest.raises(ValueError, match="extraction_policy_version"):
+        prepare_extraction_yaml(raw)
+
+
+def test_new_yaml_requires_extraction_policy_version() -> None:
+    raw = """
+workflow:
+  custom_steps:
+    - name: statement_fields
+      level: chunk
+      kind: keys
+statement:
+  workflow_step: statement_fields
+  fields:
+    account_number:
+      workflow_output_key: account_number
+      prompt:
+        instructions: Return the account number.
+        type: str
+"""
+
+    with pytest.raises(ValueError, match="extraction_policy_version: v1"):
+        prepare_extraction_yaml(raw)
+
+
+def test_field_level_workflow_step_is_rejected() -> None:
+    raw = """
+extraction_policy_version: v1
+workflow:
+  custom_steps:
+    - name: statement_fields
+      level: chunk
+      kind: keys
+statement:
+  fields:
+    account_number:
+      workflow_step: statement_fields
+      workflow_output_key: account_number
+      prompt:
+        instructions: Return the account number.
+        type: str
+"""
+
+    with pytest.raises(ValueError, match="field-level workflow_step"):
+        prepare_extraction_yaml(raw)
+
+
+def test_pseudo_field_keys_must_be_safe_output_keys() -> None:
+    raw = """
+extraction_policy_version: v1
+statement:
+  fields:
+    account_number:
+      prompt:
+        instructions: Return the account number.
+        type: str
+_pseudo_groups:
+  statement_identity:
+    fields:
+      Account Number:
+        path: /statement/account_number
+"""
+
+    with pytest.raises(ValueError, match="invalid output key"):
+        prepare_extraction_yaml(raw)
+
+
+def test_pseudo_routed_final_fields_cannot_declare_workflow_output_key() -> None:
+    raw = """
+extraction_policy_version: v1
+workflow:
+  custom_steps:
+    - name: statement_fields
+      level: chunk
+      kind: keys
+statement:
+  fields:
+    account_number:
+      workflow_output_key: account_number
+      prompt:
+        instructions: Return the account number.
+        type: str
+_pseudo_groups:
+  statement_identity:
+    workflow_step: statement_fields
+    fields:
+      account_number:
+        path: /statement/account_number
+"""
+
+    with pytest.raises(ValueError, match="pseudo-routed"):
+        prepare_extraction_yaml(raw)

--- a/tests/extract/test_extraction_workflow_definitions.py
+++ b/tests/extract/test_extraction_workflow_definitions.py
@@ -16,6 +16,8 @@ from groundx.types import (
 )
 
 CUSTOM_WORKFLOW_YAML = """
+extraction_policy_version: v1
+
 workflow:
   template:
     "{{LANGUAGE}}": English
@@ -56,6 +58,8 @@ statement:
 POLICY_METADATA_YAML = """
 extraction_policy_version: v1
 statement:
+  final_value_aliases:
+    account_number: account_number
   fields:
     account_number:
       prompt:
@@ -647,7 +651,6 @@ def test_create_and_update_yaml_path_errors_include_source_context(
     create_message = str(create_exc.value)
     assert str(path) in create_message
     assert "unsupported top-level metadata [unsupported_policy_version]" in create_message
-    assert "top_level_metadata_keys" in create_message
 
     with pytest.raises(ValueError) as update_exc:
         client.update_extraction_workflow(
@@ -659,7 +662,6 @@ def test_create_and_update_yaml_path_errors_include_source_context(
     update_message = str(update_exc.value)
     assert str(path) in update_message
     assert "unsupported top-level metadata [unsupported_policy_version]" in update_message
-    assert "top_level_metadata_keys" in update_message
     assert workflows.calls == []
 
 
@@ -831,7 +833,6 @@ async def test_async_create_and_update_yaml_path_errors_include_source_context(
     create_message = str(create_exc.value)
     assert str(path) in create_message
     assert "unsupported top-level metadata [unsupported_policy_version]" in create_message
-    assert "top_level_metadata_keys" in create_message
 
     with pytest.raises(ValueError) as update_exc:
         await client.update_extraction_workflow(
@@ -843,5 +844,4 @@ async def test_async_create_and_update_yaml_path_errors_include_source_context(
     update_message = str(update_exc.value)
     assert str(path) in update_message
     assert "unsupported top-level metadata [unsupported_policy_version]" in update_message
-    assert "top_level_metadata_keys" in update_message
     assert workflows.calls == []


### PR DESCRIPTION
## Summary
- Adds SDK support for the v1 extraction YAML contract, including workflow custom steps, routes, pseudo groups, and preserved agent-chain metadata.
- Keeps custom SDK code inside `src/groundx/extract` and avoids generated folders.
- Adds regressions for v1 YAML loading, clear errors, workflow definition helpers, and custom output routing.

## Test Plan
- `poetry run mypy .`
- `poetry run pytest -rP -n auto .`
- generated-folder diff scan for `src/groundx/types` and `src/groundx/workflows`
- `git diff --check`
