### PR TITLE
[codex] harden extraction workflow contract validation

### DIFF
--- a/openspec/changes/harden-extraction-workflow-contract-validation/design.md
+++ b/openspec/changes/harden-extraction-workflow-contract-validation/design.md
@@ -1,0 +1,79 @@
+# Harden Extraction Workflow Contract Validation Design
+
+## Goals
+
+- Preserve legacy YAML support in the SDK.
+- Make v1 and workflow-extract payloads distinguishable by contract, not guess.
+- Reject mixed or metadata-bearing payloads that are missing explicit v1 markers
+  without adding client-side stored-state downgrade enforcement.
+- Give Arcadia a verified SDK-compatible error callback body for fatal
+  pre-hydration failures.
+
+## Non-Goals
+
+- No removal of legacy YAML.
+- No harness support for authoring legacy YAML.
+- No generated OpenAPI/Fern schema rename.
+- No broad rewrite of extraction workflow helper APIs.
+
+## Shape Classification
+
+The SDK should expose or internally use one classifier before create/update:
+
+| Shape | Accepted | Notes |
+| --- | --- | --- |
+| pure legacy authored YAML | yes | Top-level extraction groups only, such as `statement`, `meters`, and `charges`, with no v1 metadata. |
+| v1 authored YAML | yes | Requires `extraction_policy_version: v1` when workflow metadata, pseudo groups, route metadata, or policy metadata are present. |
+| persisted workflow extract | yes | Contains SDK persisted metadata such as `_groundx_persisted_extract`; loaded as workflow extract, not guessed from simple group keys. |
+| execution-only workflow extract | yes with `mapping_kind="workflow_extract"` | Preserved exactly; authored inspection metadata may be unavailable. |
+| mixed or stripped v1 | no | Metadata without marker, partial persisted metadata, field-level workflow routing keys in reserved metadata positions without v1 marker, or v1-looking payloads that lost required metadata. Ordinary legacy field names, prompt text, identifiers, and customer fields are not treated as v1 metadata merely because their strings match reserved words. |
+
+The classifier can remain private if the public helper errors are clear and
+well tested. If a public enum is introduced, it should be treated as a stable
+hand-written SDK surface.
+
+## Create/Update Validation
+
+Workflow create helpers may accept pure legacy or v1 definitions. They should
+reject only structurally invalid or mixed payloads.
+
+Workflow update helpers validate only the supplied definition shape in this
+change. They should not add a default SDK preflight `workflows.get(...)` call,
+an `allow_legacy_downgrade` flag, or a new existing-workflow context surface.
+Creating a new pure legacy workflow, updating with pure legacy input, and
+loading execution-only workflow extracts all remain supported when the supplied
+shape is structurally valid.
+
+Server-side validation is the authoritative place to enforce v1-to-legacy
+downgrade safety because cashbot-go can load the stored workflow during update.
+If the SDK later adds client-side downgrade enforcement, that future change must
+first define an explicit hand-written context surface and opt-in semantics. It
+must not be inferred from `workflow_id` and must not perform hidden update-time
+reads.
+
+This SDK work is the final compatibility phase, after the Arcadia stuck-file
+fix and cashbot-go server-side validation contract. It must not block the
+production terminalization fix, and it must not add hidden update-time reads to
+compensate for missing server-side state.
+
+## Error Callback Helper
+
+The SDK currently provides extraction task classes used by internal agents.
+Before Arcadia implements raw-Celery fatal callback fallback, the SDK should
+verify the error response body required by the GroundX callback handler. The
+minimum callback body must include `documentID`, `taskID`, `code`, and
+`message`. If the callback contract accepts model or processor identifiers, the
+SDK helper should carry them as optional fields without making them required for
+legacy callers.
+
+## Test Strategy
+
+Tests should cover each classifier row, sync and async create/update helpers,
+and the no-hidden-preflight update contract. Fixtures should include:
+
+- pure legacy utility-bill YAML;
+- current v1 Arcadia YAML;
+- persisted workflow extract from v1 YAML;
+- execution-only workflow extract;
+- metadata-without-marker invalid YAML;
+- pure legacy update when existing workflow state is unavailable.

