### PR TITLE
fix: support data url agent image transport

### DIFF
--- a/src/groundx/extract/agents/agent.py
+++ b/src/groundx/extract/agents/agent.py
@@ -267,10 +267,11 @@ class AgentTool(ToolCallingAgent):
             image_urls=image_urls,
             image_transport=selected_image_transport,
         )
-        if transport == "remote_url":
-            res = self._run_with_remote_image_urls(
+        if transport in {"data_url", "remote_url"} and image_urls:
+            res = self._run_with_image_urls(
                 conflict + prompt_suffix,
                 list(image_urls or []),
+                image_transport=transport,
             )
         else:
             res = super().run(  # pyright: ignore[reportUnknownMemberType]
@@ -301,10 +302,12 @@ class AgentTool(ToolCallingAgent):
                 image_transport=transport,
             )
 
-    def _run_with_remote_image_urls(
+    def _run_with_image_urls(
         self,
         task: str,
         image_urls: typing.List[str],
+        *,
+        image_transport: str,
     ) -> typing.Any:
         self.task = task
         self.interrupt_switch = False
@@ -319,7 +322,7 @@ class AgentTool(ToolCallingAgent):
             try:
                 steps = list(self._run_stream(task=self.task, max_steps=self.max_steps, images=None))
             except Exception as exc:
-                raise RuntimeError(f"remote_url image transport failed: {exc}") from exc
+                raise RuntimeError(f"{image_transport} image transport failed: {exc}") from exc
             assert isinstance(steps[-1], FinalAnswerStep)
             return steps[-1].output
         finally:
@@ -337,8 +340,10 @@ class AgentTool(ToolCallingAgent):
                 "unsupported image_transport "
                 f"[{image_transport}]; expected one of {sorted(SUPPORTED_IMAGE_TRANSPORTS)}"
             )
-        if image_urls and image_transport != "remote_url":
-            raise ValueError("image_urls require image_transport='remote_url'")
+        if image_urls and image_transport not in {"data_url", "remote_url"}:
+            raise ValueError("image_urls require image_transport='data_url' or 'remote_url'")
+        if image_transport == "data_url" and image_urls and images:
+            raise ValueError("data_url transport does not accept PIL images when image_urls are provided")
         if image_transport == "remote_url":
             if images:
                 raise ValueError("remote_url transport does not accept PIL images")

--- a/tests/extract/agents/test_agent_tool_image_transport.py
+++ b/tests/extract/agents/test_agent_tool_image_transport.py
@@ -142,6 +142,24 @@ def test_agent_tool_data_url_transport_keeps_inline_image_path() -> None:
     assert not any(item.get("type") == "image_url" for item in content)
 
 
+def test_agent_tool_data_url_transport_uses_inline_image_url_blocks() -> None:
+    agent, model = build_agent()
+    data_url = "data:image/jpeg;base64,/9j/test"
+
+    result = agent.process(
+        "read this",
+        images=[],
+        image_urls=[data_url],
+        image_transport="data_url",
+    )
+
+    assert result == {"ok": True}
+    content = last_user_content(model)
+    assert {"type": "image_url", "image_url": {"url": data_url}} in content
+    assert not any(item.get("type") == "image" for item in content)
+    assert data_url not in json.dumps(agent.memory.get_full_steps())
+
+
 def test_agent_tool_remote_url_provider_rejection_is_not_silently_retried_inline() -> None:
     agent = AgentTool(
         AgentSettings(api_key="test-key", model_id="test-model", max_steps=1),
@@ -164,7 +182,7 @@ def test_agent_tool_rejects_unsupported_or_mixed_image_transports() -> None:
     with pytest.raises(ValueError, match="unsupported image_transport"):
         agent.process("read this", images=[], image_transport="auto")
 
-    with pytest.raises(ValueError, match="image_urls require image_transport='remote_url'"):
+    with pytest.raises(ValueError, match="image_urls require image_transport='data_url' or 'remote_url'"):
         agent.process("read this", images=[], image_urls=["https://example.com/a.png"])
 
     with pytest.raises(ValueError, match="remote_url transport does not accept PIL images"):


### PR DESCRIPTION
Fixes the extract agent image transport boundary for compact resized page images.

What changed:
- Allows `AgentTool.process(..., image_urls=[...], image_transport="data_url")`.
- Keeps existing PIL image behavior unchanged.
- Keeps `remote_url` behavior unchanged.
- Rejects mixed PIL images plus data-url `image_urls`.
- Adds coverage proving data URLs are emitted as `image_url` blocks and redacted from serialized memory.

Verified:
- `poetry run pytest -rP -n auto .`
- `poetry run mypy .`
- `poetry run pytest tests/extract/agents/test_agent_tool_image_transport.py tests/extract/settings/test_settings.py -q`
- `poetry run mypy src/groundx/extract/agents/agent.py tests/extract/agents/test_agent_tool_image_transport.py tests/extract/settings/test_settings.py`
