### PR TITLE
Fix custom output reassembly edge cases

### DIFF
--- a/openspec/specs/custom-output-readback/spec.md
+++ b/openspec/specs/custom-output-readback/spec.md
@@ -26,6 +26,16 @@ generic repeated-output container when route metadata is present.
 - **WHEN** the SDK loads the custom output
 - **THEN** both the scalar field and repeated records are present in final output.
 
+#### Scenario: SDK typed X-Ray aliases remain routable
+
+- **GIVEN** a typed SDK `DocumentXray` object exposes custom output maps with
+  snake_case aliases such as `custom_chunk_outputs`
+- **AND** route metadata still names the canonical wire map such as
+  `customChunkOutputs`
+- **WHEN** the SDK reassembles custom output
+- **THEN** it reads the typed SDK aliases as the same custom output source
+- **AND** the routed values are present in final output.
+
 #### Scenario: Repeated routes prefer records-wrapped rows
 
 - **GIVEN** a `keys` or `summary` custom step output contains both `_records[]`
@@ -162,6 +172,14 @@ metadata rather than hardcoded final group names.
 - **WHEN** the SDK applies relationship metadata
 - **THEN** the child record remains in the configured unmatched child group.
 
+#### Scenario: Missing relationship list groups become empty lists
+
+- **GIVEN** relationship metadata declares parent and child list groups
+- **AND** custom output produces no non-empty records for one or both groups
+- **WHEN** the SDK applies relationship metadata
+- **THEN** the absent relationship groups are treated as empty lists
+- **AND** no invalid relationship output diagnostic is emitted.
+
 #### Scenario: Ambiguous child matches fail clearly
 
 - **GIVEN** one child record matches more than one parent record
@@ -290,4 +308,3 @@ adding `_records[]` and top-level repeated final-group support.
 - **AND** route metadata maps that output key to a scalar final path
 - **WHEN** the SDK loads custom outputs
 - **THEN** the scalar final field is preserved.
-

--- a/src/groundx/extract/custom_outputs.py
+++ b/src/groundx/extract/custom_outputs.py
@@ -60,6 +60,15 @@ class _RouteContainer:
 
 _REPEATED_STEP_KINDS = {"keys", "summary"}
 _EXTRACTED_FIELD_VALUE_KEYS = {"value", "confidence", "conflicts", "qa"}
+_GET_ALIASES = {
+    "chunkId": ("chunk_id",),
+    "customChunkOutputs": ("custom_chunk_outputs",),
+    "customDocumentOutputs": ("custom_document_outputs",),
+    "customSectionOutputs": ("custom_section_outputs",),
+    "documentPages": ("document_pages",),
+    "pageNumbers": ("page_numbers",),
+    "sectionId": ("section_id",),
+}
 
 
 def reassemble_custom_outputs_from_xray(
@@ -428,10 +437,16 @@ def _page_numbers(value: typing.Any) -> typing.Tuple[int, ...]:
 
 
 def _get(value: typing.Any, key: str) -> typing.Any:
-    if isinstance(value, typing.Mapping):
-        raw_value = value.get(key)
-    else:
-        raw_value = getattr(value, key, None)
+    raw_value = None
+    sentinel = object()
+    for candidate in (key, *_GET_ALIASES.get(key, ())):
+        if isinstance(value, typing.Mapping):
+            candidate_value = value.get(candidate, sentinel)
+        else:
+            candidate_value = getattr(value, candidate, sentinel)
+        if candidate_value is not sentinel:
+            raw_value = candidate_value
+            break
     if isinstance(raw_value, str):
         try:
             parsed_value = json.loads(clean_json(raw_value))
@@ -798,6 +813,11 @@ def _apply_relationships(
                 )
             )
             continue
+
+        if parent_group not in result:
+            result[parent_group] = []
+        if child_group not in result:
+            result[child_group] = []
 
         parent_records = result.get(parent_group)
         child_records = result.get(child_group)

--- a/tests/extract/test_custom_output_reassembly.py
+++ b/tests/extract/test_custom_output_reassembly.py
@@ -275,6 +275,120 @@ def test_exposes_workflow_output_before_final_routing() -> None:
     }
 
 