--- a/openspec/changes/harden-extraction-workflow-contract-validation/proposal.md
+++ b/openspec/changes/harden-extraction-workflow-contract-validation/proposal.md
@@ -1,0 +1,43 @@
+# Change: Harden Extraction Workflow Contract Validation
+
+## Why
+
+The Python SDK is a shared boundary for harnesses, internal Arcadia agents, and
+direct customer code. It must keep pure legacy extraction YAML valid, while also
+rejecting mixed or metadata-bearing workflow `extract` payloads that are missing
+an explicit v1 marker. Stateful downgrade protection remains a server-side
+cashbot-go responsibility during workflow update, where stored workflow state is
+available.
+
+The recent Arcadia incident showed why shape ambiguity is dangerous: a
+legacy-looking deployed workflow can be valid legacy, or it can be a v1 workflow
+that lost the metadata needed for routing and agent selection. The SDK should
+classify these shapes clearly and fail before API calls when the source is mixed
+or ambiguous.
+
+## What Changes
+
+- Add explicit extraction workflow shape classification for authored YAML,
+  persisted workflow extracts, execution-only workflow extracts, and invalid
+  mixed payloads.
+- Keep pure legacy YAML supported by `prepare_extraction_yaml(...)` and
+  first-class create/update helpers.
+- Require v1 authored metadata to be explicitly marked by
+  `extraction_policy_version: v1`.
+- Reject mixed metadata-without-marker shapes before workflow create/update.
+- Keep workflow update helpers from adding hidden existing-workflow reads or
+  client-side downgrade enforcement in this change; server-side cashbot-go
+  validation remains authoritative for rejecting accidental v1-to-legacy
+  downgrades when stored workflow state is available.
+- Verify or extend the SDK extraction error response helper so Arcadia can build
+  a valid callback body from raw fatal-task identifiers.
+
+## Impact
+
+- Public SDK remains backwards compatible for pure legacy YAML.
+- Harness-authored workflows continue to use v1 only.
+- Invalid mixed payloads fail earlier with clearer errors.
+- Valid pure legacy payloads are not rejected because they lack harness/v1
+  metadata.
+- Any new error-response field must remain hand-written SDK code and must not
+  require generated Fern schema renames.

--- a/openspec/changes/harden-extraction-workflow-contract-validation/specs/extract-yaml/spec.md
+++ b/openspec/changes/harden-extraction-workflow-contract-validation/specs/extract-yaml/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Extraction YAML shape classification is explicit
+
+The SDK SHALL classify extraction definitions into accepted authored,
+workflow-extract, and invalid mixed shapes before preparing them for workflow
+create or update.
+
+#### Scenario: Pure legacy authored YAML remains supported
+
+- **GIVEN** YAML contains only top-level extraction groups with field
+  definitions
+- **AND** it does not contain v1 workflow metadata, pseudo groups, route
+  metadata, policy metadata, or `_groundx_persisted_extract`
+- **WHEN** the SDK prepares the YAML
+- **THEN** the definition is classified as pure legacy authored YAML
+- **AND** existing legacy preparation behavior remains supported.
+
+#### Scenario: V1 authored YAML requires explicit marker
+
+- **GIVEN** YAML contains v1 workflow metadata, pseudo groups, route metadata,
+  policy metadata, or workflow-only field routing keys
+- **WHEN** the SDK prepares the YAML
+- **THEN** preparation succeeds only when top-level
+  `extraction_policy_version: v1` is present
+- **AND** preparation fails clearly when that marker is absent.
+
+#### Scenario: Persisted workflow extract is not guessed from simple groups
+
+- **GIVEN** a mapping contains simple extraction group keys that could be either
+  authored YAML or an execution-only workflow `extract`
+- **WHEN** the caller does not pass `mapping_kind="workflow_extract"`
+- **THEN** the SDK treats the mapping as authored YAML-shaped input
+- **AND** it does not guess workflow-extract semantics from the group names
+  alone.
+
+#### Scenario: Mixed metadata shape fails clearly
+
+- **GIVEN** an extraction mapping contains partial persisted metadata, v1 field
+  routing keys in reserved metadata positions without the v1 marker, or v1
+  metadata keys mixed into legacy groups
+- **WHEN** the SDK prepares the mapping
+- **THEN** preparation fails with an error that identifies the invalid shape
+- **AND** the error says pure legacy and explicitly marked v1 are the supported
+  authored YAML shapes.
+
+#### Scenario: Legacy customer field names are not treated as v1 metadata
+
+- **GIVEN** pure legacy YAML contains a customer field name, prompt text, or
+  identifier whose string matches a reserved v1 metadata word
+- **WHEN** the SDK prepares the YAML
+- **THEN** preparation does not reject the YAML solely because of that string
+- **AND** reserved v1 metadata detection is based on YAML position and structure,
+  not substring matching.
+
+### Requirement: Persisted workflow extracts preserve v1 metadata
+
+The SDK SHALL preserve v1 persisted workflow extract metadata across JSON round
+trips and workflow helper loading.
+
+#### Scenario: V1 persisted extract reloads as v1
+
+- **GIVEN** a persisted workflow extract produced from v1 authored YAML
+- **WHEN** the mapping is serialized to JSON, deserialized, and loaded again
+- **THEN** the SDK recovers the v1 top-level metadata, route metadata, workflow
+  groups, and final groups
+- **AND** the loaded definition is not reclassified as pure legacy.
+
+#### Scenario: Execution-only workflow extract stays opaque
+
+- **GIVEN** a workflow `extract` mapping lacks authored persisted metadata
+- **WHEN** the caller loads it with `mapping_kind="workflow_extract"`
+- **THEN** the SDK preserves the mapping exactly
+- **AND** it does not fabricate authored metadata or v1 route metadata.

