### PR TITLE
Deduplicate extract relationship children

### DIFF
--- a/openspec/changes/fix-persisted-workflow-derivation/tasks.md
+++ b/openspec/changes/fix-persisted-workflow-derivation/tasks.md
@@ -31,9 +31,15 @@
 
 ## 3. Release + rollout
 
-- [ ] 3.1 Version bump + release (3.7.9) via the repo's release process (`.fern` boundary
-      untouched — `extract/` is hand-written, `.fernignore`-preserved).
-- [x] 3.2 (PR #81 — ALSO fixes the hardcoded {meters,charges} array vocabulary: array-ness now derives from workflow metadata per the archived generalize-v1 spec, UNION legacy names per owner ruling; pin bump pending 3.7.9) internal-arcadia-agents — NOW OWNS THE WILDCARD NORMALIZATION (fresh-scan P2):
+- [ ] 3.1 SDK publication was complete for the original persisted-workflow
+      derivation work via the released 3.8.4 line, but new SDK code changes
+      were added after that release for relationship child-row dedupe in
+      `src/groundx/extract/custom_outputs.py`. A new SDK PR merge and release
+      are required before deployed extract pods can prove the corrected
+      Arcadia-family 24-30 nested meter-charge shape. Runtime verification
+      remains owned by the consolidated deployment gate in
+      `internal-arcadia-agents`.
+- [x] 3.2 (PR #81 — ALSO fixes the hardcoded {meters,charges} array vocabulary: array-ness now derives from workflow metadata per the archived generalize-v1 spec, UNION legacy names per owner ruling; runtime pin/deploy verification tracked in the consolidated plan) internal-arcadia-agents — NOW OWNS THE WILDCARD NORMALIZATION (fresh-scan P2):
       `workflow_reassembly_metadata` normalizes group-repetition paths (`/g/*/f` → `/g/f`)
       when exporting `workflow_field_paths` for the reassembly parser; field-level list paths
       (still >2 tokens after the strip) get an EXPLICIT unsupported-in-reassembly error, not

--- a/src/groundx/extract/custom_outputs.py
+++ b/src/groundx/extract/custom_outputs.py
@@ -182,6 +182,7 @@ def reassemble_custom_outputs_from_xray(
         relationship_output, diagnostics = _apply_relationships(
             final_output,
             typing.cast(typing.Sequence[typing.Any], relationships),
+            workflow_extract=workflow_extract,
             diagnostics=diagnostics,
         )
         final_output = copy.deepcopy(relationship_output)
@@ -887,7 +888,11 @@ def _group_spec(
     workflow_extract: typing.Mapping[str, typing.Any],
     group_name: str,
 ) -> typing.Any:
-    for container_key in ("groups", "prepared_final_groups"):
+    for container_key in (
+        "_groundx_persisted_extract",
+        "groups",
+        "prepared_final_groups",
+    ):
         container = workflow_extract.get(container_key)
         if isinstance(container, typing.Mapping):
             group_spec = container.get(group_name)
@@ -967,6 +972,7 @@ def _apply_relationships(
     relationships: typing.Sequence[typing.Any],
     *,
     diagnostics: typing.Optional[typing.List[CustomOutputDiagnostic]] = None,
+    workflow_extract: typing.Optional[typing.Mapping[str, typing.Any]] = None,
 ) -> typing.Tuple[typing.Dict[str, typing.Any], typing.List[CustomOutputDiagnostic]]:
     result = copy.deepcopy(dict(final_output))
     diagnostics = diagnostics or []
@@ -1021,7 +1027,14 @@ def _apply_relationships(
             typing.cast(typing.List[str], match_attrs),
         )
         result[parent_group] = parent_list
-        child_list = typing.cast(typing.List[typing.Dict[str, typing.Any]], child_records)
+        child_list = _dedupe_relationship_children(
+            typing.cast(typing.List[typing.Dict[str, typing.Any]], child_records),
+            _relationship_child_unique_attrs(
+                workflow_extract,
+                child_group,
+                typing.cast(typing.List[str], match_attrs),
+            ),
+        )
         for parent in parent_list:
             parent.setdefault(parent_output_field, [])
 
@@ -1090,6 +1103,64 @@ def _dedupe_relationship_parents(
             continue
         _merge_relationship_parent(existing, parent)
     return deduped
+
+
+def _dedupe_relationship_children(
+    child_list: typing.List[typing.Dict[str, typing.Any]],
+    unique_attrs: typing.Sequence[str],
+) -> typing.List[typing.Dict[str, typing.Any]]:
+    deduped: typing.List[typing.Dict[str, typing.Any]] = []
+    by_key: typing.Dict[str, typing.Dict[str, typing.Any]] = {}
+    for child in child_list:
+        child_key = _relationship_child_dedupe_key(child, unique_attrs)
+        existing = by_key.get(child_key)
+        if existing is None:
+            by_key[child_key] = child
+            deduped.append(child)
+            continue
+        _merge_relationship_parent(existing, child)
+    return deduped
+
+
+def _relationship_child_dedupe_key(
+    child: typing.Mapping[str, typing.Any],
+    unique_attrs: typing.Sequence[str],
+) -> str:
+    if unique_attrs:
+        child_key = _match_key(child, unique_attrs)
+        if child_key:
+            return _record_key(child_key)
+    return _record_key(_plain(child))
+
+
+def _relationship_child_unique_attrs(
+    workflow_extract: typing.Optional[typing.Mapping[str, typing.Any]],
+    child_group: str,
+    match_attrs: typing.Sequence[str],
+) -> typing.Tuple[str, ...]:
+    if not isinstance(workflow_extract, typing.Mapping):
+        return ()
+
+    group_spec = _group_spec(workflow_extract, child_group)
+    if not isinstance(group_spec, typing.Mapping):
+        return ()
+
+    unique_attrs = group_spec.get("unique_attrs")
+    if not isinstance(unique_attrs, list) or not unique_attrs:
+        return ()
+
+    return _unique_strings((*match_attrs, *unique_attrs))
+
+
+def _unique_strings(values: typing.Iterable[typing.Any]) -> typing.Tuple[str, ...]:
+    seen: typing.Set[str] = set()
+    result: typing.List[str] = []
+    for value in values:
+        if not isinstance(value, str) or value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return tuple(result)
 
 
 def _merge_relationship_parent(

--- a/tests/extract/fixtures/extraction-boundary/boundary-goldens/arcadia_legacy/groundx_python_sdk_reassembly.expected.json
+++ b/tests/extract/fixtures/extraction-boundary/boundary-goldens/arcadia_legacy/groundx_python_sdk_reassembly.expected.json
@@ -1,7 +1,7 @@
 {
   "artifacts": {
     "handoff": {
-      "sha256": "cda1b44f955e4724fba1a5cd327ad9b3496bc6fe68553c20636793917b3cfd0d"
+      "sha256": "df50669d4b88745034cb907de9e1f29d8eba43c7e38f521276859e804f1b194c"
     },
     "previous_extract_chain": {
       "sha256": "2081df748c36b803a3cca6140cafa66b48110de3252b7e04192973db364fbd16"
@@ -43,8 +43,8 @@
   },
   "output": {
     "diagnostic_count": 0,
-    "final_output_sha256": "fce43e045dcae49a3fc1e7a796914f6e20d083b157d10a0ac02a7e76a6a472ae",
-    "relationship_output_sha256": "fce43e045dcae49a3fc1e7a796914f6e20d083b157d10a0ac02a7e76a6a472ae",
+    "final_output_sha256": "f3ac8bba506ad3c4c17bf75a64b2757401701a2a436e8fbec48992131c023666",
+    "relationship_output_sha256": "f3ac8bba506ad3c4c17bf75a64b2757401701a2a436e8fbec48992131c023666",
     "source_provenance_count": 339,
     "workflow_output_sha256": "a3b08ea8dcc65ff88f5d8ef8461c8ab1ec09d4b5c0730d119642c4d406fc25ee"
   },
@@ -62,7 +62,8 @@
   },
   "shape_assertions": {
     "every_parent_has_child_rows": true,
-    "has_account_level_child_rows": true,
+    "has_expected_account_child_count": true,
+    "has_expected_meter_charge_count": true,
     "has_expected_parent_count": true,
     "has_no_error_diagnostics": true,
     "has_relationship_output": true,

--- a/tests/extract/fixtures/extraction-boundary/boundary-goldens/arcadia_v1/groundx_python_sdk_reassembly.expected.json
+++ b/tests/extract/fixtures/extraction-boundary/boundary-goldens/arcadia_v1/groundx_python_sdk_reassembly.expected.json
@@ -1,7 +1,7 @@
 {
   "artifacts": {
     "handoff": {
-      "sha256": "31a32ef2749672adf7fbf0ec89cd5ec8d0de9ef885a48b97277c0f49dfe03994"
+      "sha256": "31349acbfc4cb6e8eed2511989b2355aded2fce97cc3e575c54597ec88e42e17"
     },
     "previous_extract_chain": {
       "sha256": "3bb47da435e72d4b85c0ca62292d5d17219576c71b78f3256f03c2194a294dfa"
@@ -43,8 +43,8 @@
   },
   "output": {
     "diagnostic_count": 0,
-    "final_output_sha256": "76e3388082f72951b0f82734b47488aaba2563670b1706f1d1b1359ae71da762",
-    "relationship_output_sha256": "76e3388082f72951b0f82734b47488aaba2563670b1706f1d1b1359ae71da762",
+    "final_output_sha256": "b40f6c80df3a243fe51196a5afe13b46bec7a627c87f610b9a66a94567879867",
+    "relationship_output_sha256": "b40f6c80df3a243fe51196a5afe13b46bec7a627c87f610b9a66a94567879867",
     "source_provenance_count": 339,
     "workflow_output_sha256": "a3b08ea8dcc65ff88f5d8ef8461c8ab1ec09d4b5c0730d119642c4d406fc25ee"
   },
@@ -62,7 +62,8 @@
   },
   "shape_assertions": {
     "every_parent_has_child_rows": true,
-    "has_account_level_child_rows": true,
+    "has_expected_account_child_count": true,
+    "has_expected_meter_charge_count": true,
     "has_expected_parent_count": true,
     "has_no_error_diagnostics": true,
     "has_relationship_output": true,

--- a/tests/extract/fixtures/extraction-boundary/boundary-goldens/generic_v1/groundx_python_sdk_reassembly.expected.json
+++ b/tests/extract/fixtures/extraction-boundary/boundary-goldens/generic_v1/groundx_python_sdk_reassembly.expected.json
@@ -1,7 +1,7 @@
 {
   "artifacts": {
     "handoff": {
-      "sha256": "40beb546f8510e961719c1837f111fd4cce576d52d1c6e5868edc0201312ce40"
+      "sha256": "85adfc5399ffd84c5cad8a6fd3a7048b10d4457a1cf37fcb228f3cea7b169fa1"
     },
     "previous_extract_chain": {
       "sha256": "f37bb47e0cb9d3cf7050d2c7301ce6dd4ef964fb6fcf79e4b4b9887c2746c5a4"
@@ -43,8 +43,8 @@
   },
   "output": {
     "diagnostic_count": 0,
-    "final_output_sha256": "4c04dd979864fecf57f72a6861eab84585f88c1b476cbf2858f4d39192b25c15",
-    "relationship_output_sha256": "4c04dd979864fecf57f72a6861eab84585f88c1b476cbf2858f4d39192b25c15",
+    "final_output_sha256": "7d6cabcd06ebb2bd20802181eec9cad4453ec797fdab78119a0834a2042b58af",
+    "relationship_output_sha256": "7d6cabcd06ebb2bd20802181eec9cad4453ec797fdab78119a0834a2042b58af",
     "source_provenance_count": 339,
     "workflow_output_sha256": "b8faac7e1fe78e59aed899ba562b5c403948e2ae8e2540484eb87d73326f9e3f"
   },
@@ -62,7 +62,8 @@
   },
   "shape_assertions": {
     "every_parent_has_child_rows": true,
-    "has_account_level_child_rows": true,
+    "has_expected_account_child_count": true,
+    "has_expected_meter_charge_count": true,
     "has_expected_parent_count": true,
     "has_no_error_diagnostics": true,
     "has_relationship_output": true,

--- a/tests/extract/fixtures/extraction-boundary/boundary-handoffs/arcadia_legacy/groundx_python_sdk_reassembly.handoff.json
+++ b/tests/extract/fixtures/extraction-boundary/boundary-handoffs/arcadia_legacy/groundx_python_sdk_reassembly.handoff.json
@@ -54,48 +54,6 @@
             "charge_description_as_printed": "MN State Tax on Usage",
             "meter_number": "70182657",
             "service_type": "electric"
-          },
-          {
-            "charge_amount": 55.0,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Industrial Energy Electric",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 2560.32,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Consumption",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 2218.75,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Demand",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 106.68,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Power Cost Adjustment - $.00175wh (S)",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 2.81,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "MN Sales Tax",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 249.74,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "MN State Tax on Usage",
-            "meter_number": "70182657",
-            "service_type": "electric"
           }
         ],
         "deregulation_status": "full_service",
@@ -130,27 +88,6 @@
             "charge_description_as_printed": "State Water Surcharge",
             "meter_number": "89321458",
             "service_type": "water"
-          },
-          {
-            "charge_amount": 18.43,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water Minimum Charge",
-            "meter_number": "89321458",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 223.32,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water",
-            "meter_number": "89321458",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 0.81,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "State Water Surcharge",
-            "meter_number": "89321458",
-            "service_type": "water"
           }
         ],
         "deregulation_status": "full_service",
@@ -165,20 +102,6 @@
       },
       {
         "charges": [
-          {
-            "charge_amount": 40.61,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Sewer Minimum Charge",
-            "meter_number": "89321458",
-            "service_type": "sewer"
-          },
-          {
-            "charge_amount": 275.39,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Sewer",
-            "meter_number": "89321458",
-            "service_type": "sewer"
-          },
           {
             "charge_amount": 40.61,
             "charge_amount_currency": "currency_dollars",
@@ -226,27 +149,6 @@
             "charge_description_as_printed": "State Water Surcharge",
             "meter_number": "89321459",
             "service_type": "water"
-          },
-          {
-            "charge_amount": 18.43,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water Minimum Charge",
-            "meter_number": "89321459",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 212.19,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water",
-            "meter_number": "89321459",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 0.81,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "State Water Surcharge",
-            "meter_number": "89321459",
-            "service_type": "water"
           }
         ],
         "deregulation_status": "full_service",
@@ -274,20 +176,6 @@
             "charge_description_as_printed": "Commercial Sewer",
             "meter_number": "89321459",
             "service_type": "sewer"
-          },
-          {
-            "charge_amount": 40.61,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Sewer Minimum Charge",
-            "meter_number": "89321459",
-            "service_type": "sewer"
-          },
-          {
-            "charge_amount": 262.71,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Sewer",
-            "meter_number": "89321459",
-            "service_type": "sewer"
           }
         ],
         "deregulation_status": "full_service",
@@ -302,41 +190,6 @@
       },
       {
         "charges": [
-          {
-            "charge_amount": 18.43,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water Minimum Charge",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
-          {
-            "charge_amount": 533.9,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
-          {
-            "charge_amount": 1.27,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "MN Sales Tax",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
-          {
-            "charge_amount": 36.71,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "MN State Tax on Usage",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
-          {
-            "charge_amount": 0.81,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "State Water Surcharge",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
           {
             "charge_amount": 18.43,
             "charge_amount_currency": "currency_dollars",
@@ -417,13 +270,6 @@
             "charge_amount": 0.81,
             "charge_amount_currency": "currency_dollars",
             "charge_description_as_printed": "State Water Surcharge",
-            "meter_number": "91496726",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 18.43,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water Minimum Charge",
             "meter_number": "91496726",
             "service_type": "water"
           }
@@ -562,48 +408,6 @@
             "charge_description_as_printed": "MN State Tax on Usage",
             "meter_number": "70182657",
             "service_type": "electric"
-          },
-          {
-            "charge_amount": 55.0,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Industrial Energy Electric",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 2560.32,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Consumption",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 2218.75,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Demand",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 106.68,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Power Cost Adjustment - $.00175wh (S)",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 2.81,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "MN Sales Tax",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 249.74,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "MN State Tax on Usage",
-            "meter_number": "70182657",
-            "service_type": "electric"
           }
         ],
         "deregulation_status": "full_service",
@@ -638,27 +442,6 @@
             "charge_description_as_printed": "State Water Surcharge",
             "meter_number": "89321458",
             "service_type": "water"
-          },
-          {
-            "charge_amount": 18.43,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water Minimum Charge",
-            "meter_number": "89321458",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 223.32,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water",
-            "meter_number": "89321458",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 0.81,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "State Water Surcharge",
-            "meter_number": "89321458",
-            "service_type": "water"
           }
         ],
         "deregulation_status": "full_service",
@@ -673,20 +456,6 @@
       },
       {
         "charges": [
-          {
-            "charge_amount": 40.61,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Sewer Minimum Charge",
-            "meter_number": "89321458",
-            "service_type": "sewer"
-          },
-          {
-            "charge_amount": 275.39,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Sewer",
-            "meter_number": "89321458",
-            "service_type": "sewer"
-          },
           {
             "charge_amount": 40.61,
             "charge_amount_currency": "currency_dollars",
@@ -734,27 +503,6 @@
             "charge_description_as_printed": "State Water Surcharge",
             "meter_number": "89321459",
             "service_type": "water"
-          },
-          {
-            "charge_amount": 18.43,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water Minimum Charge",
-            "meter_number": "89321459",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 212.19,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water",
-            "meter_number": "89321459",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 0.81,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "State Water Surcharge",
-            "meter_number": "89321459",
-            "service_type": "water"
           }
         ],
         "deregulation_status": "full_service",
@@ -782,20 +530,6 @@
             "charge_description_as_printed": "Commercial Sewer",
             "meter_number": "89321459",
             "service_type": "sewer"
-          },
-          {
-            "charge_amount": 40.61,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Sewer Minimum Charge",
-            "meter_number": "89321459",
-            "service_type": "sewer"
-          },
-          {
-            "charge_amount": 262.71,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Sewer",
-            "meter_number": "89321459",
-            "service_type": "sewer"
           }
         ],
         "deregulation_status": "full_service",
@@ -810,41 +544,6 @@
       },
       {
         "charges": [
-          {
-            "charge_amount": 18.43,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water Minimum Charge",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
-          {
-            "charge_amount": 533.9,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
-          {
-            "charge_amount": 1.27,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "MN Sales Tax",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
-          {
-            "charge_amount": 36.71,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "MN State Tax on Usage",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
-          {
-            "charge_amount": 0.81,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "State Water Surcharge",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
           {
             "charge_amount": 18.43,
             "charge_amount_currency": "currency_dollars",
@@ -925,13 +624,6 @@
             "charge_amount": 0.81,
             "charge_amount_currency": "currency_dollars",
             "charge_description_as_printed": "State Water Surcharge",
-            "meter_number": "91496726",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 18.43,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water Minimum Charge",
             "meter_number": "91496726",
             "service_type": "water"
           }

--- a/tests/extract/fixtures/extraction-boundary/boundary-handoffs/arcadia_v1/groundx_python_sdk_reassembly.handoff.json
+++ b/tests/extract/fixtures/extraction-boundary/boundary-handoffs/arcadia_v1/groundx_python_sdk_reassembly.handoff.json
@@ -59,48 +59,6 @@
             "charge_description_as_printed": "MN State Tax on Usage",
             "meter_number": "70182657",
             "service_type": "electric"
-          },
-          {
-            "charge_amount": 55.0,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Industrial Energy Electric",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 2560.32,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Consumption",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 2218.75,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Demand",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 106.68,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Power Cost Adjustment - $.00175wh (S)",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 2.81,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "MN Sales Tax",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 249.74,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "MN State Tax on Usage",
-            "meter_number": "70182657",
-            "service_type": "electric"
           }
         ],
         "deregulation_status": "full_service",
@@ -135,27 +93,6 @@
             "charge_description_as_printed": "State Water Surcharge",
             "meter_number": "89321458",
             "service_type": "water"
-          },
-          {
-            "charge_amount": 18.43,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water Minimum Charge",
-            "meter_number": "89321458",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 223.32,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water",
-            "meter_number": "89321458",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 0.81,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "State Water Surcharge",
-            "meter_number": "89321458",
-            "service_type": "water"
           }
         ],
         "deregulation_status": "full_service",
@@ -170,20 +107,6 @@
       },
       {
         "charges": [
-          {
-            "charge_amount": 40.61,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Sewer Minimum Charge",
-            "meter_number": "89321458",
-            "service_type": "sewer"
-          },
-          {
-            "charge_amount": 275.39,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Sewer",
-            "meter_number": "89321458",
-            "service_type": "sewer"
-          },
           {
             "charge_amount": 40.61,
             "charge_amount_currency": "currency_dollars",
@@ -231,27 +154,6 @@
             "charge_description_as_printed": "State Water Surcharge",
             "meter_number": "89321459",
             "service_type": "water"
-          },
-          {
-            "charge_amount": 18.43,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water Minimum Charge",
-            "meter_number": "89321459",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 212.19,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water",
-            "meter_number": "89321459",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 0.81,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "State Water Surcharge",
-            "meter_number": "89321459",
-            "service_type": "water"
           }
         ],
         "deregulation_status": "full_service",
@@ -279,20 +181,6 @@
             "charge_description_as_printed": "Commercial Sewer",
             "meter_number": "89321459",
             "service_type": "sewer"
-          },
-          {
-            "charge_amount": 40.61,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Sewer Minimum Charge",
-            "meter_number": "89321459",
-            "service_type": "sewer"
-          },
-          {
-            "charge_amount": 262.71,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Sewer",
-            "meter_number": "89321459",
-            "service_type": "sewer"
           }
         ],
         "deregulation_status": "full_service",
@@ -307,41 +195,6 @@
       },
       {
         "charges": [
-          {
-            "charge_amount": 18.43,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water Minimum Charge",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
-          {
-            "charge_amount": 533.9,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
-          {
-            "charge_amount": 1.27,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "MN Sales Tax",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
-          {
-            "charge_amount": 36.71,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "MN State Tax on Usage",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
-          {
-            "charge_amount": 0.81,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "State Water Surcharge",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
           {
             "charge_amount": 18.43,
             "charge_amount_currency": "currency_dollars",
@@ -422,13 +275,6 @@
             "charge_amount": 0.81,
             "charge_amount_currency": "currency_dollars",
             "charge_description_as_printed": "State Water Surcharge",
-            "meter_number": "91496726",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 18.43,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water Minimum Charge",
             "meter_number": "91496726",
             "service_type": "water"
           }
@@ -565,48 +411,6 @@
             "charge_description_as_printed": "MN State Tax on Usage",
             "meter_number": "70182657",
             "service_type": "electric"
-          },
-          {
-            "charge_amount": 55.0,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Industrial Energy Electric",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 2560.32,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Consumption",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 2218.75,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Demand",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 106.68,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Power Cost Adjustment - $.00175wh (S)",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 2.81,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "MN Sales Tax",
-            "meter_number": "70182657",
-            "service_type": "electric"
-          },
-          {
-            "charge_amount": 249.74,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "MN State Tax on Usage",
-            "meter_number": "70182657",
-            "service_type": "electric"
           }
         ],
         "deregulation_status": "full_service",
@@ -641,27 +445,6 @@
             "charge_description_as_printed": "State Water Surcharge",
             "meter_number": "89321458",
             "service_type": "water"
-          },
-          {
-            "charge_amount": 18.43,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water Minimum Charge",
-            "meter_number": "89321458",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 223.32,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water",
-            "meter_number": "89321458",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 0.81,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "State Water Surcharge",
-            "meter_number": "89321458",
-            "service_type": "water"
           }
         ],
         "deregulation_status": "full_service",
@@ -676,20 +459,6 @@
       },
       {
         "charges": [
-          {
-            "charge_amount": 40.61,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Sewer Minimum Charge",
-            "meter_number": "89321458",
-            "service_type": "sewer"
-          },
-          {
-            "charge_amount": 275.39,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Sewer",
-            "meter_number": "89321458",
-            "service_type": "sewer"
-          },
           {
             "charge_amount": 40.61,
             "charge_amount_currency": "currency_dollars",
@@ -737,27 +506,6 @@
             "charge_description_as_printed": "State Water Surcharge",
             "meter_number": "89321459",
             "service_type": "water"
-          },
-          {
-            "charge_amount": 18.43,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water Minimum Charge",
-            "meter_number": "89321459",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 212.19,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water",
-            "meter_number": "89321459",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 0.81,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "State Water Surcharge",
-            "meter_number": "89321459",
-            "service_type": "water"
           }
         ],
         "deregulation_status": "full_service",
@@ -785,20 +533,6 @@
             "charge_description_as_printed": "Commercial Sewer",
             "meter_number": "89321459",
             "service_type": "sewer"
-          },
-          {
-            "charge_amount": 40.61,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Sewer Minimum Charge",
-            "meter_number": "89321459",
-            "service_type": "sewer"
-          },
-          {
-            "charge_amount": 262.71,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Sewer",
-            "meter_number": "89321459",
-            "service_type": "sewer"
           }
         ],
         "deregulation_status": "full_service",
@@ -813,41 +547,6 @@
       },
       {
         "charges": [
-          {
-            "charge_amount": 18.43,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water Minimum Charge",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
-          {
-            "charge_amount": 533.9,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
-          {
-            "charge_amount": 1.27,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "MN Sales Tax",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
-          {
-            "charge_amount": 36.71,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "MN State Tax on Usage",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
-          {
-            "charge_amount": 0.81,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "State Water Surcharge",
-            "meter_number": "91496724",
-            "service_type": "irrigation"
-          },
           {
             "charge_amount": 18.43,
             "charge_amount_currency": "currency_dollars",
@@ -928,13 +627,6 @@
             "charge_amount": 0.81,
             "charge_amount_currency": "currency_dollars",
             "charge_description_as_printed": "State Water Surcharge",
-            "meter_number": "91496726",
-            "service_type": "water"
-          },
-          {
-            "charge_amount": 18.43,
-            "charge_amount_currency": "currency_dollars",
-            "charge_description_as_printed": "Commercial Water Minimum Charge",
             "meter_number": "91496726",
             "service_type": "water"
           }

--- a/tests/extract/fixtures/extraction-boundary/boundary-handoffs/generic_v1/groundx_python_sdk_reassembly.handoff.json
+++ b/tests/extract/fixtures/extraction-boundary/boundary-handoffs/generic_v1/groundx_python_sdk_reassembly.handoff.json
@@ -70,48 +70,6 @@
             "generic_attr_28": 249.74,
             "generic_attr_29": "currency_dollars",
             "generic_attr_30": "MN State Tax on Usage"
-          },
-          {
-            "generic_attr_18": "70182657",
-            "generic_attr_23": "electric",
-            "generic_attr_28": 55.0,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Industrial Energy Electric"
-          },
-          {
-            "generic_attr_18": "70182657",
-            "generic_attr_23": "electric",
-            "generic_attr_28": 2560.32,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Consumption"
-          },
-          {
-            "generic_attr_18": "70182657",
-            "generic_attr_23": "electric",
-            "generic_attr_28": 2218.75,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Demand"
-          },
-          {
-            "generic_attr_18": "70182657",
-            "generic_attr_23": "electric",
-            "generic_attr_28": 106.68,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Power Cost Adjustment - $.00175wh (S)"
-          },
-          {
-            "generic_attr_18": "70182657",
-            "generic_attr_23": "electric",
-            "generic_attr_28": 2.81,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "MN Sales Tax"
-          },
-          {
-            "generic_attr_18": "70182657",
-            "generic_attr_23": "electric",
-            "generic_attr_28": 249.74,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "MN State Tax on Usage"
           }
         ]
       },
@@ -126,27 +84,6 @@
         "generic_attr_25": "gallons",
         "generic_attr_26": 42303.0,
         "generic_group_c": [
-          {
-            "generic_attr_18": "89321458",
-            "generic_attr_23": "water",
-            "generic_attr_28": 18.43,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Water Minimum Charge"
-          },
-          {
-            "generic_attr_18": "89321458",
-            "generic_attr_23": "water",
-            "generic_attr_28": 223.32,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Water"
-          },
-          {
-            "generic_attr_18": "89321458",
-            "generic_attr_23": "water",
-            "generic_attr_28": 0.81,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "State Water Surcharge"
-          },
           {
             "generic_attr_18": "89321458",
             "generic_attr_23": "water",
@@ -194,20 +131,6 @@
             "generic_attr_28": 275.39,
             "generic_attr_29": "currency_dollars",
             "generic_attr_30": "Commercial Sewer"
-          },
-          {
-            "generic_attr_18": "89321458",
-            "generic_attr_23": "sewer",
-            "generic_attr_28": 40.61,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Sewer Minimum Charge"
-          },
-          {
-            "generic_attr_18": "89321458",
-            "generic_attr_23": "sewer",
-            "generic_attr_28": 275.39,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Sewer"
           }
         ]
       },
@@ -242,27 +165,6 @@
             "generic_attr_28": 0.81,
             "generic_attr_29": "currency_dollars",
             "generic_attr_30": "State Water Surcharge"
-          },
-          {
-            "generic_attr_18": "89321459",
-            "generic_attr_23": "water",
-            "generic_attr_28": 18.43,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Water Minimum Charge"
-          },
-          {
-            "generic_attr_18": "89321459",
-            "generic_attr_23": "water",
-            "generic_attr_28": 212.19,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Water"
-          },
-          {
-            "generic_attr_18": "89321459",
-            "generic_attr_23": "water",
-            "generic_attr_28": 0.81,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "State Water Surcharge"
           }
         ]
       },
@@ -277,20 +179,6 @@
         "generic_attr_25": "gallons",
         "generic_attr_26": 40356.0,
         "generic_group_c": [
-          {
-            "generic_attr_18": "89321459",
-            "generic_attr_23": "sewer",
-            "generic_attr_28": 40.61,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Sewer Minimum Charge"
-          },
-          {
-            "generic_attr_18": "89321459",
-            "generic_attr_23": "sewer",
-            "generic_attr_28": 262.71,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Sewer"
-          },
           {
             "generic_attr_18": "89321459",
             "generic_attr_23": "sewer",
@@ -318,41 +206,6 @@
         "generic_attr_25": "gallons",
         "generic_attr_26": 96600.0,
         "generic_group_c": [
-          {
-            "generic_attr_18": "91496724",
-            "generic_attr_23": "irrigation",
-            "generic_attr_28": 18.43,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Water Minimum Charge"
-          },
-          {
-            "generic_attr_18": "91496724",
-            "generic_attr_23": "irrigation",
-            "generic_attr_28": 533.9,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Water"
-          },
-          {
-            "generic_attr_18": "91496724",
-            "generic_attr_23": "irrigation",
-            "generic_attr_28": 1.27,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "MN Sales Tax"
-          },
-          {
-            "generic_attr_18": "91496724",
-            "generic_attr_23": "irrigation",
-            "generic_attr_28": 36.71,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "MN State Tax on Usage"
-          },
-          {
-            "generic_attr_18": "91496724",
-            "generic_attr_23": "irrigation",
-            "generic_attr_28": 0.81,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "State Water Surcharge"
-          },
           {
             "generic_attr_18": "91496724",
             "generic_attr_23": "irrigation",
@@ -435,13 +288,6 @@
             "generic_attr_28": 0.81,
             "generic_attr_29": "currency_dollars",
             "generic_attr_30": "State Water Surcharge"
-          },
-          {
-            "generic_attr_18": "91496726",
-            "generic_attr_23": "water",
-            "generic_attr_28": 18.43,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Water Minimum Charge"
           }
         ]
       },
@@ -576,48 +422,6 @@
             "generic_attr_28": 249.74,
             "generic_attr_29": "currency_dollars",
             "generic_attr_30": "MN State Tax on Usage"
-          },
-          {
-            "generic_attr_18": "70182657",
-            "generic_attr_23": "electric",
-            "generic_attr_28": 55.0,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Industrial Energy Electric"
-          },
-          {
-            "generic_attr_18": "70182657",
-            "generic_attr_23": "electric",
-            "generic_attr_28": 2560.32,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Consumption"
-          },
-          {
-            "generic_attr_18": "70182657",
-            "generic_attr_23": "electric",
-            "generic_attr_28": 2218.75,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Demand"
-          },
-          {
-            "generic_attr_18": "70182657",
-            "generic_attr_23": "electric",
-            "generic_attr_28": 106.68,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Power Cost Adjustment - $.00175wh (S)"
-          },
-          {
-            "generic_attr_18": "70182657",
-            "generic_attr_23": "electric",
-            "generic_attr_28": 2.81,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "MN Sales Tax"
-          },
-          {
-            "generic_attr_18": "70182657",
-            "generic_attr_23": "electric",
-            "generic_attr_28": 249.74,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "MN State Tax on Usage"
           }
         ]
       },
@@ -632,27 +436,6 @@
         "generic_attr_25": "gallons",
         "generic_attr_26": 42303.0,
         "generic_group_c": [
-          {
-            "generic_attr_18": "89321458",
-            "generic_attr_23": "water",
-            "generic_attr_28": 18.43,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Water Minimum Charge"
-          },
-          {
-            "generic_attr_18": "89321458",
-            "generic_attr_23": "water",
-            "generic_attr_28": 223.32,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Water"
-          },
-          {
-            "generic_attr_18": "89321458",
-            "generic_attr_23": "water",
-            "generic_attr_28": 0.81,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "State Water Surcharge"
-          },
           {
             "generic_attr_18": "89321458",
             "generic_attr_23": "water",
@@ -700,20 +483,6 @@
             "generic_attr_28": 275.39,
             "generic_attr_29": "currency_dollars",
             "generic_attr_30": "Commercial Sewer"
-          },
-          {
-            "generic_attr_18": "89321458",
-            "generic_attr_23": "sewer",
-            "generic_attr_28": 40.61,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Sewer Minimum Charge"
-          },
-          {
-            "generic_attr_18": "89321458",
-            "generic_attr_23": "sewer",
-            "generic_attr_28": 275.39,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Sewer"
           }
         ]
       },