+def test_reads_sdk_typed_snake_case_custom_output_maps() -> None:
+    workflow_extract = {
+        "workflow": {
+            "custom_steps": [
+                {"name": "statement_fields", "level": "chunk", "kind": "instruct"},
+            ],
+            "output_routes": [
+                {
+                    "workflow_group": "statement",
+                    "workflow_field": "account_number",
+                    "final_path": "/statement/account_number",
+                    "step_name": "statement_fields",
+                    "level": "chunk",
+                    "output_map": "customChunkOutputs",
+                    "output_key": "account_number",
+                },
+            ],
+        }
+    }
+    xray = {
+        "chunks": [
+            {
+                # SDK DocumentXray objects dump aliases as snake_case.
+                "custom_chunk_outputs": {
+                    "statement_fields": {"account_number": "A-123"}
+                },
+            }
+        ]
+    }
+
+    result = reassemble_custom_outputs_from_xray(
+        xray,
+        workflow_extract=workflow_extract,
+    )
+
+    assert result.diagnostics == []
+    assert result.final_output == {"statement": {"account_number": "A-123"}}
+    assert result.workflow_output == {"statement": {"account_number": "A-123"}}
+
+
+def test_missing_relationship_list_groups_are_empty_lists() -> None:
+    workflow_extract = {
+        "workflow": {
+            "custom_steps": [
+                {"name": "statement_fields", "level": "chunk", "kind": "instruct"},
+                {"name": "meter_fields", "level": "chunk", "kind": "summary"},
+                {"name": "charge_fields", "level": "chunk", "kind": "keys"},
+            ],
+            "output_routes": [
+                {
+                    "workflow_group": "statement",
+                    "workflow_field": "account_number",
+                    "final_path": "/statement/account_number",
+                    "step_name": "statement_fields",
+                    "level": "chunk",
+                    "output_map": "customChunkOutputs",
+                    "output_key": "account_number",
+                },
+                {
+                    "workflow_group": "meters",
+                    "workflow_field": "meter_number",
+                    "final_path": "/meters/meter_number",
+                    "step_name": "meter_fields",
+                    "level": "chunk",
+                    "output_map": "customChunkOutputs",
+                    "output_key": "meter_number",
+                },
+                {
+                    "workflow_group": "charges",
+                    "workflow_field": "charge_amount",
+                    "final_path": "/charges/charge_amount",
+                    "step_name": "charge_fields",
+                    "level": "chunk",
+                    "output_map": "customChunkOutputs",
+                    "output_key": "charge_amount",
+                },
+            ],
+            "output_relationships": [
+                {
+                    "parent_group": "meters",
+                    "child_group": "charges",
+                    "parent_output_field": "charges",
+                    "match_attrs": ["meter_number"],
+                    "unmatched_child_group": "charges",
+                }
+            ],
+        }
+    }
+    xray = {
+        "chunks": [
+            {
+                "customChunkOutputs": {
+                    "statement_fields": {"account_number": "A-123"},
+                    "meter_fields": {"meter_number": ""},
+                    "charge_fields": {"charge_amount": ""},
+                }
+            }
+        ]
+    }
+
+    result = reassemble_custom_outputs_from_xray(
+        xray,
+        workflow_extract=workflow_extract,
+    )
+
+    assert result.diagnostics == []
+    assert result.final_output == {
+        "statement": {"account_number": "A-123"},
+        "meters": [],
+        "charges": [],
+    }
+    assert result.relationship_output == result.final_output
+
+
 def test_records_wrapper_preserves_direct_outputs_next_to_records() -> None:
     workflow_extract = {
         "workflow": {


### PR DESCRIPTION
## Summary
- read SDK-typed snake_case X-Ray aliases for custom output maps during v1 reassembly
- treat absent relationship parent/child groups as empty lists instead of fatal relationship output errors
- document the two regression cases in the custom-output-readback spec

## Evidence
- Reproduced Arcadia v1 live failure locally from saved X-Ray: old SDK returned invalid_relationship_output for meters->charges and no final extract was saved.
- Replayed the same saved X-Ray through this patch: diagnostics are empty and final_output contains statement plus empty meters/charges lists.

## Tests
- poetry run pytest -q tests/extract/test_custom_output_reassembly.py::test_reads_sdk_typed_snake_case_custom_output_maps tests/extract/test_custom_output_reassembly.py::test_missing_relationship_list_groups_are_empty_lists
- poetry run pytest -q tests/extract/test_custom_output_reassembly.py
- poetry run pytest -q tests/extract
- OPENSPEC_TELEMETRY=0 npx -y @fission-ai/openspec@1.3.1 validate --all --json
- poetry run mypy .
- poetry run pytest -rP -n auto .