--- a/openspec/changes/harden-extraction-workflow-contract-validation/specs/extraction-workflow-convenience/spec.md
+++ b/openspec/changes/harden-extraction-workflow-contract-validation/specs/extraction-workflow-convenience/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Extraction workflow create/update validates supported shapes
+
+The SDK first-class extraction workflow helpers SHALL validate input definition
+shape before calling the workflow API.
+
+#### Scenario: Create accepts pure legacy
+
+- **GIVEN** a caller creates an extraction workflow from pure legacy YAML
+- **WHEN** `create_extraction_workflow(...)` validates the source
+- **THEN** the helper accepts the definition
+- **AND** it sends a legacy-compatible workflow `extract` payload.
+
+#### Scenario: Create accepts explicit v1
+
+- **GIVEN** a caller creates an extraction workflow from YAML containing
+  `extraction_policy_version: v1`
+- **WHEN** `create_extraction_workflow(...)` validates the source
+- **THEN** the helper accepts the definition
+- **AND** it preserves v1 persisted metadata in the workflow `extract` payload.
+
+#### Scenario: Create rejects mixed metadata
+
+- **GIVEN** a caller creates an extraction workflow from metadata-bearing YAML
+  that lacks `extraction_policy_version: v1`
+- **WHEN** `create_extraction_workflow(...)` validates the source
+- **THEN** the helper fails before calling the workflow API
+- **AND** the error identifies the source as mixed or unsupported.
+
+#### Scenario: Legacy update without existing state is not rejected by downgrade guard
+
+- **GIVEN** a caller updates an extraction workflow with pure legacy YAML
+- **AND** the SDK helper does not have existing-workflow state
+- **WHEN** `update_extraction_workflow(...)` validates the update
+- **THEN** the helper does not reject the update solely because the existing
+  workflow shape is unknown
+- **AND** it does not perform a hidden `workflows.get(...)` preflight read solely
+  to enforce downgrade safety
+- **AND** server-side workflow validation remains responsible for rejecting an
+  accidental v1-to-legacy downgrade when stored workflow state is available.
+
+#### Scenario: SDK does not add client-side downgrade option in this phase
+
+- **GIVEN** a caller updates an extraction workflow through the SDK helper
+- **WHEN** the helper validates the supplied extraction definition
+- **THEN** the helper does not require or expose an `allow_legacy_downgrade`
+  option in this change
+- **AND** it does not infer existing workflow shape from `workflow_id`
+- **AND** any future client-side downgrade guard requires a separately specified
+  explicit existing-workflow context surface.
+
+### Requirement: Extraction error callback bodies preserve required identity
+
+SDK extraction task error helpers SHALL be able to build a callback-compatible
+error body from fatal task identifiers even when a full typed request object is
+unavailable.
+
+#### Scenario: Minimal fatal callback body is valid
+
+- **GIVEN** a fatal extraction task error has a callback URL, document ID, task
+  ID, code, and message
+- **WHEN** the SDK error helper builds the callback body
+- **THEN** the body contains `documentID`, `taskID`, `code`, and `message`
+- **AND** the body is accepted by the GroundX extraction callback handler.
+
+#### Scenario: Optional processor identity is preserved
+
+- **GIVEN** a fatal extraction task error also has model ID or processor ID
+- **WHEN** the SDK error helper builds the callback body
+- **THEN** those identifiers are included when supported by the callback
+  contract
+- **AND** callers that only have the minimal required identifiers remain
+  supported.