@@ -748,27 +517,6 @@
             "generic_attr_28": 0.81,
             "generic_attr_29": "currency_dollars",
             "generic_attr_30": "State Water Surcharge"
-          },
-          {
-            "generic_attr_18": "89321459",
-            "generic_attr_23": "water",
-            "generic_attr_28": 18.43,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Water Minimum Charge"
-          },
-          {
-            "generic_attr_18": "89321459",
-            "generic_attr_23": "water",
-            "generic_attr_28": 212.19,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Water"
-          },
-          {
-            "generic_attr_18": "89321459",
-            "generic_attr_23": "water",
-            "generic_attr_28": 0.81,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "State Water Surcharge"
           }
         ]
       },
@@ -783,20 +531,6 @@
         "generic_attr_25": "gallons",
         "generic_attr_26": 40356.0,
         "generic_group_c": [
-          {
-            "generic_attr_18": "89321459",
-            "generic_attr_23": "sewer",
-            "generic_attr_28": 40.61,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Sewer Minimum Charge"
-          },
-          {
-            "generic_attr_18": "89321459",
-            "generic_attr_23": "sewer",
-            "generic_attr_28": 262.71,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Sewer"
-          },
           {
             "generic_attr_18": "89321459",
             "generic_attr_23": "sewer",
@@ -824,41 +558,6 @@
         "generic_attr_25": "gallons",
         "generic_attr_26": 96600.0,
         "generic_group_c": [
-          {
-            "generic_attr_18": "91496724",
-            "generic_attr_23": "irrigation",
-            "generic_attr_28": 18.43,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Water Minimum Charge"
-          },
-          {
-            "generic_attr_18": "91496724",
-            "generic_attr_23": "irrigation",
-            "generic_attr_28": 533.9,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Water"
-          },
-          {
-            "generic_attr_18": "91496724",
-            "generic_attr_23": "irrigation",
-            "generic_attr_28": 1.27,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "MN Sales Tax"
-          },
-          {
-            "generic_attr_18": "91496724",
-            "generic_attr_23": "irrigation",
-            "generic_attr_28": 36.71,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "MN State Tax on Usage"
-          },
-          {
-            "generic_attr_18": "91496724",
-            "generic_attr_23": "irrigation",
-            "generic_attr_28": 0.81,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "State Water Surcharge"
-          },
           {
             "generic_attr_18": "91496724",
             "generic_attr_23": "irrigation",
@@ -941,13 +640,6 @@
             "generic_attr_28": 0.81,
             "generic_attr_29": "currency_dollars",
             "generic_attr_30": "State Water Surcharge"
-          },
-          {
-            "generic_attr_18": "91496726",
-            "generic_attr_23": "water",
-            "generic_attr_28": 18.43,
-            "generic_attr_29": "currency_dollars",
-            "generic_attr_30": "Commercial Water Minimum Charge"
           }
         ]
       },

--- a/tests/extract/test_custom_output_reassembly.py
+++ b/tests/extract/test_custom_output_reassembly.py
@@ -147,6 +147,224 @@ def test_reassembles_records_wrapper_to_final_relationship_output() -> None:
     }
 
 
