### PR TITLE
Document the Python SDK release handoff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,17 @@ This approach is best for:
 7. Commit your changes with a clear commit message
 8. Push your branch and create a pull request
 
+### Release Handoff
+
+This repository does not own generated Python SDK releases. Releases are generated from
+[`eyelevel-fern-config`](https://github.com/eyelevelai/eyelevel-fern-config) and its
+release workflow is run by a human release owner.
+
+Contributors and agents must stop after preparing a validated, merge-ready pull request.
+When a release is required, the handoff must name the requested version, merged commit,
+validation evidence, and downstream consumers that need the new version. Do not create a
+release tag, dispatch a release workflow, or publish the package from this repository.
+
 ### Commit Messages
 
 Write clear, descriptive commit messages that explain what changed and why.


### PR DESCRIPTION
## Summary

- state that generated Python SDK releases are owned by `eyelevel-fern-config`
- require contributors and agents to stop after a validated, merge-ready PR
- define the version, commit, validation, and downstream-consumer details required in a release handoff
- prohibit tags, workflow dispatches, and package publication from this repository

This PR changes contributor documentation only. It does not generate or publish an SDK.

## Verification

- `scripts/check-line-endings.sh --all`
- `git diff --check`