### PR TITLE
Preserve Python SDK release preflight gates

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,5 +1,6 @@
 # Specify files that shouldn't be modified by Fern
 README.md
+CONTRIBUTING.md
 AGENTS.md
 src/groundx/ingest.py
 src/groundx/csv_splitter.py
@@ -17,4 +18,5 @@ CLAUDE.md
 .gitattributes
 .editorconfig
 scripts/check-line-endings.sh
+.github/workflows/ci.yml
 .github/workflows/line-endings.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: poetry run pytest -q -m "not pending_fixture_promotion" tests/extract/test_extraction_boundary_reassembly.py tests/extract/test_extraction_boundary_evidence_contract.py
 
       - name: Install aiohttp extra
-        run: poetry install --extras aiohttp
+        run: poetry install --extras extract --extras aiohttp
 
       - name: Test (aiohttp)
         run: poetry run pytest -rP -n auto -m aiohttp .

--- a/tests/custom/test_release_preflight.py
+++ b/tests/custom/test_release_preflight.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_contributor_guide_is_preserved_during_fern_generation() -> None:
+    preserved_paths = {
+        line.strip()
+        for line in (REPO_ROOT / ".fernignore").read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+    assert "CONTRIBUTING.md" in preserved_paths
+
+
+def test_release_preflight_ci_is_preserved_during_fern_generation() -> None:
+    preserved_paths = {
+        line.strip()
+        for line in (REPO_ROOT / ".fernignore").read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+    assert ".github/workflows/ci.yml" in preserved_paths
+
+
+def test_aiohttp_ci_install_retains_extract_dependencies() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/ci.yml").read_text()
+
+    assert "poetry install --extras extract --extras aiohttp" in workflow


### PR DESCRIPTION
## Summary

- retain extract dependencies when CI installs the aiohttp extra
- protect the contributor release guide and custom CI workflow from Fern regeneration
- add focused regression tests for both release safeguards

## Why

The current main CI run fails while collecting aiohttp tests because installing only the aiohttp extra removes extract-only dependencies, including gspread and fastapi. Fern release commits have also overwritten repository-owned contributor guidance and CI configuration when those paths were not protected.

## Verification

- focused release-preflight tests: 3 passed
- pre-promotion suite: 740 passed, 2 skipped, 5 subtests passed
- extraction boundary checks: 28 passed, 6 deselected
- aiohttp suite: 3 passed
- mypy: no issues in 262 source files
- Ruff, line-ending guard, and git diff check passed

## Release handoff

Request version 3.9.1 after this PR merges and GitHub CI is green. The release owner should dispatch the Fern release workflow. No live extraction run or fixture refresh is required for this CI and release-preservation change.