+def test_relationship_dedupes_child_rows_by_match_and_unique_attrs() -> None:
+    workflow_extract = {
+        "_groundx_persisted_extract": {
+            "charges": {
+                "match_attrs": ["meter_number"],
+                "unique_attrs": ["description", "amount"],
+            }
+        },
+        "workflow": {
+            "custom_steps": [
+                {"name": "meter_rows", "level": "chunk", "kind": "summary"},
+                {"name": "charge_rows", "level": "chunk", "kind": "keys"},
+            ],
+            "output_routes": [
+                {
+                    "workflow_group": "meters",
+                    "workflow_field": "meter_number",
+                    "final_path": "/meters/meter_number",
+                    "step_name": "meter_rows",
+                    "level": "chunk",
+                    "output_map": "customChunkOutputs",
+                    "output_key": "meter_number",
+                },
+                {
+                    "workflow_group": "charges",
+                    "workflow_field": "meter_number",
+                    "final_path": "/charges/meter_number",
+                    "step_name": "charge_rows",
+                    "level": "chunk",
+                    "output_map": "customChunkOutputs",
+                    "output_key": "meter_number",
+                },
+                {
+                    "workflow_group": "charges",
+                    "workflow_field": "description",
+                    "final_path": "/charges/description",
+                    "step_name": "charge_rows",
+                    "level": "chunk",
+                    "output_map": "customChunkOutputs",
+                    "output_key": "description",
+                },
+                {
+                    "workflow_group": "charges",
+                    "workflow_field": "amount",
+                    "final_path": "/charges/amount",
+                    "step_name": "charge_rows",
+                    "level": "chunk",
+                    "output_map": "customChunkOutputs",
+                    "output_key": "amount",
+                },
+            ],
+            "output_relationships": [
+                {
+                    "parent_group": "meters",
+                    "child_group": "charges",
+                    "parent_output_field": "charges",
+                    "match_attrs": ["meter_number"],
+                    "unmatched_child_group": "charges",
+                }
+            ],
+        },
+    }
+    xray = {
+        "chunks": [
+            {
+                "customChunkOutputs": {
+                    "meter_rows": {"_records": [{"meter_number": "M-1"}]},
+                    "charge_rows": {
+                        "_records": [
+                            {
+                                "meter_number": "M-1",
+                                "description": "Energy",
+                                "amount": 10,
+                            },
+                            {
+                                "meter_number": "M-1",
+                                "description": "Energy",
+                                "amount": 10,
+                            },
+                            {
+                                "meter_number": "M-1",
+                                "description": "Demand",
+                                "amount": 20,
+                            },
+                            {
+                                "description": "Account fee",
+                                "amount": 3,
+                            },
+                            {
+                                "description": "Account fee",
+                                "amount": 3,
+                            },
+                        ]
+                    },
+                }
+            }
+        ]
+    }
+
+    result = reassemble_custom_outputs_from_xray(
+        xray,
+        workflow_extract=workflow_extract,
+    )
+
+    assert result.diagnostics == []
+    assert result.final_output == {
+        "meters": [
+            {
+                "meter_number": "M-1",
+                "charges": [
+                    {
+                        "meter_number": "M-1",
+                        "description": "Energy",
+                        "amount": 10,
+                    },
+                    {
+                        "meter_number": "M-1",
+                        "description": "Demand",
+                        "amount": 20,
+                    },
+                ],
+            }
+        ],
+        "charges": [{"description": "Account fee", "amount": 3}],
+    }
+    assert result.relationship_output == result.final_output
+
+
+def test_relationship_dedupes_exact_child_rows_without_unique_attrs() -> None:
+    workflow_extract = {
+        "_groundx_persisted_extract": {
+            "charges": {
+                "match_attrs": ["meter_number"],
+            }
+        },
+        "workflow": {
+            "custom_steps": [
+                {"name": "meter_rows", "level": "chunk", "kind": "summary"},
+                {"name": "charge_rows", "level": "chunk", "kind": "keys"},
+            ],
+            "output_routes": [
+                {
+                    "workflow_group": "meters",
+                    "workflow_field": "meter_number",
+                    "final_path": "/meters/meter_number",
+                    "step_name": "meter_rows",
+                    "level": "chunk",
+                    "output_map": "customChunkOutputs",
+                    "output_key": "meter_number",
+                },
+                {
+                    "workflow_group": "charges",
+                    "workflow_field": "meter_number",
+                    "final_path": "/charges/meter_number",
+                    "step_name": "charge_rows",
+                    "level": "chunk",
+                    "output_map": "customChunkOutputs",
+                    "output_key": "meter_number",
+                },
+                {
+                    "workflow_group": "charges",
+                    "workflow_field": "amount",
+                    "final_path": "/charges/amount",
+                    "step_name": "charge_rows",
+                    "level": "chunk",
+                    "output_map": "customChunkOutputs",
+                    "output_key": "amount",
+                },
+            ],
+            "output_relationships": [
+                {
+                    "parent_group": "meters",
+                    "child_group": "charges",
+                    "parent_output_field": "charges",
+                    "match_attrs": ["meter_number"],
+                    "unmatched_child_group": "charges",
+                }
+            ],
+        },
+    }
+    xray = {
+        "chunks": [
+            {
+                "customChunkOutputs": {
+                    "meter_rows": {"_records": [{"meter_number": "M-1"}]},
+                    "charge_rows": {
+                        "_records": [
+                            {"meter_number": "M-1", "amount": 10},
+                            {"meter_number": "M-1", "amount": 10},
+                            {"meter_number": "M-1", "amount": 20},
+                        ]
+                    },
+                }
+            }
+        ]
+    }
+
+    result = reassemble_custom_outputs_from_xray(
+        xray,
+        workflow_extract=workflow_extract,
+    )
+
+    assert result.diagnostics == []
+    assert result.final_output == {
+        "meters": [
+            {
+                "meter_number": "M-1",
+                "charges": [
+                    {"meter_number": "M-1", "amount": 10},
+                    {"meter_number": "M-1", "amount": 20},
+                ],
+            }
+        ],
+        "charges": [],
+    }
+    assert result.relationship_output == result.final_output
+
+
 def test_chained_relationships_are_order_independent() -> None:
     workflow_extract = {
         "workflow": {

--- a/tests/extract/test_extraction_boundary_reassembly.py
+++ b/tests/extract/test_extraction_boundary_reassembly.py
@@ -111,6 +111,76 @@ def test_utility_shape_accepts_reviewed_meter_range(
     assert assertions["has_expected_parent_count"] is expected
 
 
+@pytest.mark.parametrize(
+    ("meter_charge_count", "expected"),
+    [
+        (23, False),
+        (24, True),
+        (28, True),
+        (30, True),
+        (31, False),
+        (50, False),
+    ],
+)
+def test_utility_shape_accepts_reviewed_meter_charge_range(
+    meter_charge_count: int,
+    expected: bool,
+) -> None:
+    final_output: typing.Dict[str, typing.Any] = {
+        "meters": [{"charges": []} for _unused in range(8)],
+        "charges": [],
+    }
+    for index in range(meter_charge_count):
+        final_output["meters"][index % 8]["charges"].append(
+            {"charge_amount": index}
+        )
+    final_output.update({f"statement_field_{index}": index for index in range(14)})
+
+    assertions = _shape_assertions(
+        "arcadia_v1",
+        final_output,
+        diagnostics=[],
+        relationship_output={"meters": final_output["meters"]},
+    )
+
+    assert assertions["has_expected_meter_charge_count"] is expected
+
+
+@pytest.mark.parametrize(
+    ("account_charge_count", "expected"),
+    [
+        (0, True),
+        (1, True),
+        (3, True),
+        (4, False),
+    ],
+)
+def test_utility_shape_accepts_reviewed_account_charge_range(
+    account_charge_count: int,
+    expected: bool,
+) -> None:
+    final_output: typing.Dict[str, typing.Any] = {
+        "meters": [
+            {"charges": [{"charge_amount": meter_index}]}
+            for meter_index in range(8)
+        ],
+        "charges": [
+            {"charge_amount": charge_index}
+            for charge_index in range(account_charge_count)
+        ],
+    }
+    final_output.update({f"statement_field_{index}": index for index in range(14)})
+
+    assertions = _shape_assertions(
+        "arcadia_v1",
+        final_output,
+        diagnostics=[],
+        relationship_output={"meters": final_output["meters"]},
+    )
+
+    assert assertions["has_expected_account_child_count"] is expected
+
+
 def _write_boundary_artifacts(
     tmp_path: pathlib.Path,
     surface: str,
@@ -320,8 +390,12 @@ def _shape_assertions(
                 and len(parent[child_field]) >= 1
                 for parent in parent_records
             ),
-            "has_account_level_child_rows": isinstance(account_children, list)
-            and len(account_children) >= 1,
+            "has_expected_account_child_count": isinstance(account_children, list)
+            and 0 <= len(account_children) <= 3,
+            "has_expected_meter_charge_count": isinstance(parent_records, list)
+            and 24
+            <= _nested_child_count(parent_records, child_field)
+            <= 30,
             "has_statement_fields": _statement_field_count(surface, final_output) >= 14,
             "has_relationship_output": bool(relationship_output),
         }
@@ -350,6 +424,18 @@ def _statement_field_count(
         )
     excluded = {"meters", "charges"}
     return sum(1 for key in final_output if key not in excluded)
+
+
+def _nested_child_count(
+    parent_records: typing.Sequence[typing.Mapping[str, typing.Any]],
+    child_field: str,
+) -> int:
+    child_count = 0
+    for parent in parent_records:
+        children = parent.get(child_field)
+        if isinstance(children, list):
+            child_count += len(children)
+    return child_count
 
 
 def _leaf_count(value: typing.Any) -> int:


### PR DESCRIPTION
## Summary
- Deduplicate child rows while applying workflow relationships in extract reassembly.
- Use child unique attributes plus relationship match attributes when unique attributes exist.
- Fall back to exact child-row dedupe for legacy workflows without explicit unique attributes.
- Regenerate Arcadia legacy, Arcadia v1, and generic v1 boundary fixtures so they preserve the reviewed 8-meter / 28-meter-charge shape.

## Root cause
SDK reassembly deduped parent meter rows but did not dedupe child charge rows before assigning them to meters. Arcadia-family workflows could therefore attach duplicate raw charge rows into the final nested meter-charge output.

## Validation
- `PYTHONPATH=src pytest -q tests/extract/test_custom_output_reassembly.py tests/extract/test_extraction_boundary_reassembly.py` -> 37 passed, 1 warning.
- `poetry run ruff check src/groundx/extract/custom_outputs.py tests/extract/test_custom_output_reassembly.py tests/extract/test_extraction_boundary_reassembly.py` -> passed.
- `OPENSPEC_TELEMETRY=0 npx -y @fission-ai/openspec@1.3.1 validate fix-persisted-workflow-derivation --strict` -> passed.
- `git diff --check` -> passed.

## Deployment note
This is not in groundx-python 3.8.4. A new SDK release is required before internal Arcadia extract pods can prove this fix live.