### PR TITLE
Preserve extraction workflow runtime metadata

### DIFF
--- a/src/groundx/extract/prompt/utility.py
+++ b/src/groundx/extract/prompt/utility.py
@@ -50,7 +50,11 @@ _RESERVED_TOP_LEVEL_KEYS = {
     _CUSTOM_WORKFLOW_KEY,
 }
 _EXTRACTION_POLICY_VERSION_KEY = "extraction_policy_version"
-_SUPPORTED_TOP_LEVEL_METADATA_KEYS = {_EXTRACTION_POLICY_VERSION_KEY}
+_SUPPORTED_TOP_LEVEL_METADATA_KEYS = {
+    _EXTRACTION_POLICY_VERSION_KEY,
+    "_groundx_internal_capture",
+}
+_SUPPORTED_PSEUDO_GROUP_METADATA_KEYS = {"role"}
 _SUPPORTED_FINAL_GROUP_METADATA_KEYS = {
     "always_check_attrs",
     "conflict_attrs",
@@ -149,6 +153,7 @@ _CUSTOM_WORKFLOW_AUTHORING_KEYS = {
     "custom_steps",
     _CUSTOM_WORKFLOW_AGENT_CHAIN_KEY,
     "output_relationships",
+    "section_strategy",
 }
 _CUSTOM_WORKFLOW_PERSISTED_KEYS = {
     "metadata_version",
@@ -156,6 +161,7 @@ _CUSTOM_WORKFLOW_PERSISTED_KEYS = {
     "custom_steps",
     _CUSTOM_WORKFLOW_AGENT_CHAIN_KEY,
     "output_relationships",
+    "section_strategy",
     "output_routes",
     "leaf_fields",
     "field_counts",
@@ -1600,6 +1606,8 @@ def _normalize_persisted_custom_workflow_metadata(
     }
     if relationships:
         metadata["output_relationships"] = relationships
+    if workflow.get("section_strategy") is not None:
+        metadata["section_strategy"] = workflow["section_strategy"]
     if template:
         metadata["template"] = template
     if field_counts:
@@ -1930,6 +1938,8 @@ def _build_authored_custom_workflow_metadata(
     }
     if relationships:
         metadata["output_relationships"] = relationships
+    if workflow.get("section_strategy") is not None:
+        metadata["section_strategy"] = workflow["section_strategy"]
     if template:
         metadata["template"] = template
     if field_counts:
@@ -2105,8 +2115,10 @@ def prepare_extraction_yaml(
     effective_workflow_metadata_key_set = workflow_metadata_key_set | {
         _CUSTOM_WORKFLOW_GROUP_METADATA_KEY
     }
-    effective_pseudo_metadata_key_set = effective_workflow_metadata_key_set | set(
-        pseudo_group_metadata_keys or []
+    effective_pseudo_metadata_key_set = (
+        effective_workflow_metadata_key_set
+        | _SUPPORTED_PSEUDO_GROUP_METADATA_KEYS
+        | set(pseudo_group_metadata_keys or [])
     )
     metadata_overlap = final_metadata_key_set & effective_workflow_metadata_key_set
     if metadata_overlap:

--- a/src/groundx/extract/workflows.py
+++ b/src/groundx/extract/workflows.py
@@ -185,7 +185,10 @@ def load_extraction_definition_from_workflow_response(
         output_routes=_plain_metadata_sequence(output_routes, _OUTPUT_ROUTE_ALIASES),
         leaf_fields=_plain_metadata_sequence(leaf_fields, _LEAF_FIELD_ALIASES),
         chunk_strategy=_get_workflow_value(workflow, "chunk_strategy"),
-        section_strategy=_get_workflow_value(workflow, "section_strategy"),
+        section_strategy=_first_present(
+            _get_workflow_value(workflow, "section_strategy"),
+            _section_strategy_from_extract(extract_mapping),
+        ),
         steps=_plain_or_none(_get_workflow_value(workflow, "steps")),
     )
 
@@ -324,6 +327,7 @@ def _definition_from_prepared(prepared: PreparedExtractionYaml) -> ExtractionDef
             metadata.get("leaf_fields"),
             _LEAF_FIELD_ALIASES,
         ),
+        section_strategy=_section_strategy_from_extract(extract),
     )
 
 
@@ -349,6 +353,7 @@ def _definition_from_workflow_extract(
             metadata.get("leaf_fields"),
             _LEAF_FIELD_ALIASES,
         ),
+        section_strategy=_section_strategy_from_extract(extract_mapping),
     )
 
 
@@ -528,6 +533,19 @@ def _workflow_metadata(
     if isinstance(metadata, Mapping):
         return typing.cast(typing.Mapping[str, typing.Any], metadata)
     return {}
+
+
+def _section_strategy_from_extract(
+    extract: typing.Mapping[str, typing.Any],
+) -> typing.Any:
+    metadata = _workflow_metadata(extract)
+    if metadata.get("section_strategy") is not None:
+        return metadata["section_strategy"]
+    persisted = extract.get(_PERSISTED_WORKFLOW_EXTRACT_KEY)
+    if isinstance(persisted, Mapping):
+        persisted_metadata = _workflow_metadata(persisted)
+        return persisted_metadata.get("section_strategy")
+    return None
 
 
 def _normalize_template(value: typing.Any) -> typing.Optional[typing.Dict[str, str]]:

--- a/tests/extract/fixtures/extraction-boundary/catalog.json
+++ b/tests/extract/fixtures/extraction-boundary/catalog.json
@@ -18,7 +18,7 @@
   ],
   "catalog_version": "2026-07-23.1",
   "schema_version": "groundx_python_extraction_boundary_catalog_v1",
-  "source_artifact_catalog_sha256": "0a4dd694334d4968dae01edb16cdfae309dfed411a40b627ed73fab72d538144",
+  "source_artifact_catalog_sha256": "c403a6593b7ec672e957789b133152015af4da3854ff77b41d422adb6d37e5b8",
   "surfaces": [
     "arcadia_legacy",
     "arcadia_v1",

--- a/tests/extract/test_extraction_boundary_reassembly.py
+++ b/tests/extract/test_extraction_boundary_reassembly.py
@@ -26,7 +26,7 @@ BOUNDARY_ROOT = ROOT / "tests" / "extract" / "fixtures" / "extraction-boundary"
 BOUNDARY_INPUT_ROOT = BOUNDARY_ROOT / "inputs"
 BOUNDARY_GOLDENS_ROOT = BOUNDARY_ROOT / "boundary-goldens"
 CATALOG_PATH = ROOT / "tests" / "extract" / "fixtures" / "extraction-boundary" / "catalog.json"
-CATALOG_SHA256 = "b3c2b146e817f33ac3c78096dcd5fa35300cc829ba78a1d2273a1b6ee1ff72c9"
+CATALOG_SHA256 = "6ecc41e2a8ea0bfb3c397a3668d2beef34e05b02ee6a8d8decfa614ba4379ec1"
 ADP_EXPECTED_SECTION_COUNT = 11
 ADP_EXPECTED_FIELD_COUNT = 159
 ADP_MIN_POPULATED_FIELDS = 100
@@ -54,7 +54,7 @@ def test_extraction_boundary_catalog_is_pinned() -> None:
     assert catalog["catalog_version"] == "2026-07-23.1"
     assert catalog["surfaces"] == SURFACES
     assert catalog["source_artifact_catalog_sha256"] == (
-        "0a4dd694334d4968dae01edb16cdfae309dfed411a40b627ed73fab72d538144"
+        "c403a6593b7ec672e957789b133152015af4da3854ff77b41d422adb6d37e5b8"
     )
     assert catalog["artifacts"] == [
         {

--- a/tests/extract/test_extraction_workflow_definitions.py
+++ b/tests/extract/test_extraction_workflow_definitions.py
@@ -1,5 +1,6 @@
 import copy
 import inspect
+import json
 import typing
 from pathlib import Path
 
@@ -69,6 +70,15 @@ statement:
         instructions: Return the account number.
         type: str
 """
+
+ADP_WORKFLOW_HANDOFF = (
+    Path(__file__).parent
+    / "fixtures"
+    / "extraction-boundary"
+    / "inputs"
+    / "adp_v1"
+    / "internal_arcadia_download_workflow_load.handoff.json"
+)
 
 
 EXECUTION_ONLY_EXTRACT = {
@@ -549,6 +559,50 @@ def test_load_definition_from_workflow_requires_extract() -> None:
 
     with pytest.raises(ValueError, match="workflow-1"):
         _client(RecordingWorkflows(response)).load_extraction_definition_from_workflow("workflow-1")
+
+
+def test_load_adp_workflow_readback_preserves_section_strategy() -> None:
+    handoff = json.loads(ADP_WORKFLOW_HANDOFF.read_text(encoding="utf-8"))
+    extract = copy.deepcopy(handoff["workflow_extract"])
+    response = WorkflowResponse(
+        workflow=WorkflowDetail(
+            workflow_id="adp-v1",
+            name="ADP v1",
+            extract=typing.cast(typing.Any, extract),
+        )
+    )
+
+    client = _client(RecordingWorkflows(response))
+    definition = client.load_extraction_definition_from_workflow("adp-v1")
+    mapping_definition = client.load_extraction_definition_from_yaml(
+        mapping=extract,
+        mapping_kind="workflow_extract",
+    )
+
+    assert definition.prepared is not None
+    assert definition.section_strategy == "page"
+    assert mapping_definition.section_strategy == "page"
+
+
+def test_prepare_adp_persisted_source_preserves_runtime_metadata() -> None:
+    handoff = json.loads(ADP_WORKFLOW_HANDOFF.read_text(encoding="utf-8"))
+    persisted_source = handoff["workflow_extract"]["_groundx_persisted_extract"]
+
+    prepared = prepare_extraction_yaml(persisted_source)
+    client = _client(RecordingWorkflows())
+    prepared_definition = client.load_extraction_definition_from_yaml(prepared=prepared)
+    persisted_definition = client.load_extraction_definition_from_yaml(
+        mapping=prepared.persisted_workflow_extract,
+        mapping_kind="workflow_extract",
+    )
+
+    assert prepared.persisted_workflow_extract["workflow"]["section_strategy"] == "page"
+    assert prepared_definition.section_strategy == "page"
+    assert persisted_definition.section_strategy == "page"
+    assert prepared.top_level_metadata["_groundx_internal_capture"]["enabled"] is True
+    assert prepared.workflow_group_metadata[
+        "adp_f1_employer_and_plan_information"
+    ]["role"] == "statement"
 
 
 def test_create_and_update_use_definition_before_yaml_sources() -> None:


### PR DESCRIPTION
## Summary
- preserve `section_strategy`, pseudo-group `role`, and workflow capture metadata through authored and persisted workflow loading
- cover the real ADP workflow handoff at SDK boundaries
- refresh the generated boundary catalog metadata without changing accepted fixture inputs or outputs

## Validation
- `poetry run pytest -q` (317 passed, 9 skipped, 5 subtests passed)
- `poetry run mypy .`
- `poetry build`
- `git diff --check`