--- a/openspec/changes/harden-extraction-workflow-contract-validation/tasks.md
+++ b/openspec/changes/harden-extraction-workflow-contract-validation/tasks.md
@@ -1,0 +1,54 @@
+# Tasks
+
+## 1. Contract Review
+
+- [x] Confirm cashbot-go server-side validation semantics before finalizing SDK
+      shape-validation behavior; the SDK stays compatible with the server-side
+      downgrade guard but is not the authoritative update guard.
+- [x] Re-read `groundx.extract` YAML preparation, `ExtractionDefinition`,
+      create/update helpers, and error response classes.
+- [x] Confirm which files are protected by `.fernignore` before editing.
+- [x] Confirm the callback error body expected by cashbot-go
+      `DocumentLayoutWebhook`.
+
+## 2. Shape Validation Tests
+
+- [x] Add fixtures for pure legacy, current v1, persisted workflow extract,
+      execution-only workflow extract, and mixed invalid payloads.
+- [x] Add tests proving pure legacy YAML remains accepted.
+- [x] Add tests proving metadata without `extraction_policy_version: v1` fails
+      clearly.
+- [x] Add tests proving workflow-extract mappings require explicit
+      `mapping_kind="workflow_extract"` where authored mapping ambiguity exists.
+
+## 3. Create/Update Safety Tests
+
+- [x] Add sync and async create helper tests for legacy and v1 definitions.
+- [x] Add tests proving pure legacy updates are not rejected solely because the
+      helper lacks existing-workflow context.
+- [x] Add tests proving update helpers do not perform a default
+      `workflows.get(...)` preflight read solely to enforce downgrade safety.
+- [x] Add tests proving this change does not introduce an
+      `allow_legacy_downgrade` option or any other implicit client-side
+      downgrade guard without an explicit future context design.
+
+## 4. Implement
+
+- [x] Keep this phase behind the Arcadia terminalization fix and cashbot-go
+      server-side validation; do not add SDK behavior that becomes required for
+      files to terminalize.
+- [x] Add the smallest shape-classification helper needed by the tests.
+- [x] Wire classification into loader and create/update helper validation.
+- [x] Do not add a legacy-downgrade opt-in, existing-workflow context argument,
+      or default update-time preflight read in the SDK as part of this change.
+- [x] Verify or extend the extraction error response helper for raw fatal-task
+      callback bodies.
+- [x] Update SDK docs/docstrings for accepted shapes, invalid mixed shapes, and
+      the fact that downgrade protection is enforced server-side in this phase.
+
+## 5. Verify
+
+- [x] Run targeted extraction helper and prompt-manager tests.
+- [x] Run `poetry run pytest -rP tests/custom tests/extract`.
+- [x] Run `poetry run mypy .`.
+- [x] Run `OPENSPEC_TELEMETRY=0 npx -y @fission-ai/openspec@1.3.1 validate harden-extraction-workflow-contract-validation --strict`.

--- a/src/groundx/extract/classes/api.py
+++ b/src/groundx/extract/classes/api.py
@@ -1,4 +1,6 @@
+import typing
 from dataclasses import dataclass
+
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -7,6 +9,8 @@ class ErrorResponse(BaseModel):
     code: int
     document_id: str = Field(alias="documentID")
     message: str
+    model_id: typing.Optional[int] = Field(alias="modelID", default=None)
+    processor_id: typing.Optional[int] = Field(alias="processorID", default=None)
     task_id: str = Field(alias="taskID")
 
 

--- a/src/groundx/extract/tasks/__init__.py
+++ b/src/groundx/extract/tasks/__init__.py
@@ -1,6 +1,7 @@
-from .utility import error_response, success_response
+from .utility import error_response, fatal_error_response, success_response
 
 __all__ = [
     "error_response",
+    "fatal_error_response",
     "success_response",
 ]

--- a/src/groundx/extract/tasks/utility.py
+++ b/src/groundx/extract/tasks/utility.py
@@ -1,11 +1,13 @@
 import typing
 
 from ..classes.api import ErrorResponse
-from ..classes.document import DocumentRequest
 from ..classes.groundx import GroundXResponse
 
+if typing.TYPE_CHECKING:
+    from ..classes.document import DocumentRequest
 
