### PR TITLE
Add extract agent trace callback

### DIFF
--- a/src/groundx/extract/agents/agent.py
+++ b/src/groundx/extract/agents/agent.py
@@ -52,6 +52,21 @@ Return only your response using the `final_answer` tool format:
 """
 
 SUPPORTED_IMAGE_TRANSPORTS = {"pil", "data_url", "remote_url"}
+AgentTraceCallback = typing.Callable[[typing.Dict[str, typing.Any]], None]
+
+
+def _emit_agent_trace(
+    log: Logger,
+    trace_callback: typing.Optional[AgentTraceCallback],
+    event: str,
+    **payload: typing.Any,
+) -> None:
+    if trace_callback is None:
+        return
+    try:
+        trace_callback({"event": event, **payload})
+    except Exception as exc:
+        log.debug_msg(f"agent trace callback failed: {exc.__class__.__name__}: {exc}")
 
 
 @dataclass
@@ -233,6 +248,7 @@ class AgentTool(ToolCallingAgent):
         type: str = "",
         image_urls: typing.Optional[typing.Sequence[str]] = None,
         image_transport: typing.Optional[str] = None,
+        trace_callback: typing.Optional[AgentTraceCallback] = None,
     ) -> typing.Any:
         selected_image_transport = image_transport or self.image_transport
         transport = self._validate_image_inputs(
@@ -240,22 +256,59 @@ class AgentTool(ToolCallingAgent):
             image_urls=image_urls,
             image_transport=selected_image_transport,
         )
+        task = conflict + prompt_suffix
+        trace_base = {
+            "attempt": attempt,
+            "image_transport": transport,
+            "request_type": type,
+        }
+        _emit_agent_trace(
+            self.log,
+            trace_callback,
+            "prompt",
+            **trace_base,
+            prompt=task,
+        )
         if transport in {"data_url", "remote_url"} and image_urls:
             res = self._run_with_image_urls(
-                conflict + prompt_suffix,
+                task,
                 list(image_urls or []),
                 image_transport=transport,
             )
         else:
             res = super().run(  # pyright: ignore[reportUnknownMemberType]
-                conflict + prompt_suffix,
+                task,
                 images=images,
             )
 
+        _emit_agent_trace(
+            self.log,
+            trace_callback,
+            "raw_response",
+            **trace_base,
+            value=res,
+        )
         try:
-            return process_response(res=res, expected_types=expected_types)
+            parsed = process_response(res=res, expected_types=expected_types)
+            _emit_agent_trace(
+                self.log,
+                trace_callback,
+                "parsed_response",
+                **trace_base,
+                value=parsed,
+            )
+            return parsed
 
         except Exception as e:
+            _emit_agent_trace(
+                self.log,
+                trace_callback,
+                "parse_error",
+                **trace_base,
+                error_message=str(e),
+                error_type=e.__class__.__name__,
+                raw_response=res,
+            )
             if attempt > 2:
                 raise TypeError(
                     f"agent process result is not of expected type(s) {expected_types!r}: [{e}]\n\n{res}"
@@ -273,6 +326,7 @@ class AgentTool(ToolCallingAgent):
                 type,
                 image_urls=image_urls,
                 image_transport=transport,
+                trace_callback=trace_callback,
             )
 
     def _run_with_image_urls(

--- a/tests/extract/agents/test_agent_tool_trace.py
+++ b/tests/extract/agents/test_agent_tool_trace.py
@@ -1,0 +1,105 @@
+import typing
+
+import pytest
+
+try:
+    from smolagents import ToolCallingAgent
+except ModuleNotFoundError:
+    pytest.skip("smolagents extra is not installed", allow_module_level=True)
+
+from groundx.extract.agents.agent import AgentTool, prompt_suffix
+from groundx.extract.services.logger import Logger
+from groundx.extract.settings.settings import AgentSettings
+
+
+def _agent() -> AgentTool:
+    return AgentTool(
+        AgentSettings(api_key="test-key", model_id="test-model", max_steps=1),
+        Logger("agent-tool-trace", "error"),
+    )
+
+
+def test_agent_tool_trace_callback_records_exact_prompt_raw_and_parsed_response(
+    monkeypatch,
+) -> None:
+    events: typing.List[typing.Dict[str, typing.Any]] = []
+
+    def fake_run(
+        self: typing.Any,
+        task: str,
+        images: typing.List[typing.Any],
+    ) -> str:
+        assert images == []
+        return '{"answer": {"type": {"ok": true}}}'
+
+    monkeypatch.setattr(ToolCallingAgent, "run", fake_run)
+
+    result = _agent().process(
+        "trace me",
+        images=[],
+        type="qa_statement",
+        trace_callback=events.append,
+    )
+
+    assert result == {"ok": True}
+    assert events == [
+        {
+            "attempt": 0,
+            "event": "prompt",
+            "image_transport": "pil",
+            "prompt": "trace me" + prompt_suffix,
+            "request_type": "qa_statement",
+        },
+        {
+            "attempt": 0,
+            "event": "raw_response",
+            "image_transport": "pil",
+            "request_type": "qa_statement",
+            "value": '{"answer": {"type": {"ok": true}}}',
+        },
+        {
+            "attempt": 0,
+            "event": "parsed_response",
+            "image_transport": "pil",
+            "request_type": "qa_statement",
+            "value": {"ok": True},
+        },
+    ]
+
+
+def test_agent_tool_trace_callback_records_parse_error(monkeypatch) -> None:
+    events: typing.List[typing.Dict[str, typing.Any]] = []
+
+    def fake_run(
+        self: typing.Any,
+        task: str,
+        images: typing.List[typing.Any],
+    ) -> str:
+        return "{not json"
+
+    monkeypatch.setattr(ToolCallingAgent, "run", fake_run)
+
+    with pytest.raises(TypeError, match="agent process result is not of expected type"):
+        _agent().process(
+            "bad json",
+            images=[],
+            attempt=3,
+            type="qa_statement",
+            trace_callback=events.append,
+        )
+
+    assert events[0]["event"] == "prompt"
+    assert events[0]["prompt"] == "bad json" + prompt_suffix
+    assert events[1] == {
+        "attempt": 3,
+        "event": "raw_response",
+        "image_transport": "pil",
+        "request_type": "qa_statement",
+        "value": "{not json",
+    }
+    assert events[2]["event"] == "parse_error"
+    assert events[2]["attempt"] == 3
+    assert events[2]["image_transport"] == "pil"
+    assert events[2]["request_type"] == "qa_statement"
+    assert events[2]["raw_response"] == "{not json"
+    assert events[2]["error_type"] == "JSONDecodeError"


### PR DESCRIPTION
## Summary

Adds an optional `trace_callback` hook to `AgentTool.process(...)` so hosted extract services can capture the exact prompt sent to the agent, the raw provider response before SDK parsing, the parsed response, and parse/type errors.

This is needed for internal extraction pipeline traces: final JSON and parsed agent responses were not enough to debug where Arcadia/Generic/ADP cases were losing rows or failing malformed-output paths.

## Validation

- `poetry run pytest -q tests/extract/agents/test_agent_tool_trace.py tests/extract/agents/test_agent_tool_image_transport.py`
- `poetry run mypy src/groundx/extract/agents/agent.py tests/extract/agents/test_agent_tool_trace.py`
- `git diff --check`
- `poetry run mypy .`
- `poetry run pytest -rP -n auto .`