### PR TITLE
[codex] Add AgentTool URL image transport

### DIFF
--- a/src/groundx/extract/agents/agent.py
+++ b/src/groundx/extract/agents/agent.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
 import json, traceback, typing
+from dataclasses import dataclass, field
+from urllib.parse import urlparse
 
 from smolagents import (  # pyright: ignore[reportMissingTypeStubs]
     CodeAgent,
     Tool,
     ToolCallingAgent,
 )
+from smolagents.memory import (  # pyright: ignore[reportMissingTypeStubs]
+    FinalAnswerStep,
+    SystemPromptStep,
+    TaskStep,
+)
 from smolagents.models import (  # pyright: ignore[reportMissingTypeStubs]
+    ChatMessage,
+    MessageRole,
     OpenAIServerModel,
 )
 
@@ -26,6 +35,37 @@ Return only your response using the `final_answer` tool format:
 {{"answer": {{"type": RESPONSE_HERE, "description": "The final answer to the problem"}}}}
 ```
 """
+
+SUPPORTED_IMAGE_TRANSPORTS = {"pil", "data_url", "remote_url"}
+
+
+@dataclass
+class RemoteImageTaskStep(TaskStep):
+    image_urls: typing.List[str] = field(default_factory=list)
+
+    def to_messages(self, summary_mode: bool = False) -> typing.List[ChatMessage]:
+        content: typing.List[typing.Dict[str, typing.Any]] = [
+            {"type": "text", "text": f"New task:\n{self.task}"}
+        ]
+        content.extend(
+            {"type": "image_url", "image_url": {"url": image_url}}
+            for image_url in self.image_urls
+        )
+        return [ChatMessage(role=MessageRole.USER, content=content)]
+
+    def dict(self) -> typing.Dict[str, typing.Any]:
+        return {
+            "task": self.task,
+            "task_images": None,
+            "image_urls": [_sanitize_image_url(image_url) for image_url in self.image_urls],
+        }
+
+
+def _sanitize_image_url(image_url: str) -> str:
+    parsed = urlparse(image_url)
+    if not parsed.scheme or not parsed.netloc:
+        return "<invalid-image-url>"
+    return f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
 
 
 def extract_response(res: typing.Dict[str, typing.Any]) -> typing.Any:
@@ -209,6 +249,7 @@ class AgentTool(ToolCallingAgent):
         )
 
         self.log = log
+        self.image_transport = settings.image_transport
 
     def process(
         self,
@@ -217,11 +258,25 @@ class AgentTool(ToolCallingAgent):
         expected_types: typing.Union[type, typing.Tuple[type, ...]] = dict,
         attempt: int = 0,
         type: str = "",
+        image_urls: typing.Optional[typing.Sequence[str]] = None,
+        image_transport: typing.Optional[str] = None,
     ) -> typing.Any:
-        res = super().run(  # pyright: ignore[reportUnknownMemberType]
-            conflict + prompt_suffix,
+        selected_image_transport = image_transport or self.image_transport
+        transport = self._validate_image_inputs(
             images=images,
+            image_urls=image_urls,
+            image_transport=selected_image_transport,
         )
+        if transport == "remote_url":
+            res = self._run_with_remote_image_urls(
+                conflict + prompt_suffix,
+                list(image_urls or []),
+            )
+        else:
+            res = super().run(  # pyright: ignore[reportUnknownMemberType]
+                conflict + prompt_suffix,
+                images=images,
+            )
 
         try:
             return process_response(res=res, expected_types=expected_types)
@@ -236,4 +291,73 @@ class AgentTool(ToolCallingAgent):
                 f"agent process result is not of expected type(s) {expected_types!r}: [{e}], attempting again [{attempt+1}]\n\n{res}"
             )
 
-            return self.process(conflict, images, expected_types, attempt + 1)
+            return self.process(
+                conflict,
+                images,
+                expected_types,
+                attempt + 1,
+                type,
+                image_urls=image_urls,
+                image_transport=transport,
+            )
+
+    def _run_with_remote_image_urls(
+        self,
+        task: str,
+        image_urls: typing.List[str],
+    ) -> typing.Any:
+        self.task = task
+        self.interrupt_switch = False
+        self.memory.system_prompt = SystemPromptStep(system_prompt=self.system_prompt)
+        self.memory.reset()
+        self.monitor.reset()
+        self.memory.steps.append(
+            RemoteImageTaskStep(task=self.task, task_images=None, image_urls=image_urls)
+        )
+
+        try:
+            try:
+                steps = list(self._run_stream(task=self.task, max_steps=self.max_steps, images=None))
+            except Exception as exc:
+                raise RuntimeError(f"remote_url image transport failed: {exc}") from exc
+            assert isinstance(steps[-1], FinalAnswerStep)
+            return steps[-1].output
+        finally:
+            self._sanitize_remote_image_urls_in_memory()
+
+    def _validate_image_inputs(
+        self,
+        *,
+        images: typing.Sequence[Image],
+        image_urls: typing.Optional[typing.Sequence[str]],
+        image_transport: str,
+    ) -> str:
+        if image_transport not in SUPPORTED_IMAGE_TRANSPORTS:
+            raise ValueError(
+                "unsupported image_transport "
+                f"[{image_transport}]; expected one of {sorted(SUPPORTED_IMAGE_TRANSPORTS)}"
+            )
+        if image_urls and image_transport != "remote_url":
+            raise ValueError("image_urls require image_transport='remote_url'")
+        if image_transport == "remote_url":
+            if images:
+                raise ValueError("remote_url transport does not accept PIL images")
+            if not image_urls:
+                raise ValueError("remote_url transport requires image_urls")
+        return image_transport
+
+    def _sanitize_remote_image_urls_in_memory(self) -> None:
+        for step in self.memory.steps:
+            model_input_messages = getattr(step, "model_input_messages", None)
+            if not model_input_messages:
+                continue
+            for message in model_input_messages:
+                content = getattr(message, "content", None)
+                if not isinstance(content, list):
+                    continue
+                for item in content:
+                    if not isinstance(item, dict) or item.get("type") != "image_url":
+                        continue
+                    image_url = item.get("image_url")
+                    if isinstance(image_url, dict) and isinstance(image_url.get("url"), str):
+                        image_url["url"] = _sanitize_image_url(image_url["url"])

--- a/src/groundx/extract/settings/settings.py
+++ b/src/groundx/extract/settings/settings.py
@@ -43,6 +43,7 @@ class AgentSettings(BaseModel):
     max_steps: int = 7
     model_id: str = "gpt-5-mini"
     reasoning_effort: typing.Optional[str] = "medium"
+    image_transport: str = "pil"
     model_kwargs: typing.Optional[typing.Dict[str, typing.Any]] = None
 
     def get_api_key(self) -> str:

--- a/tests/extract/agents/test_agent_tool_image_transport.py
+++ b/tests/extract/agents/test_agent_tool_image_transport.py
@@ -3,12 +3,16 @@ import json
 import typing
 
 import pytest
-from smolagents.models import (
-    ChatMessage,
-    ChatMessageToolCall,
-    ChatMessageToolCallFunction,
-    MessageRole,
-)
+
+try:
+    from smolagents.models import (
+        ChatMessage,
+        ChatMessageToolCall,
+        ChatMessageToolCallFunction,
+        MessageRole,
+    )
+except ModuleNotFoundError:
+    pytest.skip("smolagents extra is not installed", allow_module_level=True)
 
 from groundx.extract.agents.agent import AgentTool
 from groundx.extract.services.logger import Logger

--- a/tests/extract/agents/test_agent_tool_image_transport.py
+++ b/tests/extract/agents/test_agent_tool_image_transport.py
@@ -1,0 +1,172 @@
+import copy
+import json
+import typing
+
+import pytest
+from PIL import Image
+from smolagents.models import (
+    ChatMessage,
+    ChatMessageToolCall,
+    ChatMessageToolCallFunction,
+    MessageRole,
+)
+
+from groundx.extract.agents.agent import AgentTool
+from groundx.extract.services.logger import Logger
+from groundx.extract.settings.settings import AgentSettings
+
+
+class CapturingModel:
+    model_id = "capturing-model"
+
+    def __init__(self) -> None:
+        self.messages: typing.List[typing.List[typing.Any]] = []
+
+    def generate(
+        self,
+        messages: typing.List[typing.Any],
+        **_: typing.Any,
+    ) -> ChatMessage:
+        self.messages.append(copy.deepcopy(messages))
+        return ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content=None,
+            tool_calls=[
+                ChatMessageToolCall(
+                    id="call-1",
+                    type="function",
+                    function=ChatMessageToolCallFunction(
+                        name="final_answer",
+                        arguments={"answer": {"type": {"ok": True}}},
+                    ),
+                )
+            ],
+        )
+
+
+class RejectingModel:
+    model_id = "rejecting-model"
+
+    def generate(
+        self,
+        messages: typing.List[typing.Any],
+        **_: typing.Any,
+    ) -> ChatMessage:
+        raise RuntimeError("provider rejected remote image URL")
+
+
+def build_agent() -> typing.Tuple[AgentTool, CapturingModel]:
+    agent = AgentTool(
+        AgentSettings(api_key="test-key", model_id="test-model", max_steps=1),
+        Logger("agent-tool-image-transport", "error"),
+    )
+    model = CapturingModel()
+    agent.model = model  # type: ignore[assignment]
+    return agent, model
+
+
+def last_user_content(model: CapturingModel) -> typing.List[typing.Dict[str, typing.Any]]:
+    assert model.messages
+    first_call = model.messages[0]
+    user_messages = [message for message in first_call if message.role == MessageRole.USER]
+    assert user_messages
+    content = user_messages[-1].content
+    assert isinstance(content, list)
+    return content
+
+
+def test_agent_tool_preserves_existing_pil_image_process_path() -> None:
+    agent, model = build_agent()
+    image = Image.new("RGB", (2, 2), "white")
+
+    result = agent.process("read this", images=[image])
+
+    assert result == {"ok": True}
+    content = last_user_content(model)
+    assert any(item.get("type") == "image" for item in content)
+
+
+def test_agent_tool_remote_url_transport_uses_image_url_blocks_without_fetching() -> None:
+    agent, model = build_agent()
+    remote_url = "https://upload.eyelevel.ai/workflows/pages/page-1.png?sig=secret"
+
+    result = agent.process(
+        "read this",
+        images=[],
+        image_urls=[remote_url],
+        image_transport="remote_url",
+    )
+
+    assert result == {"ok": True}
+    content = last_user_content(model)
+    assert {"type": "image_url", "image_url": {"url": remote_url}} in content
+    assert not any(item.get("type") == "image" for item in content)
+    assert "sig=secret" not in json.dumps(agent.memory.get_full_steps())
+
+
+def test_agent_tool_uses_agent_settings_image_transport_default() -> None:
+    agent = AgentTool(
+        AgentSettings(
+            api_key="test-key",
+            model_id="test-model",
+            max_steps=1,
+            image_transport="remote_url",
+        ),
+        Logger("agent-tool-image-transport", "error"),
+    )
+    model = CapturingModel()
+    agent.model = model  # type: ignore[assignment]
+    remote_url = "https://upload.eyelevel.ai/workflows/pages/page-1.png"
+
+    result = agent.process("read this", images=[], image_urls=[remote_url])
+
+    assert result == {"ok": True}
+    content = last_user_content(model)
+    assert {"type": "image_url", "image_url": {"url": remote_url}} in content
+
+
+def test_agent_tool_data_url_transport_keeps_inline_image_path() -> None:
+    agent, model = build_agent()
+    image = Image.new("RGB", (2, 2), "white")
+
+    result = agent.process("read this", images=[image], image_transport="data_url")
+
+    assert result == {"ok": True}
+    content = last_user_content(model)
+    assert any(item.get("type") == "image" for item in content)
+    assert not any(item.get("type") == "image_url" for item in content)
+
+
+def test_agent_tool_remote_url_provider_rejection_is_not_silently_retried_inline() -> None:
+    agent = AgentTool(
+        AgentSettings(api_key="test-key", model_id="test-model", max_steps=1),
+        Logger("agent-tool-image-transport", "error"),
+    )
+    agent.model = RejectingModel()  # type: ignore[assignment]
+
+    with pytest.raises(RuntimeError, match="provider rejected remote image URL"):
+        agent.process(
+            "read this",
+            images=[],
+            image_urls=["https://upload.eyelevel.ai/workflows/pages/page-1.png"],
+            image_transport="remote_url",
+        )
+
+
+def test_agent_tool_rejects_unsupported_or_mixed_image_transports() -> None:
+    agent, _ = build_agent()
+    image = Image.new("RGB", (2, 2), "white")
+
+    with pytest.raises(ValueError, match="unsupported image_transport"):
+        agent.process("read this", images=[], image_transport="auto")
+
+    with pytest.raises(ValueError, match="image_urls require image_transport='remote_url'"):
+        agent.process("read this", images=[], image_urls=["https://example.com/a.png"])
+
+    with pytest.raises(ValueError, match="remote_url transport does not accept PIL images"):
+        agent.process(
+            "read this",
+            images=[image],
+            image_urls=["https://example.com/a.png"],
+            image_transport="remote_url",
+        )

--- a/tests/extract/agents/test_agent_tool_image_transport.py
+++ b/tests/extract/agents/test_agent_tool_image_transport.py
@@ -3,7 +3,6 @@ import json
 import typing
 
 import pytest
-from PIL import Image
 from smolagents.models import (
     ChatMessage,
     ChatMessageToolCall,
@@ -76,8 +75,9 @@ def last_user_content(model: CapturingModel) -> typing.List[typing.Dict[str, typ
 
 
 def test_agent_tool_preserves_existing_pil_image_process_path() -> None:
+    image_module = pytest.importorskip("PIL.Image")
     agent, model = build_agent()
-    image = Image.new("RGB", (2, 2), "white")
+    image = image_module.new("RGB", (2, 2), "white")
 
     result = agent.process("read this", images=[image])
 
@@ -126,8 +126,9 @@ def test_agent_tool_uses_agent_settings_image_transport_default() -> None:
 
 
 def test_agent_tool_data_url_transport_keeps_inline_image_path() -> None:
+    image_module = pytest.importorskip("PIL.Image")
     agent, model = build_agent()
-    image = Image.new("RGB", (2, 2), "white")
+    image = image_module.new("RGB", (2, 2), "white")
 
     result = agent.process("read this", images=[image], image_transport="data_url")
 
@@ -155,7 +156,6 @@ def test_agent_tool_remote_url_provider_rejection_is_not_silently_retried_inline
 
 def test_agent_tool_rejects_unsupported_or_mixed_image_transports() -> None:
     agent, _ = build_agent()
-    image = Image.new("RGB", (2, 2), "white")
 
     with pytest.raises(ValueError, match="unsupported image_transport"):
         agent.process("read this", images=[], image_transport="auto")
@@ -166,7 +166,7 @@ def test_agent_tool_rejects_unsupported_or_mixed_image_transports() -> None:
     with pytest.raises(ValueError, match="remote_url transport does not accept PIL images"):
         agent.process(
             "read this",
-            images=[image],
+            images=[typing.cast(typing.Any, object())],
             image_urls=["https://example.com/a.png"],
             image_transport="remote_url",
         )

--- a/tests/extract/settings/test_settings.py
+++ b/tests/extract/settings/test_settings.py
@@ -32,6 +32,7 @@ class TestAgentSettings(unittest.TestCase):
                 "expect": {
                     "api_base": None,
                     "api_key": Exception,
+                    "image_transport": "pil",
                     "max_steps": 7,
                     "model_id": "gpt-5-mini",
                 },
@@ -40,11 +41,13 @@ class TestAgentSettings(unittest.TestCase):
                 "api_base": "http://test.com",
                 "api_key": "mykey",
                 "api_key_env_val": "val",
+                "image_transport": "remote_url",
                 "max_steps": 4,
                 "model_id": "gpt-5",
                 "expect": {
                     "api_base": "http://test.com",
                     "api_key": "mykey",
+                    "image_transport": "remote_url",
                     "max_steps": 4,
                     "model_id": "gpt-5",
                 },
@@ -54,6 +57,7 @@ class TestAgentSettings(unittest.TestCase):
                 "expect": {
                     "api_base": None,
                     "api_key": "val",
+                    "image_transport": "pil",
                     "max_steps": 7,
                     "model_id": "gpt-5-mini",
                 },
@@ -70,6 +74,8 @@ class TestAgentSettings(unittest.TestCase):
                 input["api_key"] = tst["api_key"]
             if "api_key_env_val" in tst:
                 os.environ.update({GX_AGENT_KEY: tst["api_key_env_val"]})
+            if "image_transport" in tst:
+                input["image_transport"] = tst["image_transport"]
             if "max_steps" in tst:
                 input["max_steps"] = tst["max_steps"]
             if "model_id" in tst:
@@ -87,6 +93,10 @@ class TestAgentSettings(unittest.TestCase):
                 self.assertEqual(settings.get_api_key(), tst["expect"]["api_key"])
 
             self.assertEqual(settings.max_steps, tst["expect"]["max_steps"])
+
+            self.assertEqual(
+                settings.image_transport, tst["expect"]["image_transport"]
+            )
 
             self.assertEqual(settings.model_id, tst["expect"]["model_id"])
 


### PR DESCRIPTION
## Summary
- Add explicit AgentTool image transport support: pil, data_url, and remote_url.
- Add AgentSettings.image_transport so runtime config can select remote_url without touching generated SDK folders.
- Add tests proving remote_url emits image_url blocks, avoids local fetch/base64, rejects auto/mixed inputs, and redacts query strings from run memory.

## Validation
- poetry install --extras extract
- poetry run mypy .
- PYTHONPATH=src python -m pytest tests/extract/agents/test_agent_tool_image_transport.py tests/extract/settings/test_settings.py::TestAgentSettings::test tests/extract/test_import_boundaries.py -q
- poetry run pytest -rP -n auto .
- PYTHONPATH=src python -m compileall src/groundx/extract/agents src/groundx/extract/settings tests/extract/agents tests/extract/settings -q
- git diff --check

## Notes
- No release was performed. Expected release version is 3.7.3 after approval.