-def error_response(req: DocumentRequest, msg: str) -> typing.Dict[str, typing.Any]:
+
+def error_response(req: "DocumentRequest", msg: str) -> typing.Dict[str, typing.Any]:
     return fatal_error_response(
         document_id=req.document_id,
         task_id=req.task_id,
@@ -35,7 +37,7 @@ def fatal_error_response(
 
 
 def success_response(
-    req: DocumentRequest, result_url: str
+    req: "DocumentRequest", result_url: str
 ) -> typing.Dict[str, typing.Any]:
     return GroundXResponse(
         code=200,

--- a/src/groundx/extract/tasks/utility.py
+++ b/src/groundx/extract/tasks/utility.py
@@ -6,12 +6,32 @@ from ..classes.groundx import GroundXResponse
 
 
 def error_response(req: DocumentRequest, msg: str) -> typing.Dict[str, typing.Any]:
-    return ErrorResponse(
-        code=500,
-        documentID=req.document_id,
+    return fatal_error_response(
+        document_id=req.document_id,
+        task_id=req.task_id,
         message=msg,
-        taskID=req.task_id,
-    ).model_dump(by_alias=True)
+        model_id=req.model_id,
+        processor_id=req.processor_id,
+    )
+
+
+def fatal_error_response(
+    *,
+    document_id: str,
+    task_id: str,
+    message: str,
+    code: int = 500,
+    model_id: typing.Optional[int] = None,
+    processor_id: typing.Optional[int] = None,
+) -> typing.Dict[str, typing.Any]:
+    return ErrorResponse(
+        code=code,
+        documentID=document_id,
+        message=message,
+        modelID=model_id,
+        processorID=processor_id,
+        taskID=task_id,
+    ).model_dump(by_alias=True, exclude_none=True)
 
 
 def success_response(

--- a/src/groundx/extract/workflows.py
+++ b/src/groundx/extract/workflows.py
@@ -2,15 +2,17 @@ import copy
 import dataclasses
 import inspect
 import typing
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 from .prompt import PreparedExtractionYaml, prepare_extraction_yaml
 
 _PERSISTED_WORKFLOW_EXTRACT_KEY = "_groundx_persisted_extract"
 _WORKFLOW_METADATA_KEY = "workflow"
+_WORKFLOW_METADATA_VERSION = 1
 _WORKFLOW_EXTRACT_MAPPING_KIND = "workflow_extract"
 _AUTHORED_YAML_MAPPING_KIND = "authored_yaml"
+_AUTHORING_ONLY_WORKFLOW_KEYS = {"workflow_step", "workflow_output_key"}
 _PERSISTED_WORKFLOW_METADATA_KEYS = {
     "agent_chain",
     "metadata_version",
@@ -329,10 +331,11 @@ def _definition_from_workflow_extract(
     extract: typing.Mapping[str, typing.Any],
 ) -> ExtractionDefinition:
     extract_mapping = _deepcopy_mapping(extract)
+    prepared = _validate_workflow_extract_mapping(extract_mapping)
     metadata = _workflow_metadata(extract_mapping)
     return ExtractionDefinition(
         extract=extract_mapping,
-        prepared=_prepared_from_workflow_extract(extract_mapping),
+        prepared=prepared,
         template=_normalize_template(metadata.get("template")),
         custom_steps=_plain_metadata_sequence(
             metadata.get("custom_steps"),
@@ -355,6 +358,134 @@ def _prepared_from_workflow_extract(
     if _PERSISTED_WORKFLOW_EXTRACT_KEY not in extract:
         return None
     return prepare_extraction_yaml(extract)
+
+
+def _validate_workflow_extract_mapping(
+    extract: typing.Mapping[str, typing.Any],
+) -> typing.Optional[PreparedExtractionYaml]:
+    authoring_paths = _find_authoring_only_workflow_keys(extract)
+    if authoring_paths:
+        preview = ", ".join(authoring_paths[:3])
+        raise ValueError(
+            "workflow_extract contains authoring-only workflow metadata "
+            f"at {preview}; load authored YAML without mapping_kind or persist a "
+            "workflow extract with workflow.metadata_version"
+        )
+
+    metadata = _workflow_metadata(extract)
+    has_workflow_metadata = bool(set(metadata.keys()) & _PERSISTED_WORKFLOW_METADATA_KEYS)
+    if not has_workflow_metadata:
+        return _prepared_from_workflow_extract(extract)
+
+    if metadata.get("metadata_version") != _WORKFLOW_METADATA_VERSION:
+        raise ValueError("unsupported custom workflow metadata_version")
+
+    prepared = prepare_extraction_yaml(extract)
+    _validate_workflow_metadata_references(extract, metadata)
+    if _PERSISTED_WORKFLOW_EXTRACT_KEY in extract:
+        return prepared
+    return None
+
+
+def _find_authoring_only_workflow_keys(
+    value: typing.Any,
+    *,
+    path: str = "$",
+    parent_key: typing.Optional[str] = None,
+) -> typing.List[str]:
+    if not isinstance(value, Mapping):
+        return []
+
+    paths: typing.List[str] = []
+    mapping = typing.cast(typing.Mapping[str, typing.Any], value)
+    for key, child in mapping.items():
+        if path == "$" and key in {
+            _PERSISTED_WORKFLOW_EXTRACT_KEY,
+            _WORKFLOW_METADATA_KEY,
+        }:
+            continue
+
+        child_path = f"{path}.{key}"
+        is_name_position = parent_key == "fields"
+        if (
+            isinstance(key, str)
+            and key in _AUTHORING_ONLY_WORKFLOW_KEYS
+            and not is_name_position
+        ):
+            paths.append(child_path)
+
+        paths.extend(
+            _find_authoring_only_workflow_keys(
+                child,
+                path=child_path,
+                parent_key=key if isinstance(key, str) else None,
+            )
+        )
+
+    return paths
+
+
+def _validate_workflow_metadata_references(
+    extract: typing.Mapping[str, typing.Any],
+    metadata: typing.Mapping[str, typing.Any],
+) -> None:
+    for metadata_key in ("output_routes", "leaf_fields"):
+        entries = metadata.get(metadata_key)
+        if entries is None:
+            continue
+        if not isinstance(entries, Sequence) or isinstance(entries, (str, bytes)):
+            raise ValueError(f"workflow.{metadata_key} must be a list")
+        for idx, entry in enumerate(entries):
+            if not isinstance(entry, Mapping):
+                raise ValueError(f"workflow.{metadata_key}[{idx}] must be a mapping")
+            entry_mapping = typing.cast(typing.Mapping[str, typing.Any], entry)
+            group_name = entry_mapping.get("workflow_group")
+            field_name = entry_mapping.get("workflow_field")
+            if not isinstance(group_name, str) or group_name == "":
+                raise ValueError(f"workflow.{metadata_key}[{idx}] is missing workflow_group")
+            if not isinstance(field_name, str) or field_name == "":
+                raise ValueError(f"workflow.{metadata_key}[{idx}] is missing workflow_field")
+            if not _workflow_field_exists(extract, group_name, field_name):
+                raise ValueError(
+                    f"workflow.{metadata_key}[{idx}] references missing "
+                    f"workflow field [{group_name}.{field_name}]"
+                )
+
+
+def _workflow_field_exists(
+    extract: typing.Mapping[str, typing.Any],
+    group_name: str,
+    workflow_field: str,
+) -> bool:
+    group = extract.get(group_name)
+    if not isinstance(group, Mapping):
+        return False
+
+    fields = group.get("fields")
+    if not isinstance(fields, Mapping):
+        return False
+
+    current: typing.Any = fields
+    parts = workflow_field.split(".")
+    for idx, part in enumerate(parts):
+        if not isinstance(current, Mapping) or part not in current:
+            return False
+        value = current[part]
+        if idx == len(parts) - 1:
+            return True
+        if isinstance(value, list):
+            if not value:
+                return False
+            value = value[0]
+        if isinstance(value, Mapping) and isinstance(value.get("fields"), Mapping):
+            current = value["fields"]
+            continue
+        if isinstance(value, Mapping):
+            current = value
+            continue
+        return False
+
+    return False
 
 
 def _prepare_extraction_yaml_with_context(

--- a/src/groundx/ingest.py
+++ b/src/groundx/ingest.py
@@ -382,6 +382,10 @@ class GroundX(GroundXBase):
 
         Prefer `load_extraction_definition(...)` for new code when the source
         may be either YAML or an existing workflow ID.
+        Authored YAML may be pure legacy or explicitly marked v1 YAML. Existing
+        workflow extract mappings must use `mapping_kind="workflow_extract"`;
+        mixed payloads that leak authoring-only workflow metadata into
+        execution extracts are rejected.
         """
         extraction_workflows = _import_extraction_workflows()
         return extraction_workflows.load_extraction_definition_from_yaml(
@@ -612,6 +616,9 @@ class GroundX(GroundXBase):
         If `definition` is provided, it takes precedence over YAML/prepared
         inputs. Otherwise pass exactly one of `path`, `yaml_text`, `mapping`, or
         `prepared`.
+        The SDK validates only the supplied definition shape here. Stored-state
+        downgrade protection is enforced server-side by the workflow API; this
+        helper does not perform a hidden `workflows.get(...)` preflight read.
         """
         extraction_workflows = _import_extraction_workflows()
         resolved = extraction_workflows.resolve_extraction_definition_source(
@@ -1202,6 +1209,10 @@ class AsyncGroundX(AsyncGroundXBase):
 
         Prefer `load_extraction_definition(...)` for new code when the source
         may be either YAML or an existing workflow ID.
+        Authored YAML may be pure legacy or explicitly marked v1 YAML. Existing
+        workflow extract mappings must use `mapping_kind="workflow_extract"`;
+        mixed payloads that leak authoring-only workflow metadata into
+        execution extracts are rejected.
         """
         extraction_workflows = _import_extraction_workflows()
         return extraction_workflows.load_extraction_definition_from_yaml(
@@ -1407,6 +1418,9 @@ class AsyncGroundX(AsyncGroundXBase):
         `definition` is provided, it takes precedence over YAML/prepared inputs.
         Otherwise pass exactly one of `path`, `yaml_text`, `mapping`, or
         `prepared`.
+        The SDK validates only the supplied definition shape here. Stored-state
+        downgrade protection is enforced server-side by the workflow API; this
+        helper does not perform a hidden `workflows.get(...)` preflight read.
         """
         extraction_workflows = _import_extraction_workflows()
         resolved = extraction_workflows.resolve_extraction_definition_source(

--- a/tests/extract/tasks/test_utility.py
+++ b/tests/extract/tasks/test_utility.py
@@ -1,0 +1,36 @@
+from groundx.extract.classes.document import DocumentRequest
+from groundx.extract.tasks import error_response, fatal_error_response
+
+
+def test_fatal_error_response_builds_minimal_callback_body() -> None:
+    assert fatal_error_response(
+        document_id="document-1",
+        task_id="task-1",
+        message="failed before request hydration",
+    ) == {
+        "code": 500,
+        "documentID": "document-1",
+        "message": "failed before request hydration",
+        "taskID": "task-1",
+    }
+
+
+def test_error_response_preserves_optional_processor_identity() -> None:
+    req = DocumentRequest.model_validate(
+        {
+            "documentID": "document-1",
+            "fileName": "statement.pdf",
+            "modelID": 10,
+            "processorID": 20,
+            "taskID": "task-1",
+        }
+    )
+
+    assert error_response(req, "failed") == {
+        "code": 500,
+        "documentID": "document-1",
+        "message": "failed",
+        "modelID": 10,
+        "processorID": 20,
+        "taskID": "task-1",
+    }

--- a/tests/extract/tasks/test_utility.py
+++ b/tests/extract/tasks/test_utility.py
@@ -1,5 +1,13 @@
-from groundx.extract.classes.document import DocumentRequest
+import typing
+
 from groundx.extract.tasks import error_response, fatal_error_response
+
+
+class _Request:
+    document_id = "document-1"
+    model_id = 10
+    processor_id = 20
+    task_id = "task-1"
 
 
 def test_fatal_error_response_builds_minimal_callback_body() -> None:
@@ -16,17 +24,7 @@ def test_fatal_error_response_builds_minimal_callback_body() -> None:
 
 
 def test_error_response_preserves_optional_processor_identity() -> None:
-    req = DocumentRequest.model_validate(
-        {
-            "documentID": "document-1",
-            "fileName": "statement.pdf",
-            "modelID": 10,
-            "processorID": 20,
-            "taskID": "task-1",
-        }
-    )
-
-    assert error_response(req, "failed") == {
+    assert error_response(typing.cast(typing.Any, _Request()), "failed") == {
         "code": 500,
         "documentID": "document-1",
         "message": "failed",

--- a/tests/extract/test_extraction_workflow_definitions.py
+++ b/tests/extract/test_extraction_workflow_definitions.py
@@ -1,8 +1,11 @@
+import copy
+import inspect
 import typing
 from pathlib import Path
 
 import pytest
 import yaml
+from .prompt._fixtures import SAMPLE_YAML_1
 
 from groundx import AsyncGroundX, GroundX
 from groundx.core.request_options import RequestOptions
@@ -397,6 +400,60 @@ def test_workflow_extract_without_authored_metadata_returns_no_prepared() -> Non
     assert definition.custom_steps[0]["name"] == "line_item_labels"
 
 
+def test_workflow_extract_rejects_custom_metadata_without_version() -> None:
+    mapping = typing.cast(
+        typing.Dict[str, typing.Any],
+        yaml.safe_load(CUSTOM_WORKFLOW_YAML),
+    )
+    extract = prepare_extraction_yaml(mapping).persisted_workflow_extract
+    del extract["workflow"]["metadata_version"]
+
+    with pytest.raises(ValueError, match="metadata_version"):
+        _client(RecordingWorkflows()).load_extraction_definition_from_yaml(
+            mapping=extract,
+            mapping_kind="workflow_extract",
+        )
+
+
+def test_workflow_extract_rejects_authoring_markers_without_metadata() -> None:
+    extract = {
+        "line_items": {
+            "workflow_step": "line_item_labels",
+            "fields": {
+                "description": {
+                    "workflow_output_key": "label",
+                    "prompt": {
+                        "instructions": "Return the printed line-item description.",
+                        "type": "str",
+                    },
+                }
+            },
+        }
+    }
+
+    with pytest.raises(ValueError, match="authoring-only"):
+        _client(RecordingWorkflows()).load_extraction_definition_from_yaml(
+            mapping=extract,
+            mapping_kind="workflow_extract",
+        )
+
+
+def test_workflow_extract_rejects_route_to_missing_group() -> None:
+    extract = typing.cast(
+        typing.Dict[str, typing.Any],
+        copy.deepcopy(EXECUTION_ONLY_EXTRACT),
+    )
+    workflow = typing.cast(typing.Dict[str, typing.Any], extract["workflow"])
+    workflow["output_routes"][0]["workflow_group"] = "missing_items"
+    workflow["leaf_fields"][0]["workflow_group"] = "missing_items"
+
+    with pytest.raises(ValueError, match="missing_items"):
+        _client(RecordingWorkflows()).load_extraction_definition_from_yaml(
+            mapping=extract,
+            mapping_kind="workflow_extract",
+        )
+
+
 def test_template_values_must_be_strings() -> None:
     mapping = typing.cast(
         typing.Dict[str, typing.Any],
@@ -727,6 +784,40 @@ def test_create_and_update_yaml_path_accept_supported_policy_metadata(
     update_extract = workflows.calls[1][2]["extract"]
     assert create_extract == update_extract
     assert create_extract["_groundx_persisted_extract"]["extraction_policy_version"] == "v1"
+
+
+def test_create_and_update_accept_legacy_yaml_without_preflight() -> None:
+    workflows = RecordingWorkflows()
+    client = _client(workflows)
+
+    assert (
+        client.create_extraction_workflow(
+            yaml_text=SAMPLE_YAML_1,
+            name="legacy extraction",
+        )
+        == "created"
+    )
+    assert (
+        client.update_extraction_workflow(
+            "workflow-1",
+            yaml_text=SAMPLE_YAML_1,
+        )
+        == "updated"
+    )
+
+    assert [call[0] for call in workflows.calls] == ["create", "update"]
+    create_extract = workflows.calls[0][1]["extract"]
+    update_extract = workflows.calls[1][2]["extract"]
+    assert "workflow" not in create_extract
+    assert "_groundx_persisted_extract" not in create_extract
+    assert update_extract == create_extract
+
+
+def test_update_helper_exposes_no_client_side_downgrade_option() -> None:
+    signature = inspect.signature(GroundX.update_extraction_workflow)
+
+    assert "allow_legacy_downgrade" not in signature.parameters
+    assert "existing_workflow" not in signature.parameters
 
 
 def test_create_requires_name_but_update_can_omit_name() -> None:


### PR DESCRIPTION
## What changed
- Add SDK workflow-extract validation for malformed persisted metadata, authoring-only marker leakage, and route references to missing groups/fields.
- Preserve pure legacy YAML, explicit v1 YAML, persisted workflow extracts, and execution-only workflow extracts.
- Add a raw-ID `fatal_error_response(...)` helper and keep `error_response(req, msg)` as a compatibility wrapper with optional model/processor identity.
- Document accepted shapes and server-side downgrade enforcement in the public helper docstrings.
- Add OpenSpec coverage for SDK shape validation and callback body identity.

## Why
The SDK is a shared producer boundary for harnesses and internal agents. It should reject mixed/stripped v1 shapes before API calls without becoming the stateful downgrade authority; cashbot-go owns stored-state validation.

## Validation
- `poetry run pytest tests/extract/test_extraction_workflow_definitions.py tests/extract/prompt/test_persisted_workflow_extract.py tests/extract/prompt/test_yaml_contract_v1.py tests/extract/tasks/test_utility.py -q`
- `poetry run pytest -rP tests/custom tests/extract`
- `poetry run mypy .`
- `poetry run ruff check src/groundx/extract/workflows.py src/groundx/extract/classes/api.py src/groundx/extract/tasks/utility.py src/groundx/extract/tasks/__init__.py src/groundx/ingest.py tests/extract/test_extraction_workflow_definitions.py tests/extract/tasks/test_utility.py`
- `OPENSPEC_TELEMETRY=0 npx -y @fission-ai/openspec@1.3.1 validate harden-extraction-workflow-contract-validation --strict`