### PR TITLE
[codex] Fix local upload presign handling

### DIFF
--- a/src/groundx/ingest.py
+++ b/src/groundx/ingest.py
@@ -62,6 +62,10 @@ SUFFIX_ALIASES = {
 MAX_BATCH_SIZE = 50
 MIN_BATCH_SIZE = 1
 MAX_BATCH_SIZE_BYTES = 50 * 1024 * 1024
+UPLOAD_REQUEST_TIMEOUT_SECONDS = 60
+UPLOAD_RETRY_ATTEMPTS = 3
+UPLOAD_RETRY_BACKOFF_SECONDS = 0.5
+HOSTED_URL_HEADER = "gx-hosted-url"
 
 
 def _import_extraction_workflows() -> typing.Any:
@@ -129,6 +133,73 @@ def strip_query_params(
     clean_url = urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
 
     return clean_url
+
+
+def _first_header_value(value: typing.Any) -> typing.Optional[str]:
+    if isinstance(value, list) and value:
+        first = value[0]
+        return first if isinstance(first, str) else None
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def _header_value(
+    headers: typing.Mapping[str, typing.Any],
+    name: str,
+) -> typing.Optional[str]:
+    for key, value in headers.items():
+        if key.lower() != name.lower():
+            continue
+        return _first_header_value(value)
+    return None
+
+
+def _upload_headers_from_presign(
+    headers: typing.Any,
+) -> typing.Tuple[typing.Dict[str, str], typing.Optional[str]]:
+    upload_headers: typing.Dict[str, str] = {}
+    hosted_url: typing.Optional[str] = None
+
+    if not isinstance(headers, dict):
+        return upload_headers, hosted_url
+
+    for key, value in headers.items():
+        if not isinstance(key, str):
+            continue
+
+        parsed_value = _first_header_value(value)
+        if parsed_value is None:
+            continue
+
+        if key.lower() == HOSTED_URL_HEADER:
+            hosted_url = parsed_value
+            continue
+
+        upload_headers[key] = parsed_value
+
+    return upload_headers, hosted_url
+
+
+def _put_upload_file(
+    upload_url: str,
+    file_data: bytes,
+    headers: typing.Dict[str, str],
+) -> requests.Response:
+    for attempt in range(UPLOAD_RETRY_ATTEMPTS):
+        try:
+            return requests.put(
+                upload_url,
+                data=file_data,
+                headers=headers,
+                timeout=UPLOAD_REQUEST_TIMEOUT_SECONDS,
+            )
+        except requests.RequestException:
+            if attempt == UPLOAD_RETRY_ATTEMPTS - 1:
+                raise
+            time.sleep(UPLOAD_RETRY_BACKOFF_SECONDS * (attempt + 1))
+
+    raise RuntimeError("upload retry loop exited unexpectedly")
 
 
 def prep_documents(
@@ -863,13 +934,8 @@ class GroundX(GroundXBase):
         presigned_info = get_presigned_url(endpoint, file_name, file_extension)
 
         upload_url = presigned_info["URL"]
-        hd = presigned_info.get("Header", {})
+        headers, hosted_url = _upload_headers_from_presign(presigned_info.get("Header", {}))
         method = presigned_info.get("Method", "PUT").upper()
-
-        headers: typing.Dict[str, typing.Any] = {}
-        for key, value in hd.items():
-            if isinstance(value, list):
-                headers[key.upper()] = value[0]
 
         try:
             with open(file_path, "rb") as f:
@@ -878,15 +944,19 @@ class GroundX(GroundXBase):
             raise ValueError(f"Error reading file {file_path}: {e}")
 
         if method == "PUT":
-            upload_response = requests.put(upload_url, data=file_data, headers=headers)
+            upload_response = _put_upload_file(upload_url, file_data, headers)
         else:
             raise ValueError(f"Unsupported HTTP method: {method}")
 
         if upload_response.status_code not in (200, 201):
             raise Exception(f"Upload failed: {upload_response.status_code} - {upload_response.text}")
 
-        if "GX-HOSTED-URL" in headers:
-            return headers["GX-HOSTED-URL"]
+        response_hosted_url = _header_value(upload_response.headers, HOSTED_URL_HEADER)
+        if response_hosted_url is not None:
+            return response_hosted_url
+
+        if hosted_url is not None:
+            return hosted_url
 
         return strip_query_params(upload_url)
 
@@ -1479,13 +1549,8 @@ class AsyncGroundX(AsyncGroundXBase):
         presigned_info = get_presigned_url(endpoint, file_name, file_extension)
 
         upload_url = presigned_info["URL"]
-        hd = presigned_info.get("Header", {})
+        headers, hosted_url = _upload_headers_from_presign(presigned_info.get("Header", {}))
         method = presigned_info.get("Method", "PUT").upper()
-
-        headers: typing.Dict[str, typing.Any] = {}
-        for key, value in hd.items():
-            if isinstance(value, list):
-                headers[key.upper()] = value[0]
 
         try:
             with open(file_path, "rb") as f:
@@ -1494,14 +1559,18 @@ class AsyncGroundX(AsyncGroundXBase):
             raise ValueError(f"Error reading file {file_path}: {e}")
 
         if method == "PUT":
-            upload_response = requests.put(upload_url, data=file_data, headers=headers)
+            upload_response = _put_upload_file(upload_url, file_data, headers)
         else:
             raise ValueError(f"Unsupported HTTP method: {method}")
 
         if upload_response.status_code not in (200, 201):
             raise Exception(f"Upload failed: {upload_response.status_code} - {upload_response.text}")
 
-        if "GX-HOSTED-URL" in headers:
-            return headers["GX-HOSTED-URL"]
+        response_hosted_url = _header_value(upload_response.headers, HOSTED_URL_HEADER)
+        if response_hosted_url is not None:
+            return response_hosted_url
+
+        if hosted_url is not None:
+            return hosted_url
 
         return strip_query_params(upload_url)

--- a/tests/custom/test_ingest_upload.py
+++ b/tests/custom/test_ingest_upload.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+import requests
+
+from groundx import GroundX
+import groundx.ingest as ingest
+
+
+class _Response:
+    def __init__(self, status_code: int = 200) -> None:
+        self.status_code = status_code
+        self.text = ""
+        self.headers: dict[str, str] = {}
+
+
+def _presigned_info() -> dict[str, Any]:
+    return {
+        "URL": "https://eyelevel-upload.s3.us-west-2.amazonaws.com/prod/file/ssp/file.png?signature=test",
+        "Header": {
+            "Host": ["eyelevel-upload.s3.us-west-2.amazonaws.com"],
+            "Gx-Hosted-Url": ["https://upload.eyelevel.ai/prod/file/ssp/file.png"],
+            "Content-Type": ["image/png"],
+        },
+        "Method": "PUT",
+    }
+
+
+def test_upload_file_does_not_send_hosted_url_header_to_s3(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "file.png"
+    path.write_bytes(b"png")
+    sent_headers: dict[str, Any] = {}
+
+    monkeypatch.setattr(ingest, "get_presigned_url", lambda *args: _presigned_info())
+
+    def put(url: str, *, data: bytes, headers: dict[str, Any], timeout: int) -> _Response:
+        sent_headers.update(headers)
+        return _Response()
+
+    monkeypatch.setattr(ingest.requests, "put", put)
+
+    hosted_url = GroundX(api_key="test")._upload_file("https://api.eyelevel.ai/upload/file", path)
+
+    assert hosted_url == "https://upload.eyelevel.ai/prod/file/ssp/file.png"
+    assert "Gx-Hosted-Url" not in sent_headers
+    assert "GX-HOSTED-URL" not in sent_headers
+
+
+def test_upload_file_retries_transient_put_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "file.png"
+    path.write_bytes(b"png")
+    attempts = 0
+
+    monkeypatch.setattr(ingest, "get_presigned_url", lambda *args: _presigned_info())
+    monkeypatch.setattr(ingest.time, "sleep", lambda seconds: None)
+
+    def put(url: str, *, data: bytes, headers: dict[str, Any], timeout: int) -> _Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise requests.exceptions.SSLError("transient ssl error")
+        return _Response()
+
+    monkeypatch.setattr(ingest.requests, "put", put)
+
+    hosted_url = GroundX(api_key="test")._upload_file("https://api.eyelevel.ai/upload/file", path)
+
+    assert hosted_url == "https://upload.eyelevel.ai/prod/file/ssp/file.png"
+    assert attempts == 2


### PR DESCRIPTION
## Summary

Fixes local-file ingest uploads when the presign response includes a hosted GroundX URL alongside S3 upload details.

The SDK was forwarding every presign header to S3, including `GX-HOSTED-URL`. That header is not part of the S3 signature contract and can cause presigned PUT failures. The SDK now separates real upload headers from the hosted URL, retries transient upload errors, and returns the hosted URL from the upload response when present.

## Changes

- Parse presign headers case-insensitively.
- Keep `GX-HOSTED-URL` out of the S3 PUT headers.
- Prefer hosted URL from the upload response header, then presign metadata, then stripped upload URL.
- Add timeout and small retry loop for transient upload failures.
- Add mocked custom tests for hosted URL handling and retry behavior.

## Validation

- `PYTHONPATH=src python3 -m pytest tests/custom -q`
- `PYTHONPATH=src python3 -m mypy src/groundx/ingest.py tests/custom/test_ingest_upload.py`