### PR TITLE
Handle trailing JSON closers in extract responses

### DIFF
--- a/src/groundx/extract/utility/utility.py
+++ b/src/groundx/extract/utility/utility.py
@@ -1,12 +1,65 @@
 import typing
 
 
+def _complete_json_document_end(txt: str) -> typing.Optional[int]:
+    stack: typing.List[str] = []
+    in_string = False
+    escaped = False
+    started = False
+
+    for idx, char in enumerate(txt):
+        if not started:
+            if char.isspace():
+                continue
+            if char == "{":
+                stack.append("}")
+                started = True
+                continue
+            if char == "[":
+                stack.append("]")
+                started = True
+                continue
+            return None
+
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            stack.append("}")
+        elif char == "[":
+            stack.append("]")
+        elif char in "}]":
+            if not stack:
+                return idx
+            if char != stack[-1]:
+                return None
+            stack.pop()
+            if not stack:
+                return idx + 1
+
+    return None
+
+
 def clean_json(txt: str) -> str:
     for p in ("json```\n", "```json\n", "json\n"):
         if txt.startswith(p):
             txt = txt[len(p) :]
     if txt.endswith("```"):
         txt = txt[:-3]
+    txt = txt.strip()
+    document_end = _complete_json_document_end(txt)
+    if document_end is not None and document_end < len(txt):
+        trailing = txt[document_end:].strip()
+        if trailing and all(char in "}]" for char in trailing):
+            txt = txt[:document_end]
     return txt.strip()
 
 

--- a/tests/extract/utility/test_utility.py
+++ b/tests/extract/utility/test_utility.py
@@ -1,6 +1,21 @@
-import typing, unittest
+import json
+import typing
+import unittest
 
-from groundx.extract.utility.utility import coerce_numeric_string
+from groundx.extract.utility.utility import clean_json, coerce_numeric_string
+
+
+class TestUtilCleanJson(unittest.TestCase):
+    def test_trims_only_unmatched_trailing_json_closers(self) -> None:
+        cleaned = clean_json('{"plan_name": "Example", "items": [1, 2]}]')
+
+        self.assertEqual(
+            json.loads(cleaned),
+            {"plan_name": "Example", "items": [1, 2]},
+        )
+
+    def test_preserves_trailing_non_json_text(self) -> None:
+        self.assertEqual(clean_json('{"plan_name": "Example"} thanks'), '{"plan_name": "Example"} thanks')
 
 
 class TestUtilCoerceNumericString(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Trims unmatched trailing JSON closers after the first complete JSON document in extract-agent responses.
- Keeps trailing prose/non-JSON text as a parse failure instead of silently truncating it.
- Adds parser regression coverage for the ADP failure shape.

## Root Cause

The ADP run reached the extract agent and produced a nearly valid JSON object with one extra trailing `]`. `clean_json` only stripped markdown fences, so typed parsing failed with a JSON decode error even though the useful response body was complete.

## Validation

- `poetry run pytest tests/extract/utility/test_utility.py tests/extract/agents/test_agent_model_settings.py tests/extract/agents/test_agent_tool_image_transport.py -q`
- `poetry run mypy .`
- `git diff --check`

## Deployment Note

This needs to be released as the next `groundx-python` patch after 3.8.5 before the internal Arcadia extraction image is rebuilt for four-case E2E.