### PR TITLE
Normalize extraction values and make parser retries safe

### DIFF
--- a/openspec/changes/normalize-extracted-value-types/.openspec.yaml
+++ b/openspec/changes/normalize-extracted-value-types/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/normalize-extracted-value-types/design.md
+++ b/openspec/changes/normalize-extracted-value-types/design.md
@@ -93,7 +93,7 @@ could break it on an automatic minor upgrade.
 | Target | Accepted conversion |
 | --- | --- |
 | `str` | JSON scalar text for bool and numbers; compact JSON text for list and dict |
-| `int` | int, float, numeric text; decimal truncation remains toward zero |
+| `int` | int, float, numeric text parsed without a binary-float round trip; decimal truncation remains toward zero |
 | `float` | int, float, numeric text |
 | `list` | list unchanged; JSON array text parsed |
 | `dict` | dict unchanged; JSON object text parsed |

--- a/openspec/changes/normalize-extracted-value-types/design.md
+++ b/openspec/changes/normalize-extracted-value-types/design.md
@@ -93,7 +93,7 @@ could break it on an automatic minor upgrade.
 | Target | Accepted conversion |
 | --- | --- |
 | `str` | JSON scalar text for bool and numbers; compact JSON text for list and dict |
-| `int` | int, float, numeric text parsed without a binary-float round trip; decimal truncation remains toward zero |
+| `int` | int, float, integer-form text parsed exactly; decimal truncation remains toward zero |
 | `float` | int, float, numeric text |
 | `list` | list unchanged; JSON array text parsed |
 | `dict` | dict unchanged; JSON object text parsed |

--- a/openspec/changes/normalize-extracted-value-types/design.md
+++ b/openspec/changes/normalize-extracted-value-types/design.md
@@ -1,0 +1,237 @@
+## Context
+
+GroundX Python 3.9.2 has two separate SDK-owned problems.
+
+`coerce_numeric_string`, `Prompt.valid_value`, and `ExtractedField` apply
+different type rules. Python booleans pass some integer checks, so a boolean for
+a string field can become `"1.0"` or `"True"`. List and dict handling is partly
+implemented in downstream consumers instead of one SDK boundary.
+
+The SDK also owns response parsing and configured parser retry. `AgentTool`
+prints the malformed response before a retry, and `process_response` prints a
+stack for wrong native or parsed types. Enabling retry unchanged would place
+customer-derived output in container logs.
+
+AGE-272 reported a terminal `TypeError` and inferred a boolean-to-string
+mismatch from X-Ray output. The cited task and document later completed, and the
+retained production logs do not contain the original terminal detail. A separate
+governed ADP fixture proves malformed JSON can recover on a second parser
+attempt, but it is not proof of AGE-272's exact cause. The implementation and
+ticket must keep that distinction.
+
+## Goals
+
+- Make the SDK the only owner of primitive extracted-value coercion.
+- Support every declared extraction type currently recognized by the SDK.
+- Prevent one incompatible field value from failing a document.
+- Keep typed outputs type-safe when conversion is impossible.
+- Preserve null for missing and newly created unmatched fields instead of
+  substituting an empty string, list, or dict. Preserve an existing valid value
+  when a later reconcile or QA update is unmatched.
+- Make configured parser retry safe to enable in containerized consumers.
+- Ship both SDK changes in one tested release.
+
+## Non-Goals
+
+- No claim that either verified SDK defect caused the original AGE-272 failure.
+- No new schema type such as `bool`.
+- No prompt, workflow-routing, generated Fern, API, or database change.
+- No broad rewrite of Internal Arcadia conversion call sites.
+- No model-client, transport, Celery, or stage-retry policy change.
+- No ordinary SDK log record for successful conversion or recovered parser retry.
+
+## Shared Coercion Interface
+
+Add these hand-written types under `groundx.extract.utility`:
+
+```python
+@dataclass(frozen=True)
+class CoercionResult:
+    value: typing.Any
+    matched: bool
+    converted: bool
+    warning: typing.Optional[str] = None
+
+
+def coerce_value(
+    value: typing.Any,
+    expected_types: typing.Optional[typing.Union[str, typing.List[str]]] = None,
+) -> CoercionResult:
+    ...
+```
+
+`coerce_value` is total for JSON-compatible inputs. It catches parse and cast
+errors. An impossible or unknown target returns `value=None`, `matched=False`,
+and a content-free warning containing source and target type names. The helper
+does not log because it does not have document, stage, or field context.
+
+`coerce_numeric_string` remains a compatibility entry point:
+
+```python
+def coerce_numeric_string(value, et=None):
+    return coerce_value(value, et).value
+```
+
+This is one conversion implementation with two return shapes. Existing callers
+receive only the selected primitive value. Field-aware code uses
+`CoercionResult` when it needs match status or a warning. The old name remains
+because it is exported by the SDK and is used by Internal Arcadia and legacy
+Arcadia. Legacy Arcadia declares `groundx[extract]>=3.4.1`, so removing the name
+could break it on an automatic minor upgrade.
+
+## Conversion Rules
+
+1. Return `None` unchanged with matched status.
+2. Resolve declared type names. Unknown names return an unmatched null result.
+3. Preserve an exact allowed Python type. Exact checks use `type(value)`, so a
+   boolean does not masquerade as an integer.
+4. For `int` and `float` unions, inspect numeric text and choose integer or float
+   without losing decimals.
+5. Attempt target conversions in declared order.
+6. Return an unmatched null result when every supported conversion fails.
+
+| Target | Accepted conversion |
+| --- | --- |
+| `str` | JSON scalar text for bool and numbers; compact JSON text for list and dict |
+| `int` | int, float, numeric text; decimal truncation remains toward zero |
+| `float` | int, float, numeric text |
+| `list` | list unchanged; JSON array text parsed |
+| `dict` | dict unchanged; JSON object text parsed |
+
+The helper does not invent container shapes. It does not wrap scalars in lists,
+convert dicts to lists, or create `{"value": ...}` wrappers. The exact string
+`"0"` remains `"0"` for a string target. Empty text for a numeric target is
+unmatched and becomes null; it is not converted to zero. A boolean for an `int`
+or `float` target is also unmatched and becomes null. Treating `true` as one or
+`false` as zero would turn a model type error into plausible wrong data.
+
+## SDK Integration
+
+- `Prompt.valid_value` uses exact-type validation. Conversion happens before
+  validation.
+- `ExtractedField.set_value` and `get_value` delegate primitive conversion to
+  `coerce_value`. Existing date normalization remains separate.
+- `ExtractedField.none_value` returns `None` for every declared type. Missing and
+  unmatched fields therefore serialize as null, not as an empty string, list,
+  or dict, and the field remains present.
+- The field value annotation accepts JSON-compatible inputs before conversion.
+- SDK confidence validation delegates to `coerce_value`, keeps its existing
+  public tuple shape, and returns a field-scoped nonfatal warning for an
+  unmatched value.
+- `coerce_numeric_string` remains the compatibility path for existing consumers.
+- Utility exports expose `CoercionResult` and `coerce_value`.
+
+An unmatched raw value remains available to the caller that supplied it and to
+authorized diagnostic capture. The typed extracted output contains null for the
+field, not the raw value or an empty substitute. Sibling fields continue
+processing. `coerce_value` does not decide update semantics. A consumer creating
+a field uses the returned null. A consumer updating an existing field rejects an
+unmatched update and keeps the prior valid value.
+
+## Parser Retry Output Safety
+
+Keep the existing `process_response` and `AgentTool.process` ownership:
+
+- unwrap supported `answer.type` response envelopes before final type
+  validation, then validate that final value against `expected_types`;
+- remove `traceback.print_stack()` from wrong native and parsed type failures;
+- remove direct stdout output before `AgentTool` retry;
+- keep the terminal exception class and expected-type context, but remove the
+  raw provider response from its message;
+- keep any SDK retry log content-free and debug-only;
+- preserve exact prompt, raw response, parsed response, parse error, and attempt
+  events through the existing `AgentTool` trace callback;
+- keep retry exhaustion terminal.
+
+This plan does not add another parser or retry loop. Internal Arcadia can set
+`response_parse_max_retries=1` after it pins the released SDK.
+
+## Internal Arcadia Integration
+
+Internal Arcadia consumes the release through its separate
+`age-272-retry-terminal-agent-diagnostics` change:
+
+- pin the one released SDK version containing both changes;
+- use `coerce_value` directly at model-output field-writing boundaries that must
+  preserve unmatched fields and collect match metadata;
+- write null for an unmatched field only when no valid prior field exists;
+- reject an unmatched reconcile or QA update when the target already has a
+  valid value, preserving that value while recording the unmatched metadata;
+- leave rendering, CSV, and other compatibility callers that do not need match
+  metadata on `coerce_numeric_string`;
+- remove only `_json_string_field_value` and other local conversion code proven
+  equivalent to `coerce_value`;
+- do not add an Internal Arcadia conversion helper or second conversion matrix;
+- add no log for a successful conversion;
+- aggregate unmatched fields into the existing stage completion or terminal
+  record, with count, field names, source types, and target types, and without
+  raw values or exception messages;
+- preserve existing transport, stage-owned, model-client, Celery, and callback
+  behavior.
+
+Every direct caller of `coerce_numeric_string`, `Prompt.valid_value`, and
+`ExtractedField` must be inventoried and tested before changing the shared
+wrapper because the wrapper changes all of them at once. Only field-writing
+callers that need `matched`, `converted`, or `warning` migrate to `coerce_value`.
+
+## Harness Documentation
+
+Update the root extraction references, then regenerate plugin mirrors. Document:
+
+- all declared types use shared best-effort coercion;
+- boolean string fields become lowercase `"true"` or `"false"`;
+- container-to-string conversion uses JSON;
+- impossible conversion yields a type-safe null for a new field, preserves a
+  valid prior value on update, and produces one field-aware warning;
+- explicit output-shape prompts remain preferred because coercion is a safety
+  net.
+
+## Release And Rollout
+
+1. Build one SDK candidate wheel containing coercion and parser-output safety.
+2. Install that exact wheel in an isolated Internal Arcadia environment.
+3. Test the wrapper call inventory, field-aware integration, one parser retry,
+   terminal callback behavior, and all protected extraction paths.
+4. Merge the SDK PR and hand the tested commit, candidate evidence, requested
+   next version, and Internal Arcadia consumer pin to the human Fern release
+   owner. Do not tag, dispatch, or publish from this repo.
+5. Pin the released version in Internal Arcadia and repeat consumer and
+   container tests from a clean install.
+6. Update Harness source references and regenerate both plugin bundles.
+7. Deploy Internal Arcadia only after its terminal diagnostic storage gate is
+   satisfied. Record the new and prior image identities for rollback.
+
+If the protected current reproduction, Arcadia legacy, Arcadia v1, generic v1,
+or ADP v1 regresses, roll Internal Arcadia back to the recorded image. The
+additive SDK release remains available, but consumers need not adopt it until
+their tests pass.
+
+## Verification
+
+- SDK coercion tests cover each scalar, container, union, null, unknown target,
+  and impossible pair, including exact result types and warnings.
+- SDK field tests prove `True` with `type: str` reads as `"true"` and an
+  impossible conversion becomes a nonfatal null.
+- SDK agent tests prove recovery and exhaustion retain trace events while
+  stdout, stderr, and ordinary logs contain no stack or raw provider content.
+- SDK agent tests cover native and JSON-string response envelopes whose outer
+  object is valid but whose unwrapped `answer.type` has the wrong type. The
+  first failure consumes one parser retry and the second remains terminal.
+- Internal Arcadia tests cover every existing wrapper call shape, each migrated
+  field-writing boundary, new-field null behavior, prior-value preservation,
+  one stage-level warning aggregate, the AGE-272 field shape, parser recovery
+  and exhaustion, and callback compatibility.
+- Certification names evidence for the current reproduction, Arcadia legacy,
+  Arcadia v1, generic v1, and ADP v1.
+- Harness validation proves root references and generated bundles remain
+  synchronized.
+
+Any certification output follows the linked-repository manual artifact
+procedure because this change is owned by `groundx-python`, not GroundX Studio
+Harness. Raw X-Rays, prompts, model output, logs, and customer data remain
+ignored and are removed after disposition.
+
+## No ADR
+
+This is a narrow hand-written extract utility and parser-output change. It adds
+no service, storage, generated API, or deployment boundary.

--- a/openspec/changes/normalize-extracted-value-types/proposal.md
+++ b/openspec/changes/normalize-extracted-value-types/proposal.md
@@ -1,0 +1,98 @@
+## Why
+
+Structured extraction currently has two independently verified resilience gaps.
+
+First, extracted-value conversion is split across `coerce_numeric_string`,
+`Prompt.valid_value`, `ExtractedField`, and downstream consumers. The current SDK
+can turn a native boolean for a string field into `"1.0"` or `"True"`, treats
+booleans as numbers through Python subclassing, and does not provide one contract
+for list and dict targets.
+
+Second, the SDK owns response-parser retry but writes malformed provider content
+and stack traces to ordinary process output. Internal Arcadia therefore disables
+the parser retry and one malformed response can terminalize a document.
+
+The original AGE-272 terminal `TypeError` cannot be assigned to either gap from
+retained evidence. The cited production task later completed successfully and no
+matching detailed terminal trace was retained. This change fixes the verified SDK
+defects without treating either theory as the incident's proven root cause.
+
+## What Changes
+
+- Add one SDK coercion implementation for `str`, `int`, `float`, `list`, `dict`,
+  declared type unions, and null.
+- Convert compatible values deterministically. Native booleans become lowercase
+  JSON text for string fields. A boolean supplied for a numeric field is
+  unmatched and becomes null rather than plausible but incorrect numeric data.
+- Return a type-safe null plus a content-free warning when conversion is
+  impossible. Preserve that null through new field readback and serialization.
+  When an unmatched model update targets a field that already has a valid
+  value, keep the valid value instead of overwriting it with null. Do not pass
+  the incompatible raw value to typed consumers.
+- Route SDK field handling and confidence validation through the shared helper.
+  Keep `coerce_numeric_string` only as a thin compatibility entry point over the
+  same implementation so downstream callers do not fail on import.
+- Remove direct parser-retry output, parser stack printing, and raw provider
+  content from raised parser exception messages. Preserve exact parser evidence
+  through the existing `AgentTool` trace callback.
+- Validate the final value after the SDK unwraps an `answer.type` response.
+  Wrong inner types therefore remain parser failures and consume the configured
+  parser retry instead of escaping into later processing.
+- Keep one SDK parser retry available to consumers. A parser failure remains
+  terminal after configured retries are exhausted.
+- Release the coercion and parser-output changes together, then let Internal
+  Arcadia pin that one released version.
+- Document the shared conversion contract and keep explicit output-shape prompts
+  as the authoring default.
+
+## Capabilities
+
+### New Capabilities
+
+- `extracted-value-coercion`: one non-failing SDK contract that converts
+  extracted JSON values to declared schema types and reports unmatched values
+  without failing a document.
+- `agent-response-reliability`: parser retry writes no provider content or stack
+  trace to ordinary output while exact evidence remains available through the
+  trace callback.
+
+### Modified Capabilities
+
+(none)
+
+## Impact
+
+- **Hand-written SDK files:** `src/groundx/extract/utility/`,
+  `src/groundx/extract/classes/field.py`,
+  `src/groundx/extract/classes/prompt.py`, and
+  `src/groundx/extract/agents/agent.py`. These paths are protected by
+  `.fernignore`.
+- **Public extract surface:** adds `CoercionResult` and `coerce_value`. The
+  release owner chooses the next package version. This plan does not tag,
+  dispatch, or publish a release.
+- **Compatibility:** `coerce_numeric_string` keeps its call signature and
+  primitive return shape. It delegates all conversion to `coerce_value`; there
+  is no second conversion matrix. The wrapper prevents import failures in the
+  SDK, Internal Arcadia, and legacy Arcadia, whose `groundx[extract]>=3.4.1`
+  dependency can take a newer minor release automatically. Corrected values can
+  differ from current behavior, including `True` becoming `"true"` rather than
+  `"1.0"` or `"True"`, `"0"` remaining a string for a `str` target, and missing
+  or unmatched values remaining null instead of becoming empty containers or
+  strings.
+- **Downstream consumer:** Internal Arcadia uses `coerce_value` only at
+  model-output field-writing boundaries that need match metadata. Other callers
+  remain on the compatibility wrapper. It removes only local conversion code
+  duplicated by the SDK. New unmatched fields serialize as null. Unmatched
+  reconcile or QA updates preserve an existing valid value. Internal Arcadia
+  pins the one released SDK version, enables one parser retry, and owns terminal
+  trace retention and service logging.
+- **Consolidated extraction plan:** remaining cross-repo certification work is
+  tracked in
+  `internal-arcadia-agents/openspec/changes/complete-extraction-boundary-regression-coverage/tasks.md`.
+- **Logging:** the SDK adds no ordinary log record for conversion or parser
+  retry. A consumer may write one content-free retry decision record with its
+  document and stage context. An impossible conversion is aggregated by a
+  field-aware consumer, not logged independently by the SDK helper.
+- **No API schema, database, workflow-data, or generated Fern change is
+  required.**
+- **Open design questions:** none.

--- a/openspec/changes/normalize-extracted-value-types/specs/agent-response-reliability/spec.md
+++ b/openspec/changes/normalize-extracted-value-types/specs/agent-response-reliability/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Configured parser retry is safe for ordinary output
+
+The extraction SDK SHALL write no raw provider response or stack trace to
+stdout, stderr, ordinary SDK logs, or raised parser exception messages when
+response parsing fails or retries. Exact parser evidence SHALL remain available
+through the existing `AgentTool` trace callback.
+
+#### Scenario: Malformed JSON recovers
+
+- **WHEN** the first provider response is malformed JSON
+- **AND** a configured second attempt returns a valid expected response
+- **THEN** the SDK returns the parsed second response
+- **AND** it emits prompt, raw-response, parse-error, and parsed-response trace
+  events with attempt numbers
+- **AND** ordinary output contains no provider content or stack trace.
+
+#### Scenario: Wrong native or parsed type is rejected
+
+- **WHEN** a response has the wrong native type or parses to the wrong type
+- **THEN** the SDK raises the existing parser exception after configured retries
+  are exhausted
+- **AND** ordinary output and the exception message contain no provider content
+  or stack trace
+- **AND** the trace callback retains the exact failure evidence.
+
+#### Scenario: Response envelope contains the wrong inner type
+
+- **WHEN** a native object or JSON string has a supported `answer.type` envelope
+- **AND** the unwrapped value does not match the expected response type
+- **THEN** final response validation treats it as a parser failure
+- **AND** the configured parser retry applies
+- **AND** exhaustion remains terminal with exact evidence in the trace callback.
+
+### Requirement: Parser retry remains bounded and consumer-configured
+
+The SDK SHALL preserve the configured `response_parse_max_retries` limit and
+SHALL keep parser exhaustion terminal after that limit.
+
+#### Scenario: One configured retry is exhausted
+
+- **WHEN** a consumer configures one parser retry
+- **AND** both provider responses fail parsing
+- **THEN** the SDK makes exactly two provider calls
+- **AND** it raises the existing terminal parser exception after the second
+  failure.
+
+#### Scenario: No retry is configured
+
+- **WHEN** a consumer configures zero parser retries
+- **THEN** the first parser failure remains terminal without an extra provider
+  call.
+
+### Requirement: Parser output safety does not change other retry owners
+
+The SDK change SHALL NOT add model-client, transport, task, or stage retry
+behavior.
+
+#### Scenario: Provider transport fails
+
+- **WHEN** the provider call fails before a response reaches the parser
+- **THEN** response-parser retry is not consumed
+- **AND** the consumer's existing transport policy remains the retry owner.
+
+#### Scenario: Post-parser processing raises TypeError
+
+- **WHEN** downstream processing raises `TypeError` after parsing succeeded
+- **THEN** the SDK does not classify it as a response-parser failure.

--- a/openspec/changes/normalize-extracted-value-types/specs/extracted-value-coercion/spec.md
+++ b/openspec/changes/normalize-extracted-value-types/specs/extracted-value-coercion/spec.md
@@ -98,6 +98,12 @@ targets before conversion.
 - **WHEN** text cannot be parsed for an `int` or `float` target
 - **THEN** the helper returns null, marks it unmatched, and returns a warning.
 
+#### Scenario: Numeric text exceeds the target representation
+
+- **WHEN** numeric text cannot be represented by the target type without
+  excessive expansion
+- **THEN** the helper returns null, marks it unmatched, and returns a warning.
+
 ### Requirement: Container conversion uses JSON semantics
 
 The helper SHALL use JSON encoding and decoding for conversions between string

--- a/openspec/changes/normalize-extracted-value-types/specs/extracted-value-coercion/spec.md
+++ b/openspec/changes/normalize-extracted-value-types/specs/extracted-value-coercion/spec.md
@@ -77,7 +77,9 @@ targets before conversion.
 - **WHEN** numeric text, including comma-formatted or decimal text, is supplied
   for an `int` target
 - **THEN** the helper returns an integer and retains the current truncation
-  toward zero for decimal values.
+  toward zero for decimal values
+- **AND** integer text is not routed through binary floating point or changed by
+  floating-point precision limits.
 
 #### Scenario: Numeric text targets a float
 

--- a/openspec/changes/normalize-extracted-value-types/specs/extracted-value-coercion/spec.md
+++ b/openspec/changes/normalize-extracted-value-types/specs/extracted-value-coercion/spec.md
@@ -41,7 +41,8 @@ value.
 
 #### Scenario: Unknown target type is declared
 
-- **WHEN** the helper receives an unsupported declared type name
+- **WHEN** the helper receives an unsupported declared type name, alone or in a
+  union
 - **THEN** it returns null and an unmatched warning instead of guessing a
   conversion.
 
@@ -102,6 +103,11 @@ targets before conversion.
 
 - **WHEN** numeric text cannot be represented by the target type without
   excessive expansion
+- **THEN** the helper returns null, marks it unmatched, and returns a warning.
+
+#### Scenario: Non-finite number targets a numeric type
+
+- **WHEN** a numeric value or numeric text would produce infinity or NaN
 - **THEN** the helper returns null, marks it unmatched, and returns a warning.
 
 ### Requirement: Container conversion uses JSON semantics

--- a/openspec/changes/normalize-extracted-value-types/specs/extracted-value-coercion/spec.md
+++ b/openspec/changes/normalize-extracted-value-types/specs/extracted-value-coercion/spec.md
@@ -1,0 +1,219 @@
+## ADDED Requirements
+
+### Requirement: The SDK provides one schema-driven coercion contract
+
+The hand-written extraction SDK SHALL expose one helper that accepts a JSON
+value and an optional declared type of `str`, `int`, `float`, `list`, `dict`, or
+a list of those types, and returns the selected value, match status, conversion
+status, and an optional content-free warning.
+
+#### Scenario: Value already matches the declared type
+
+- **WHEN** the helper receives a value whose exact Python type matches an allowed
+  declared type
+- **THEN** it returns the original value with matched status and without
+  conversion.
+
+#### Scenario: No declared type exists
+
+- **WHEN** the helper receives no declared type
+- **THEN** it returns the original value with matched status and without
+  conversion.
+
+### Requirement: Coercion cannot fail document processing
+
+The helper SHALL NOT raise for any JSON-compatible input. When no supported
+conversion exists, it SHALL return a type-safe null, mark the result unmatched,
+and return a warning containing source and target type names without the raw
+value.
+
+#### Scenario: Container cannot become a number
+
+- **WHEN** a list or dict is supplied for an `int` or `float` target
+- **THEN** the helper returns null, marks it unmatched, and returns a warning
+- **AND** sibling fields remain eligible for processing.
+
+#### Scenario: Invalid JSON string targets a container
+
+- **WHEN** a non-JSON string is supplied for a `list` or `dict` target
+- **THEN** the helper returns null, marks it unmatched, and returns a warning
+  instead of raising.
+
+#### Scenario: Unknown target type is declared
+
+- **WHEN** the helper receives an unsupported declared type name
+- **THEN** it returns null and an unmatched warning instead of guessing a
+  conversion.
+
+### Requirement: Scalar conversion is deterministic
+
+The helper SHALL convert scalar JSON values according to one shared matrix.
+Exact type checks SHALL prevent Python booleans from matching integer or float
+targets before conversion.
+
+#### Scenario: Boolean targets a string
+
+- **WHEN** `true` or `false` is supplied for a `str` target
+- **THEN** the helper returns lowercase `"true"` or `"false"`.
+
+#### Scenario: Number targets a string
+
+- **WHEN** an integer or float is supplied for a `str` target
+- **THEN** the helper returns its JSON scalar text.
+
+#### Scenario: String zero targets a string
+
+- **WHEN** `"0"` is supplied for a `str` target
+- **THEN** the helper preserves `"0"` as an exact string.
+
+#### Scenario: Boolean targets a number
+
+- **WHEN** a boolean is supplied for an `int` or `float` target
+- **THEN** the helper returns null, marks it unmatched, and returns a warning
+- **AND** it does not turn the boolean into zero or one.
+
+#### Scenario: Numeric text targets an integer
+
+- **WHEN** numeric text, including comma-formatted or decimal text, is supplied
+  for an `int` target
+- **THEN** the helper returns an integer and retains the current truncation
+  toward zero for decimal values.
+
+#### Scenario: Numeric text targets a float
+
+- **WHEN** numeric text, including comma-formatted text, is supplied for a
+  `float` target
+- **THEN** the helper returns the parsed float.
+
+#### Scenario: Empty text targets a number
+
+- **WHEN** an empty string is supplied for an `int` or `float` target
+- **THEN** the helper returns null, marks it unmatched, and returns a warning
+  instead of inventing numeric zero.
+
+#### Scenario: Non-numeric text targets a number
+
+- **WHEN** text cannot be parsed for an `int` or `float` target
+- **THEN** the helper returns null, marks it unmatched, and returns a warning.
+
+### Requirement: Container conversion uses JSON semantics
+
+The helper SHALL use JSON encoding and decoding for conversions between string
+and container targets.
+
+#### Scenario: List or dict targets a string
+
+- **WHEN** a list or dict is supplied for a `str` target
+- **THEN** the helper returns compact valid JSON text, not Python representation
+  text.
+
+#### Scenario: JSON array text targets a list
+
+- **WHEN** a string containing a JSON array is supplied for a `list` target
+- **THEN** the helper returns the parsed list.
+
+#### Scenario: JSON object text targets a dict
+
+- **WHEN** a string containing a JSON object is supplied for a `dict` target
+- **THEN** the helper returns the parsed dict.
+
+#### Scenario: Parsed JSON has the wrong container shape
+
+- **WHEN** JSON array text targets `dict` or JSON object text targets `list`
+- **THEN** the helper returns null, marks it unmatched, and returns a warning.
+
+### Requirement: Union coercion has stable precedence
+
+The helper SHALL preserve an exact allowed input type before attempting
+conversions. When conversion is required, it SHALL prefer numeric interpretation
+for an `int` and `float` union and otherwise use declared order.
+
+#### Scenario: Decimal text targets an integer and float union
+
+- **WHEN** decimal text targets `['int', 'float']`
+- **THEN** the helper returns a float without truncation.
+
+#### Scenario: Integer text targets an integer and float union
+
+- **WHEN** integer text targets `['int', 'float']`
+- **THEN** the helper returns an integer.
+
+#### Scenario: Exact union member is supplied
+
+- **WHEN** a value already has an exact type listed in a union
+- **THEN** the helper preserves that value regardless of declared order.
+
+### Requirement: SDK field handling uses the shared contract
+
+`ExtractedField`, `Prompt.valid_value`, and SDK confidence validation SHALL use
+the shared coercion and exact-type rules instead of separate primitive
+conversion logic. Existing date normalization SHALL remain separate.
+
+#### Scenario: Boolean is assigned to a string field
+
+- **WHEN** `ExtractedField` receives `True` for a prompt declared as `str`
+- **THEN** its value reads back as `"true"`, not `"1.0"`, `"True"`, or an
+  exception.
+
+#### Scenario: Unsupported value reaches field handling
+
+- **WHEN** a field value cannot match or convert to its declared type
+- **THEN** field handling produces a nonfatal null and a field-scoped warning
+- **AND** it does not put the incompatible value in typed extracted JSON
+- **AND** it does not fail sibling fields or the document.
+
+#### Scenario: Null remains null for every declared type
+
+- **WHEN** a field is missing or conversion to `str`, `int`, `float`, `list`, or
+  `dict` is impossible
+- **THEN** the field remains present with a null value through field readback and
+  typed output serialization
+- **AND** the SDK does not replace null with an empty string, list, or dict.
+
+#### Scenario: Successful conversion is quiet
+
+- **WHEN** field handling converts a compatible mismatched value
+- **THEN** the SDK emits no ordinary log record.
+
+### Requirement: Existing callers have a narrow migration path
+
+`coerce_numeric_string` SHALL remain available as a compatibility wrapper over
+the shared helper, preserving its call signature and primitive return shape. It
+SHALL NOT contain a second conversion policy.
+
+#### Scenario: Existing caller uses the old helper
+
+- **WHEN** a caller invokes `coerce_numeric_string(value, expected_types)`
+- **THEN** it receives the shared helper's selected value without changing its
+  call signature.
+
+### Requirement: Protected extraction paths retain behavior
+
+The change SHALL include regression evidence for the current reproduction,
+Arcadia legacy, Arcadia v1, generic v1, and ADP v1 extraction paths.
+
+#### Scenario: Protected path receives coercible mismatched output
+
+- **WHEN** any protected path receives a JSON value that can be converted to the
+  declared field type
+- **THEN** it uses the shared result and completes without losing sibling
+  fields.
+
+#### Scenario: Protected path receives unmatched output
+
+- **WHEN** any protected path receives a JSON value that cannot be converted to
+  the declared field type
+- **AND** no valid prior value exists for that field
+- **THEN** it emits a type-safe null for that field, records one field-aware
+  warning through the consumer boundary, and continues the document.
+
+#### Scenario: Unmatched update targets a valid field
+
+- **WHEN** reconcile, QA, or another model-driven update cannot be converted to
+  the declared type
+- **AND** the target field already contains a valid typed value
+- **THEN** the consumer preserves the prior value
+- **AND** it does not overwrite that value with null or the incompatible raw
+  value
+- **AND** it records the unmatched metadata through the consumer boundary and
+  continues the document.

--- a/openspec/changes/normalize-extracted-value-types/tasks.md
+++ b/openspec/changes/normalize-extracted-value-types/tasks.md
@@ -94,8 +94,8 @@
 - [x] 4.4 Build one candidate wheel with `poetry build`. Record its SHA-256 and
   source commit. Do not release it.
   Candidate: `groundx-3.9.2-py3-none-any.whl`, source commit
-  `adbaa137f3da3d7c70f57bd7be1099cc009d30e3`, SHA-256
-  `5a52ef45dd7d53da3cdad40c23a9a2ca9f7570e60eed2bc03bfd4123b6f86ee5`.
+  `d37d8d7679ca29a3c03dea1460016d9a82b2b55f`, SHA-256
+  `76d71b1bb1f00404a3243424df16eccc0926a00bc9d4ee962c83986cdb47abc2`.
 
 ## 5. Prove The Internal Arcadia Consumer
 

--- a/openspec/changes/normalize-extracted-value-types/tasks.md
+++ b/openspec/changes/normalize-extracted-value-types/tasks.md
@@ -1,0 +1,177 @@
+## 0. Establish The Pushed Baseline
+
+- [x] 0.1 Create the SDK change branch from the current pushed `origin/main`,
+  carry this OpenSpec change onto it without unrelated local files, and verify
+  the reviewed SDK symbols and Fern boundaries still match before implementation.
+
+## 1. Lock The Shared Coercion Contract
+
+- [x] 1.1 Add `CoercionResult` and `coerce_value` import expectations to
+  `tests/extract/utility/test_utility.py`, then add a table-driven failing test
+  for `str`, `int`, `float`, `list`, `dict`, unions, null, unknown targets, and
+  impossible conversions. Assert value, exact Python type, matched status,
+  converted status, and warning contents.
+- [x] 1.2 Add explicit regressions for `True` to `"true"`, `False` to `"false"`,
+  boolean to numeric unmatched null, `"0"` remaining a string, list and dict JSON
+  encoding, JSON container parsing, decimal union selection, impossible
+  conversion to null, direct null input, decimal-to-int truncation, and
+  empty numeric text becoming null rather than zero. For every declared type,
+  prove a missing or unmatched field remains present as null instead of becoming
+  an empty string, list, or dict.
+- [x] 1.3 Run
+  `poetry run pytest -q tests/extract/utility/test_utility.py` and confirm the
+  tests fail because the shared interface does not exist.
+
+## 2. Implement One SDK Conversion Boundary
+
+- [x] 2.1 Implement `CoercionResult` and `coerce_value` in
+  `src/groundx/extract/utility/utility.py` using exact type checks, JSON encoding
+  and decoding, guarded numeric casts, deterministic union precedence, and
+  unmatched null fallback.
+- [x] 2.2 Export the new interface from
+  `src/groundx/extract/utility/__init__.py`. Rewrite
+  `coerce_numeric_string` as a compatibility wrapper that returns
+  `coerce_value(...).value` without changing its signature or implementing a
+  second conversion matrix.
+- [x] 2.3 Add failing tests in `tests/extract/classes/test_prompt.py` proving a
+  boolean does not pass direct integer or float validation. Add failing tests in
+  `tests/extract/classes/test_field.py` proving all supported targets use the
+  shared helper, date normalization remains unchanged, `True` for `str` reads as
+  `"true"`, and missing or impossible values remain nonfatal nulls through
+  readback and serialization for every declared type.
+- [x] 2.4 Update `src/groundx/extract/classes/prompt.py` to validate exact types.
+  Update `src/groundx/extract/classes/field.py` to accept JSON-compatible input,
+  delegate primitive conversion, make `none_value` return `None` for every
+  declared type, preserve date handling, and expose the latest content-free
+  warning without serializing it into extracted JSON.
+- [x] 2.5 Route SDK confidence validation through `coerce_value`. Preserve its
+  public tuple shape, return a field-scoped nonfatal warning for unmatched input,
+  and never include the raw value in the warning.
+- [x] 2.6 Run
+  `poetry run pytest -q tests/extract/utility/test_utility.py tests/extract/classes/test_prompt.py tests/extract/classes/test_field.py`
+  and confirm all focused conversion tests pass.
+
+## 3. Make Parser Retry Output-Safe
+
+- [x] 3.1 Add failing tests under `tests/extract/agents/` proving malformed JSON
+  recovery makes two provider calls, returns the corrected result, preserves
+  exact trace events, and writes no raw response or stack trace to stdout,
+  stderr, or ordinary logs.
+- [x] 3.2 Add wrong-native-type and wrong-parsed-type regressions for
+  `process_response`, `AgentTool`, and the shared behavior used by `AgentCode`.
+  Include native and JSON-string `answer.type` envelopes whose outer object is
+  valid but whose unwrapped value has the wrong type. Prove the first failure
+  consumes the configured parser retry, exhaustion remains terminal, and the
+  exception message contains expected-type context without raw provider content.
+- [x] 3.3 Remove direct parser-retry output, `traceback.print_stack()`, and raw
+  provider content from raised parser exception messages in
+  `src/groundx/extract/agents/agent.py`. Unwrap supported response envelopes
+  before validating the final value against `expected_types`. Keep the exception
+  class and expected-type context. Keep any retry log content-free and debug-only,
+  and preserve the existing `AgentTool` trace events.
+- [x] 3.4 Add transport-failure and post-parser `TypeError` tests proving parser
+  retry does not consume or replace another retry owner's failure.
+- [x] 3.5 Run `poetry run pytest -q tests/extract/agents` and confirm the focused
+  parser suite passes with captured stdout, stderr, and logs empty of provider
+  content.
+
+## 4. Prove SDK Compatibility Before Release
+
+- [x] 4.1 Inventory every SDK caller of `coerce_numeric_string`,
+  `Prompt.valid_value`, `ExtractedField.set_value`, `ExtractedField.get_value`,
+  and `process_response`. Add a focused regression for each distinct supported
+  call shape not covered above.
+- [x] 4.2 Confirm every modified source and test path is protected by the current
+  `.fernignore`. Do not edit generated files or package metadata.
+- [ ] 4.3 Run `poetry run ruff check .`, `poetry run ruff format --check .`,
+  `poetry run mypy .`, `poetry run pytest -rP -n auto .`,
+  `scripts/check-line-endings.sh --all`, and `git diff --check`.
+  Changed files pass Ruff. The repository-wide Ruff check still reports 29
+  pre-existing import-order and f-string findings outside this change. Mypy,
+  parallel pytest, line endings, and diff checks pass.
+- [ ] 4.4 Build one candidate wheel with `poetry build`. Record its SHA-256 and
+  source commit. Do not release it.
+
+## 5. Prove The Internal Arcadia Consumer
+
+- [ ] 5.1 In an isolated Internal Arcadia environment, install the exact wheel
+  from task 4.4 and verify its SHA-256. Do not update `requirements.txt` to an
+  unreleased version.
+- [ ] 5.2 Inventory every Internal Arcadia caller of
+  `coerce_numeric_string`, `Prompt.valid_value`, and `ExtractedField`. Keep those
+  callers on the compatibility wrapper unless the caller writes model output to
+  a typed field and needs match metadata. Classify each migrated caller as a new
+  field write or an update to existing state.
+- [ ] 5.3 Add regressions for the current reproduction and the AGE-272 field
+  shape with native booleans for `employer_match_true_up` and
+  `safe_harbor_annual_true_up`. Assert lowercase strings, preserved sibling
+  fields, no new conversion log, and successful document completion. Do not
+  claim this reproduces the original terminal cause.
+- [ ] 5.4 Replace `_json_string_field_value` and other local primitive conversion
+  code only where shared-helper tests prove equivalent or corrected behavior.
+  Migrate only model-output field-writing boundaries that need match metadata to
+  `coerce_value`; keep other callers on the compatibility wrapper. Keep
+  prompt-specific business rules separate and add no second conversion helper.
+- [ ] 5.5 At each migrated field-writing boundary, write null when an unmatched
+  result creates a field with no valid prior value. When reconcile, QA, or
+  another update targets an existing valid field, reject the unmatched update
+  and preserve the prior value. Add the content-free metadata to one
+  request-local stage aggregate. Extend one existing stage completion or
+  terminal record with document, task, stage, workflow group, count, field
+  names, source types, and target types. Include no raw value, prompt, response,
+  source URL, credential, or exception message.
+- [ ] 5.6 Add statement, meter, charge, and confidence regressions for every
+  distinct migrated write shape. Prove new unmatched fields serialize as null,
+  unmatched updates do not erase valid prior values, sibling fields continue,
+  and only one stage aggregate is produced.
+- [ ] 5.7 Run the focused Internal Arcadia conversion, statement, meter, charge,
+  parser-retry, logging, and callback tests named by
+  `age-272-retry-terminal-agent-diagnostics` against the exact candidate wheel.
+
+## 6. Update Harness Guidance
+
+- [ ] 6.1 In `groundx-studio-harness`, update
+  `skills/groundx-extraction-workflows/references/2_schema_design.md`,
+  `16_prompt_writing.md`, and `prompt-quality.md` with the shared conversion
+  contract and explicit-prompt guidance.
+- [ ] 6.2 Update retrieval evals for boolean string output, container JSON text,
+  unmatched null behavior, and parser retry diagnostics.
+- [ ] 6.3 Run `node scripts/sync-plugin.mjs`,
+  `node scripts/sync-plugin.mjs --check`, and `node scripts/validate.mjs`. Do not
+  hand-edit generated plugin mirrors.
+
+## 7. Release And Roll Out Once
+
+- [ ] 7.1 Run focused offline regressions against the candidate wheel for the
+  current reproduction, Arcadia legacy, Arcadia v1, generic v1, and ADP v1.
+  Record the exact test or fixture and result for each surface.
+- [ ] 7.2 Merge the tested SDK PR. Give the human Fern release owner the requested
+  next version, merged commit, wheel hash, validation evidence, and Internal
+  Arcadia consumer pin. Do not tag, dispatch, or publish from GroundX Python.
+- [ ] 7.3 Pin the released version once in Internal Arcadia, reinstall from the
+  package index, and repeat focused, full-suite, type, line-ending, container,
+  and protected-surface checks.
+- [ ] 7.4 Complete the terminal diagnostic storage and rollout tasks in
+  `age-272-retry-terminal-agent-diagnostics`. Record the new and prior Internal
+  Arcadia image identities before deployment.
+- [ ] 7.5 Rerun document `5e68599a-e879-452b-a29e-753d3336fbce` with workflow
+  `1e066a84-1afe-4477-9c9c-82cd67ec9806` when an authorized production rerun is
+  available. Confirm completion and lowercase strings. Record this as current
+  behavior, not proof of the missing original terminal cause.
+- [ ] 7.6 Roll Internal Arcadia back to the recorded image if the current
+  reproduction or any protected surface regresses. Preserve rejected-run
+  evidence until disposition.
+
+## 8. Close Evidence Safely
+
+- [ ] 8.1 Before certification writes output, create one ignored dedicated run
+  root under `groundx-python/openspec/work/normalize-extracted-value-types/` with
+  owner, reason, and expiry. Use the installed Harness linked-repository local
+  artifact procedure, not Harness root-locked helpers.
+- [ ] 8.2 Settle the run as accepted, rejected, or superseded. Preserve only
+  approved sanitized handoffs, remove the exact run root, and verify its absence
+  before archive.
+- [ ] 8.3 Strictly validate this OpenSpec change and the linked Internal Arcadia
+  change with OpenSpec 1.3.1. Run `git diff --check` and confirm neither change
+  contains customer documents, X-Rays, prompts, model output, credentials, or
+  local run artifacts.

--- a/openspec/changes/normalize-extracted-value-types/tasks.md
+++ b/openspec/changes/normalize-extracted-value-types/tasks.md
@@ -94,8 +94,8 @@
 - [x] 4.4 Build one candidate wheel with `poetry build`. Record its SHA-256 and
   source commit. Do not release it.
   Candidate: `groundx-3.9.2-py3-none-any.whl`, source commit
-  `6944e54bd537266e7a133e491380e31750db619e`, SHA-256
-  `0fde74e1e1bea11d5e4f591b9fc166bc9eca4bf46dcbef7bacd765393753c76c`.
+  `adbaa137f3da3d7c70f57bd7be1099cc009d30e3`, SHA-256
+  `5a52ef45dd7d53da3cdad40c23a9a2ca9f7570e60eed2bc03bfd4123b6f86ee5`.
 
 ## 5. Prove The Internal Arcadia Consumer
 

--- a/openspec/changes/normalize-extracted-value-types/tasks.md
+++ b/openspec/changes/normalize-extracted-value-types/tasks.md
@@ -89,8 +89,11 @@
   Changed files pass Ruff. The repository-wide Ruff check still reports 29
   pre-existing import-order and f-string findings outside this change. Mypy,
   parallel pytest, line endings, and diff checks pass.
-- [ ] 4.4 Build one candidate wheel with `poetry build`. Record its SHA-256 and
+- [x] 4.4 Build one candidate wheel with `poetry build`. Record its SHA-256 and
   source commit. Do not release it.
+  Candidate: `groundx-3.9.2-py3-none-any.whl`, source commit
+  `870fa2d817c26466d94259002e3145868e9f285a`, SHA-256
+  `b1c4861b59aa73f80a84b7134828b03c42788ed7688f5f1b0d63b6d1c6ed6d96`.
 
 ## 5. Prove The Internal Arcadia Consumer
 

--- a/openspec/changes/normalize-extracted-value-types/tasks.md
+++ b/openspec/changes/normalize-extracted-value-types/tasks.md
@@ -94,8 +94,8 @@
 - [x] 4.4 Build one candidate wheel with `poetry build`. Record its SHA-256 and
   source commit. Do not release it.
   Candidate: `groundx-3.9.2-py3-none-any.whl`, source commit
-  `870fa2d817c26466d94259002e3145868e9f285a`, SHA-256
-  `b1c4861b59aa73f80a84b7134828b03c42788ed7688f5f1b0d63b6d1c6ed6d96`.
+  `6944e54bd537266e7a133e491380e31750db619e`, SHA-256
+  `0fde74e1e1bea11d5e4f591b9fc166bc9eca4bf46dcbef7bacd765393753c76c`.
 
 ## 5. Prove The Internal Arcadia Consumer
 

--- a/openspec/changes/normalize-extracted-value-types/tasks.md
+++ b/openspec/changes/normalize-extracted-value-types/tasks.md
@@ -93,9 +93,9 @@
   parallel pytest, line endings, and diff checks pass.
 - [x] 4.4 Build one candidate wheel with `poetry build`. Record its SHA-256 and
   source commit. Do not release it.
-  Candidate: `groundx-3.9.2-py3-none-any.whl`, source commit
-  `d37d8d7679ca29a3c03dea1460016d9a82b2b55f`, SHA-256
-  `76d71b1bb1f00404a3243424df16eccc0926a00bc9d4ee962c83986cdb47abc2`.
+  Candidate: `groundx-3.9.3-py3-none-any.whl`, source commit
+  `4c18c195e403cf48591aaa901b7bfdfe5364d60e`, SHA-256
+  `ecb57255c87291cbc8bb6df1af26ef6ea08e5152b1b52dfe94dc799fdd40945c`.
 
 ## 5. Prove The Internal Arcadia Consumer
 

--- a/openspec/changes/normalize-extracted-value-types/tasks.md
+++ b/openspec/changes/normalize-extracted-value-types/tasks.md
@@ -18,6 +18,8 @@
   empty numeric text becoming null rather than zero. For every declared type,
   prove a missing or unmatched field remains present as null instead of becoming
   an empty string, list, or dict.
+- [x] 1.2a Add a large integer-text regression proving integer coercion does not
+  lose precision through a binary floating-point conversion.
 - [x] 1.3 Run
   `poetry run pytest -q tests/extract/utility/test_utility.py` and confirm the
   tests fail because the shared interface does not exist.

--- a/src/groundx/extract/agents/agent.py
+++ b/src/groundx/extract/agents/agent.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
-import json, traceback, typing
+import json
+import typing
 from dataclasses import dataclass, field
 from urllib.parse import urlparse
 
+from ..services.deadline import remaining_operation_seconds
+from ..services.logger import Logger
+from ..settings.settings import AgentSettings
+from ..utility.utility import clean_json
 from smolagents import (  # pyright: ignore[reportMissingTypeStubs]
     CodeAgent,
     Tool,
@@ -19,11 +24,6 @@ from smolagents.models import (  # pyright: ignore[reportMissingTypeStubs]
     MessageRole,
     OpenAIServerModel,
 )
-
-from ..services.deadline import remaining_operation_seconds
-from ..services.logger import Logger
-from ..settings.settings import AgentSettings
-from ..utility.utility import clean_json
 
 if typing.TYPE_CHECKING:
     from PIL.Image import Image
@@ -111,13 +111,8 @@ class RemoteImageTaskStep(TaskStep):
     image_urls: typing.List[str] = field(default_factory=list)
 
     def to_messages(self, summary_mode: bool = False) -> typing.List[ChatMessage]:
-        content: typing.List[typing.Dict[str, typing.Any]] = [
-            {"type": "text", "text": f"New task:\n{self.task}"}
-        ]
-        content.extend(
-            {"type": "image_url", "image_url": {"url": image_url}}
-            for image_url in self.image_urls
-        )
+        content: typing.List[typing.Dict[str, typing.Any]] = [{"type": "text", "text": f"New task:\n{self.task}"}]
+        content.extend({"type": "image_url", "image_url": {"url": image_url}} for image_url in self.image_urls)
         return [ChatMessage(role=MessageRole.USER, content=content)]
 
     def dict(self) -> typing.Dict[str, typing.Any]:
@@ -145,47 +140,61 @@ def extract_response(res: typing.Dict[str, typing.Any]) -> typing.Any:
     return res
 
 
+class _ResponseTypeError(TypeError):
+    pass
+
+
+def _matches_expected_type(
+    value: typing.Any,
+    expected_types: typing.Union[type, typing.Tuple[type, ...]],
+) -> bool:
+    return isinstance(value, expected_types)
+
+
+def _expects_dict(expected_types: typing.Union[type, typing.Tuple[type, ...]]) -> bool:
+    return isinstance({}, expected_types)
+
+
+def _unwrap_response(
+    value: typing.Any,
+    expected_types: typing.Union[type, typing.Tuple[type, ...]],
+) -> typing.Any:
+    if (
+        type(value) is list
+        and not _matches_expected_type(value, expected_types)
+        and _expects_dict(expected_types)
+        and len(value) == 1
+    ):
+        value = value[0]
+    if type(value) is dict:
+        return extract_response(value)
+    return value
+
+
+def _raise_response_type_error(
+    value: typing.Any,
+    expected_types: typing.Union[type, typing.Tuple[type, ...]],
+) -> typing.NoReturn:
+    raise _ResponseTypeError(f"agent process result is not of expected type(s) {expected_types!r}, got {type(value)!r}")
+
+
 def process_response(
     res: typing.Any,
     expected_types: typing.Union[type, typing.Tuple[type, ...]] = dict,
 ) -> typing.Any:
-    if not isinstance(res, expected_types):
-        if (
-            isinstance(res, list)
-            and isinstance(dict(), expected_types)
-            and len(res) == 1  # pyright: ignore[reportUnknownArgumentType]
-        ):
-            return extract_response(
-                res[0]  # pyright: ignore[reportUnknownArgumentType]
-            )
+    candidate = res
+    if not _matches_expected_type(candidate, expected_types):
+        if type(candidate) is list and _expects_dict(expected_types) and len(candidate) == 1:
+            pass
+        elif type(candidate) is str:
+            candidate = json.loads(clean_json(candidate))
+        else:
+            _raise_response_type_error(candidate, expected_types)
 
-        if not isinstance(res, str):
-            traceback.print_stack()
-            raise TypeError(
-                f"agent process result is not of expected type(s) {expected_types!r}, got {type(res)!r}"  # type: ignore
-            )
-
-        res = clean_json(res)
-
-        loaded = json.loads(res)
-        if not isinstance(loaded, expected_types):
-            if isinstance(loaded, list) and isinstance(dict(), expected_types) and len(loaded) == 1:  # type: ignore
-                return extract_response(loaded[0])  # type: ignore
-
-            traceback.print_stack()
-            raise TypeError(
-                f"agent process result is not of expected type(s) {expected_types!r} after JSON parsing, got {type(loaded)!r}"  # type: ignore
-            )
-
-        if isinstance(loaded, typing.Dict):
-            return extract_response(loaded)  # type: ignore
-
-        return loaded
-
-    if isinstance(res, typing.Dict):
-        return extract_response(res)  # type: ignore
-
-    return res
+    candidate = _unwrap_response(candidate, expected_types)
+    if not _matches_expected_type(candidate, expected_types):
+        _raise_response_type_error(candidate, expected_types)
+    return candidate
 
 
 class AgentCode(CodeAgent):
@@ -237,15 +246,11 @@ class AgentCode(CodeAgent):
         try:
             return process_response(res=res, expected_types=expected_types)
 
-        except Exception as e:
+        except (json.JSONDecodeError, _ResponseTypeError) as e:
             if attempt >= self.response_parse_max_retries:
                 raise TypeError(
-                    f"agent process result is not of expected type(s) {expected_types!r}: [{e}]\n\n{res}"
-                )
-
-            self.log.debug_msg(
-                f"agent process result is not of expected type(s) {expected_types!r}: [{e}], attempting again [{attempt+1}]\n\n{res}"
-            )
+                    f"agent process result is not of expected type(s) {expected_types!r} after {attempt + 1} attempt(s)"
+                ) from None
 
             return self.process(conflict, images, expected_types, attempt + 1)
 
@@ -338,7 +343,7 @@ class AgentTool(ToolCallingAgent):
             )
             return parsed
 
-        except Exception as e:
+        except (json.JSONDecodeError, _ResponseTypeError) as e:
             _emit_agent_trace(
                 self.log,
                 trace_callback,
@@ -350,12 +355,8 @@ class AgentTool(ToolCallingAgent):
             )
             if attempt >= self.response_parse_max_retries:
                 raise TypeError(
-                    f"agent process result is not of expected type(s) {expected_types!r}: [{e}]\n\n{res}"
-                )
-
-            print(
-                f"agent process result is not of expected type(s) {expected_types!r}: [{e}], attempting again [{attempt+1}]\n\n{res}"
-            )
+                    f"agent process result is not of expected type(s) {expected_types!r} after {attempt + 1} attempt(s)"
+                ) from None
 
             return self.process(
                 conflict,
@@ -380,9 +381,7 @@ class AgentTool(ToolCallingAgent):
         self.memory.system_prompt = SystemPromptStep(system_prompt=self.system_prompt)
         self.memory.reset()
         self.monitor.reset()
-        self.memory.steps.append(
-            RemoteImageTaskStep(task=self.task, task_images=None, image_urls=image_urls)
-        )
+        self.memory.steps.append(RemoteImageTaskStep(task=self.task, task_images=None, image_urls=image_urls))
 
         try:
             try:
@@ -403,8 +402,7 @@ class AgentTool(ToolCallingAgent):
     ) -> str:
         if image_transport not in SUPPORTED_IMAGE_TRANSPORTS:
             raise ValueError(
-                "unsupported image_transport "
-                f"[{image_transport}]; expected one of {sorted(SUPPORTED_IMAGE_TRANSPORTS)}"
+                f"unsupported image_transport [{image_transport}]; expected one of {sorted(SUPPORTED_IMAGE_TRANSPORTS)}"
             )
         if image_urls and image_transport not in {"data_url", "remote_url"}:
             raise ValueError("image_urls require image_transport='data_url' or 'remote_url'")

--- a/src/groundx/extract/classes/document.py
+++ b/src/groundx/extract/classes/document.py
@@ -170,6 +170,8 @@ class Document(Group):
             return None, element
 
         element.prompt = gf.prompt
+        if isinstance(element, ExtractedField):
+            element.set_value(element.value)
 
         if group_name != parent:
             return parent, element

--- a/src/groundx/extract/classes/field.py
+++ b/src/groundx/extract/classes/field.py
@@ -1,29 +1,35 @@
-import dateparser, typing
-from pydantic import Field
-from typing_extensions import Annotated
+import typing
 
+import dateparser
+from ..utility import coerce_value, str_to_type_sequence
 from .element import Element
-from ..utility import str_to_type_sequence
+from pydantic import Field, PrivateAttr
+from typing_extensions import Annotated
 
 
 class ExtractedField(Element):
     confidence: typing.Optional[str] = None
     conflicts: Annotated[typing.List[typing.Any], Field(default_factory=list)]
 
-    value: typing.Optional[typing.Union[str, float, typing.List[typing.Any]]] = ""
+    value: typing.Any = None
+    _coercion_warning: typing.Optional[str] = PrivateAttr(default=None)
 
     def __init__(
         self,
-        value: typing.Union[str, float, typing.List[typing.Any]] = "",
+        value: typing.Any = None,
         **data: typing.Any,
     ) -> None:
         super().__init__(**data)
 
         self.set_value(value)
 
+    @property
+    def coercion_warning(self) -> typing.Optional[str]:
+        return self._coercion_warning
+
     def attr_name(self) -> typing.Optional[str]:
         if not self.prompt:
-            raise Exception(f"prompt is not set")
+            raise Exception("prompt is not set")
 
         return self.prompt.attr_name
 
@@ -91,71 +97,23 @@ class ExtractedField(Element):
 
     def get_value(
         self,
-    ) -> typing.Optional[typing.Union[str, float, typing.List[typing.Any]]]:
+    ) -> typing.Any:
         if self.value is None:
-            return self.none_value()
-
-        ty = self.type()
-        if ty is None:
-            return self.value
-
-        expected_types = str_to_type_sequence(ty)
-
-        if type(self.value) in expected_types:
-            return self.value
-
-        if isinstance(self.value, dict):
-            nv = typing.cast(typing.Dict[str, typing.Any], self.value)
-            if "value" in nv and (
-                isinstance(nv["value"], str)
-                or isinstance(nv["value"], float)
-                or isinstance(nv["value"], int)
-            ):
-                return nv["value"]
-
-        if not isinstance(self.value, (str, float, int)):
-            return self.value
-
-        if isinstance(self.value, str):
-            if not self.value:
-                if any(t in (int, float) for t in expected_types):
-                    return self.none_value()
-                ev = self.empty_value()
-                if ev is not None:
-                    return ev
-                return self.value
-            if float in expected_types:
-                return float(self.value)
-            return int(self.value)
-
-        return str(self.value)
+            return None
+        expected_type = self.prompt.type if self.prompt else None
+        result = coerce_value(self.value, expected_type)
+        self._set_coercion_warning(result.warning)
+        return result.value
 
     def key(self) -> str:
         if not self.prompt:
-            raise Exception(f"prompt is not set")
+            raise Exception("prompt is not set")
 
         return self.prompt.key()
 
     def none_value(
         self,
     ) -> typing.Optional[typing.Optional[typing.Union[int, float, typing.Any]]]:
-        ty = self.type()
-        if ty is None:
-            return None
-        expected_types = str_to_type_sequence(ty)
-
-        if any(t in (int, float) for t in expected_types):
-            return None
-
-        if str in expected_types:
-            return ""
-
-        if list in expected_types:
-            return []
-
-        if dict in expected_types:
-            return {}
-
         return None
 
     def remove_conflict(self, value: typing.Any) -> None:
@@ -213,42 +171,40 @@ Special Instructions:
 
     def required(self) -> bool:
         if not self.prompt:
-            raise Exception(f"prompt is not set")
+            raise Exception("prompt is not set")
 
         return self.prompt.required
 
-    def set_value(
-        self, value: typing.Union[str, float, typing.List[typing.Any]]
-    ) -> None:
-        if isinstance(value, int):
-            self.value = float(value)
-        elif (
-            isinstance(value, str)
-            and self.prompt
-            and self.prompt.attr_name
-            and "date" in self.prompt.key().lower()
-        ):
+    def set_value(self, value: typing.Any) -> None:
+        if type(value) is str and self.prompt and self.prompt.attr_name and "date" in self.prompt.key().lower():
             try:
                 dt = dateparser.parse(value)
-                if dt is None:
-                    self.value = value
-                else:
-                    self.value = dt.strftime("%Y-%m-%d")
-            except Exception as e:
-                print(f"date error [{value}]: [{e}]")
-                self.value = value
-        else:
-            self.value = value
+                if dt is not None:
+                    value = dt.strftime("%Y-%m-%d")
+            except Exception:
+                pass
+
+        expected_type = self.prompt.type if self.prompt else None
+        result = coerce_value(value, expected_type)
+        self.value = result.value
+        self._set_coercion_warning(result.warning)
+
+    def _set_coercion_warning(self, warning: typing.Optional[str]) -> None:
+        if warning is None:
+            self._coercion_warning = None
+            return
+        field_name = self.prompt.attr_name if self.prompt and self.prompt.attr_name else "unknown"
+        self._coercion_warning = f"field {field_name}: {warning}"
 
     def type(self) -> typing.Optional[typing.Union[str, typing.List[str]]]:
         if not self.prompt:
-            raise Exception(f"prompt is not set")
+            raise Exception("prompt is not set")
 
         return self.prompt.type
 
     def valid_value(self, value: typing.Any) -> bool:
         if not self.prompt:
-            raise Exception(f"prompt is not set")
+            raise Exception("prompt is not set")
 
         return self.prompt.valid_value(value)
 

--- a/src/groundx/extract/classes/prompt.py
+++ b/src/groundx/extract/classes/prompt.py
@@ -1,8 +1,7 @@
 import typing
 
+from ..utility import coerce_value
 from pydantic import BaseModel, ConfigDict
-
-from ..utility import str_to_type_sequence
 
 
 class Prompt(BaseModel):
@@ -28,21 +27,5 @@ class Prompt(BaseModel):
         if not ty:
             return True
 
-        types: typing.List[typing.Type[typing.Any]] = []
-        if isinstance(ty, list):
-            for t in ty:
-                if t == "int" or t == "float":
-                    types.extend([int, float])
-                elif t == "str":
-                    types.append(str)
-
-            return isinstance(value, tuple(types))
-
-        exp = str_to_type_sequence(ty)
-        for et in exp:
-            if et in (int, float):
-                types.extend([int, float])
-            else:
-                types.append(et)
-        types = list(dict.fromkeys(types))
-        return isinstance(value, tuple(types))
+        result = coerce_value(value, ty)
+        return result.matched and not result.converted

--- a/src/groundx/extract/utility/__init__.py
+++ b/src/groundx/extract/utility/__init__.py
@@ -1,11 +1,15 @@
 from .utility import (
+    CoercionResult,
     clean_json,
     coerce_numeric_string,
+    coerce_value,
     str_to_type_sequence,
 )
 
 __all__ = [
+    "CoercionResult",
     "clean_json",
     "coerce_numeric_string",
+    "coerce_value",
     "str_to_type_sequence",
 ]

--- a/src/groundx/extract/utility/utility.py
+++ b/src/groundx/extract/utility/utility.py
@@ -1,5 +1,6 @@
 import dataclasses
 import json
+import math
 import typing
 
 
@@ -53,6 +54,9 @@ def _coerce_to_type(value: typing.Any, target: str) -> typing.Tuple[typing.Any, 
         else:
             return None, False
 
+        if type(number) is float and not math.isfinite(number):
+            return None, False
+
         try:
             if target_type is int:
                 return int(number), True
@@ -88,10 +92,6 @@ def coerce_value(
         )
 
     supported_targets = [target for target in targets if target in _SUPPORTED_TYPES]
-    for target in supported_targets:
-        if type(value) is _SUPPORTED_TYPES[target]:
-            return CoercionResult(value=value, matched=True, converted=False)
-
     if len(supported_targets) != len(targets):
         return CoercionResult(
             value=None,
@@ -99,6 +99,18 @@ def coerce_value(
             converted=False,
             warning=_coercion_warning(value, targets),
         )
+
+    if type(value) is float and not math.isfinite(value):
+        return CoercionResult(
+            value=None,
+            matched=False,
+            converted=False,
+            warning=_coercion_warning(value, targets),
+        )
+
+    for target in supported_targets:
+        if type(value) is _SUPPORTED_TYPES[target]:
+            return CoercionResult(value=value, matched=True, converted=False)
 
     if value is None:
         return CoercionResult(value=None, matched=True, converted=False)

--- a/src/groundx/extract/utility/utility.py
+++ b/src/groundx/extract/utility/utility.py
@@ -1,4 +1,5 @@
 import dataclasses
+import decimal
 import json
 import typing
 
@@ -41,8 +42,8 @@ def _coerce_to_type(value: typing.Any, target: str) -> typing.Tuple[typing.Any, 
             if not normalized:
                 return None, False
             try:
-                number = float(normalized)
-            except (OverflowError, ValueError):
+                number = decimal.Decimal(normalized) if target_type is int else float(normalized)
+            except (decimal.InvalidOperation, OverflowError, ValueError):
                 return None, False
         elif type(value) in (int, float):
             number = value

--- a/src/groundx/extract/utility/utility.py
+++ b/src/groundx/extract/utility/utility.py
@@ -1,5 +1,4 @@
 import dataclasses
-import decimal
 import json
 import typing
 
@@ -42,8 +41,12 @@ def _coerce_to_type(value: typing.Any, target: str) -> typing.Tuple[typing.Any, 
             if not normalized:
                 return None, False
             try:
-                number = decimal.Decimal(normalized) if target_type is int else float(normalized)
-            except (decimal.InvalidOperation, OverflowError, ValueError):
+                number: typing.Union[int, float]
+                if target_type is int and not any(char in normalized for char in ".eE"):
+                    number = int(normalized)
+                else:
+                    number = float(normalized)
+            except (OverflowError, ValueError):
                 return None, False
         elif type(value) in (int, float):
             number = value

--- a/src/groundx/extract/utility/utility.py
+++ b/src/groundx/extract/utility/utility.py
@@ -1,4 +1,123 @@
+import dataclasses
+import json
 import typing
+
+
+@dataclasses.dataclass(frozen=True)
+class CoercionResult:
+    value: typing.Any
+    matched: bool
+    converted: bool
+    warning: typing.Optional[str] = None
+
+
+_SUPPORTED_TYPES: typing.Dict[str, typing.Type[typing.Any]] = {
+    "str": str,
+    "int": int,
+    "float": float,
+    "list": list,
+    "dict": dict,
+}
+
+
+def _coercion_warning(value: typing.Any, targets: typing.Sequence[str]) -> str:
+    target_names = ", ".join(targets) if targets else "unsupported"
+    return f"cannot coerce {type(value).__name__} to {target_names}"
+
+
+def _coerce_to_type(value: typing.Any, target: str) -> typing.Tuple[typing.Any, bool]:
+    target_type = _SUPPORTED_TYPES[target]
+
+    if target_type is str:
+        if type(value) in (bool, int, float, list, dict):
+            return json.dumps(value, separators=(",", ":")), True
+        return None, False
+
+    if target_type in (int, float):
+        if type(value) is bool or type(value) in (list, dict):
+            return None, False
+        if type(value) is str:
+            normalized = value.replace(",", "")
+            if not normalized:
+                return None, False
+            try:
+                number = float(normalized)
+            except (OverflowError, ValueError):
+                return None, False
+        elif type(value) in (int, float):
+            number = value
+        else:
+            return None, False
+
+        try:
+            if target_type is int:
+                return int(number), True
+            return float(number), True
+        except (OverflowError, ValueError):
+            return None, False
+
+    if target_type in (list, dict) and type(value) is str:
+        try:
+            decoded = json.loads(value)
+        except (json.JSONDecodeError, RecursionError):
+            return None, False
+        if type(decoded) is target_type:
+            return decoded, True
+
+    return None, False
+
+
+def coerce_value(
+    value: typing.Any,
+    expected_types: typing.Optional[typing.Union[str, typing.List[str]]] = None,
+) -> CoercionResult:
+    if not expected_types:
+        return CoercionResult(value=value, matched=True, converted=False)
+
+    targets = [expected_types] if isinstance(expected_types, str) else expected_types
+    if not isinstance(targets, list) or not all(isinstance(target, str) for target in targets):
+        return CoercionResult(
+            value=None,
+            matched=False,
+            converted=False,
+            warning=_coercion_warning(value, []),
+        )
+
+    supported_targets = [target for target in targets if target in _SUPPORTED_TYPES]
+    for target in supported_targets:
+        if type(value) is _SUPPORTED_TYPES[target]:
+            return CoercionResult(value=value, matched=True, converted=False)
+
+    if len(supported_targets) != len(targets):
+        return CoercionResult(
+            value=None,
+            matched=False,
+            converted=False,
+            warning=_coercion_warning(value, targets),
+        )
+
+    if value is None:
+        return CoercionResult(value=None, matched=True, converted=False)
+
+    conversion_order = supported_targets
+    if set(supported_targets) == {"int", "float"} and type(value) is str:
+        normalized = value.replace(",", "")
+        conversion_order = ["float", "int"] if any(char in normalized for char in ".eE") else ["int", "float"]
+
+    for target in conversion_order:
+        try:
+            converted_value, converted = _coerce_to_type(value, target)
+        except (RecursionError, TypeError, ValueError):
+            continue
+        if converted:
+            return CoercionResult(value=converted_value, matched=True, converted=True)
+
+    return CoercionResult(
+        value=None,
+        matched=False,
+        converted=False,
+        warning=_coercion_warning(value, targets),
+    )
 
 
 def _complete_json_document_end(txt: str) -> typing.Optional[int]:
@@ -67,39 +186,7 @@ def coerce_numeric_string(
     value: typing.Any,
     et: typing.Optional[typing.Union[str, typing.List[str]]] = None,
 ) -> typing.Optional[typing.Union[int, float, typing.Any]]:
-    if not et:
-        return value
-
-    expected_types = str_to_type_sequence(et)
-
-    if isinstance(value, dict):
-        if (
-            "value" not in value
-            or not isinstance(value["value"], str)
-            or not isinstance(value["value"], float)
-            or not isinstance(value["value"], int)
-        ):
-            return ""
-        value = value["value"]
-
-    if any(t in (int, float) for t in expected_types):
-        if isinstance(value, str):
-            if value == "":
-                return 0.0
-
-            value = value.replace(",", "")
-            try:
-                value = float(value)
-            except ValueError:
-                return value
-        if float in expected_types:
-            return value
-        return int(value)
-
-    if str in expected_types and isinstance(value, str) and value == "0":
-        return None
-
-    return str(value)
+    return coerce_value(value, et).value
 
 
 def str_to_type_sequence(
@@ -176,46 +263,47 @@ def validate_confidence(
         return (
             None,
             None,
-            f"unexpected value type [{key_data.attr_name}] [{type(value)}] [{key_data.type}]\n[{value}]",
+            f"field {key_data.attr_name}: expected confidence object, got {type(value).__name__}",
         )
 
     if "value" not in value:
         return (
             None,
             None,
-            f'value is missing "value" key [{key_data.attr_name}]\n[{value}]',
+            f"field {key_data.attr_name}: confidence object is missing value",
         )
 
     if value["value"] is None:
         return None, None, None
 
-    final_value = coerce_numeric_string(value["value"], key_data.type)
-    if not key_data.valid_value(final_value):
+    result = coerce_value(value["value"], key_data.type)
+    final_value = result.value
+    if not result.matched:
         return (
             final_value,
             None,
-            f"unexpected type for statement [{key}] value [{type(final_value)}]\n\n{final_value}",
+            f"field {key_data.attr_name}: {result.warning}",
         )
 
     if "confidence" not in value:
         return (
             final_value,
             None,
-            f'value is missing "confidence" key [{key_data.attr_name}]\n[{value}]',
+            f"field {key_data.attr_name}: confidence object is missing confidence",
         )
 
     if not isinstance(value["confidence"], str):
         return (
             final_value,
             None,
-            f"confidence is not type str [{key_data.attr_name}]\n[{value}]",
+            f"field {key_data.attr_name}: confidence must be str, got {type(value['confidence']).__name__}",
         )
 
     if value["confidence"] not in ["low", "medium", "high"]:
         return (
             final_value,
             None,
-            f'confidence value is unsupported value [{key_data.attr_name}]\n[{value["confidence"]}]',
+            f"field {key_data.attr_name}: confidence is unsupported",
         )
 
     return final_value, value["confidence"], None

--- a/tests/extract/agents/test_agent_response_reliability.py
+++ b/tests/extract/agents/test_agent_response_reliability.py
@@ -1,0 +1,148 @@
+import typing
+
+import pytest
+
+try:
+    from smolagents import CodeAgent, ToolCallingAgent
+except ModuleNotFoundError:
+    pytest.skip("smolagents extra is not installed", allow_module_level=True)
+
+import groundx.extract.agents.agent as agent_module
+from groundx.extract.agents.agent import AgentCode, AgentTool, process_response
+from groundx.extract.services.logger import Logger
+from groundx.extract.settings.settings import AgentSettings
+
+
+def settings(retries: int) -> AgentSettings:
+    return AgentSettings(
+        api_key="test-key",
+        model_id="test-model",
+        max_steps=1,
+        response_parse_max_retries=retries,
+        imports=[],
+    )
+
+
+def test_process_response_validates_unwrapped_native_and_json_envelopes() -> None:
+    for response in [
+        {"answer": {"type": ["private value"]}},
+        '{"answer":{"type":["private value"]}}',
+        [{"answer": {"type": ["private value"]}}],
+    ]:
+        with pytest.raises(TypeError) as exc:
+            process_response(response, dict)
+        assert "expected type(s)" in str(exc.value)
+        assert "private value" not in str(exc.value)
+
+
+def test_process_response_preserves_an_exact_list_union_member() -> None:
+    response = [{"answer": {"type": {"ok": True}}}]
+
+    assert process_response(response, (dict, list)) == response
+
+
+def test_agent_tool_retries_one_parser_failure_without_ordinary_output(
+    monkeypatch,
+    capsys,
+    caplog,
+) -> None:
+    responses = iter(["{private malformed", '{"answer":{"type":{"ok":true}}}'])
+    calls = 0
+    events: typing.List[typing.Dict[str, typing.Any]] = []
+
+    def fake_run(self: typing.Any, task: str, images: typing.List[typing.Any]) -> str:
+        nonlocal calls
+        calls += 1
+        return next(responses)
+
+    monkeypatch.setattr(ToolCallingAgent, "run", fake_run)
+    agent = AgentTool(settings(1), Logger("agent-retry-safe", "debug"))
+
+    assert agent.process("parse", images=[], trace_callback=events.append) == {"ok": True}
+    assert calls == 2
+    assert [(event["event"], event["attempt"]) for event in events] == [
+        ("prompt", 0),
+        ("raw_response", 0),
+        ("parse_error", 0),
+        ("prompt", 1),
+        ("raw_response", 1),
+        ("parsed_response", 1),
+    ]
+    assert events[2]["raw_response"] == "{private malformed"
+    captured = capsys.readouterr()
+    ordinary_output = captured.out + captured.err + caplog.text
+    assert "private malformed" not in ordinary_output
+    assert "Traceback" not in ordinary_output
+
+
+def test_agent_tool_parser_exhaustion_is_terminal_and_content_free(
+    monkeypatch,
+    capsys,
+    caplog,
+) -> None:
+    calls = 0
+    events: typing.List[typing.Dict[str, typing.Any]] = []
+
+    def fake_run(self: typing.Any, task: str, images: typing.List[typing.Any]) -> str:
+        nonlocal calls
+        calls += 1
+        return "{private malformed"
+
+    monkeypatch.setattr(ToolCallingAgent, "run", fake_run)
+    agent = AgentTool(settings(1), Logger("agent-exhaustion-safe", "debug"))
+
+    with pytest.raises(TypeError) as exc:
+        agent.process("parse", images=[], trace_callback=events.append)
+
+    assert calls == 2
+    assert "expected type(s)" in str(exc.value)
+    assert "private malformed" not in str(exc.value)
+    assert [event["event"] for event in events].count("parse_error") == 2
+    assert events[-1]["raw_response"] == "{private malformed"
+    captured = capsys.readouterr()
+    ordinary_output = captured.out + captured.err + caplog.text
+    assert "private malformed" not in ordinary_output
+    assert "Traceback" not in ordinary_output
+
+
+def test_agent_tool_does_not_retry_transport_or_unowned_type_errors(monkeypatch) -> None:
+    calls = 0
+
+    def transport_failure(self: typing.Any, task: str, images: typing.List[typing.Any]) -> str:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("transport unavailable")
+
+    monkeypatch.setattr(ToolCallingAgent, "run", transport_failure)
+    agent = AgentTool(settings(1), Logger("agent-transport-owner", "error"))
+    with pytest.raises(RuntimeError, match="transport unavailable"):
+        agent.process("parse", images=[])
+    assert calls == 1
+
+    monkeypatch.setattr(ToolCallingAgent, "run", lambda *_args, **_kwargs: "{}")
+    monkeypatch.setattr(
+        agent_module,
+        "process_response",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(TypeError("downstream type error")),
+    )
+    with pytest.raises(TypeError, match="downstream type error"):
+        agent.process("parse", images=[])
+
+
+def test_agent_code_parser_exhaustion_is_content_free(monkeypatch) -> None:
+    calls = 0
+
+    def fake_run(self: typing.Any, *args: typing.Any, **kwargs: typing.Any) -> str:
+        nonlocal calls
+        calls += 1
+        return "{private malformed"
+
+    monkeypatch.setattr(CodeAgent, "run", fake_run)
+    agent = AgentCode(settings(1), Logger("agent-code-safe", "debug"))
+
+    with pytest.raises(TypeError) as exc:
+        agent.process("parse", images=[])
+
+    assert calls == 2
+    assert "expected type(s)" in str(exc.value)
+    assert "private malformed" not in str(exc.value)

--- a/tests/extract/classes/test_document.py
+++ b/tests/extract/classes/test_document.py
@@ -197,6 +197,21 @@ def _make_request() -> DocumentRequest:
 
 
 class TestDocument(unittest.TestCase):
+    def test_injected_prompt_coerces_value_before_serialization(self) -> None:
+        source = TestSource(SAMPLE_YAML_1)
+        manager = PromptManager(cache_source=source, config_source=source)
+
+        doc = Document.model_validate(
+            {"fields": {"statement_date": {"value": True}}},
+            context={"prompt_manager": manager},
+        )
+
+        field = doc.fields["statement_date"]
+        self.assertIsInstance(field, ExtractedField)
+        assert isinstance(field, ExtractedField)
+        self.assertEqual(field.get_value(), "true")
+        self.assertEqual(field.model_dump(exclude_none=False)["value"], "true")
+
     def setUp(self) -> None:
         patcher = patch("groundx.extract.classes.document.GroundXDocument.xray", autospec=True)
         self.mock_xray = patcher.start()

--- a/tests/extract/classes/test_field.py
+++ b/tests/extract/classes/test_field.py
@@ -6,10 +6,62 @@ import pytest
 pytest.importorskip("dateparser")
 
 
+from groundx.extract.classes.field import ExtractedField
+from groundx.extract.classes.prompt import Prompt
 from groundx.extract.classes.testing import TestField
 
 
+def typed_field(name, target, value):
+    return ExtractedField(
+        prompt=Prompt(
+            attr_name=name,
+            identifiers=[name],
+            instructions=name,
+            type=target,
+        ),
+        value=value,
+    )
+
+
 class TestExtractedField(unittest.TestCase):
+    def test_supported_types_use_shared_coercion(self):
+        cases = [
+            ("str_field", "str", True, "true"),
+            ("int_field", "int", "3.9", 3),
+            ("float_field", "float", "1,234.5", 1234.5),
+            ("list_field", "list", '[1,"two"]', [1, "two"]),
+            ("dict_field", "dict", '{"a":true}', {"a": True}),
+        ]
+        for name, target, value, expected in cases:
+            with self.subTest(target=target):
+                field = typed_field(name, target, value)
+                self.assertEqual(field.get_value(), expected)
+                self.assertIs(type(field.get_value()), type(expected))
+                self.assertIsNone(field.coercion_warning)
+
+    def test_missing_and_impossible_values_remain_null(self):
+        for target in ["str", "int", "float", "list", "dict"]:
+            with self.subTest(target=target, kind="missing"):
+                field = typed_field(f"{target}_field", target, None)
+                self.assertIsNone(field.get_value())
+                self.assertIn("value", field.model_dump(exclude_none=False))
+                self.assertIsNone(field.model_dump(exclude_none=False)["value"])
+
+            with self.subTest(target=target, kind="impossible"):
+                impossible = {"str": object(), "int": [], "float": {}, "list": "bad", "dict": "bad"}[target]
+                field = typed_field(f"{target}_field", target, impossible)
+                self.assertIsNone(field.get_value())
+                self.assertIsNone(field.model_dump(exclude_none=False)["value"])
+                self.assertIsNotNone(field.coercion_warning)
+                self.assertIn(f"{target}_field", field.coercion_warning)
+                self.assertNotIn("bad", field.coercion_warning)
+                self.assertNotIn("coercion_warning", field.model_dump(exclude_none=False))
+
+    def test_date_normalization_remains_separate(self):
+        field = typed_field("statement_date", "str", "3/29/25")
+        self.assertEqual(field.get_value(), "2025-03-29")
+        self.assertIsNone(field.coercion_warning)
+
     def test_equalToValue_string(self):
         ef = TestField("test", "hello")
         self.assertTrue(ef.equal_to_value("hello"))

--- a/tests/extract/classes/test_prompt.py
+++ b/tests/extract/classes/test_prompt.py
@@ -1,4 +1,5 @@
-import typing, unittest
+import typing
+import unittest
 
 from groundx.extract.classes.prompt import Prompt
 
@@ -27,16 +28,18 @@ class TestPromptValidValue(unittest.TestCase):
         p = TestPrompt("field1", "int")
         self.assertFalse(p.valid_value("hello"))
         self.assertTrue(p.valid_value(123))
-        self.assertTrue(p.valid_value(12.3))
+        self.assertFalse(p.valid_value(12.3))
+        self.assertFalse(p.valid_value(True))
         self.assertFalse(p.valid_value((1, 2, 3)))
         self.assertFalse(p.valid_value([1, 2, 3]))
 
     def test_single_type_float(self):
         p = TestPrompt("field1", "float")
         self.assertFalse(p.valid_value("hello"))
-        self.assertTrue(p.valid_value(123))
+        self.assertFalse(p.valid_value(123))
         self.assertTrue(p.valid_value(12.3))
         self.assertTrue(p.valid_value(123.0))
+        self.assertFalse(p.valid_value(False))
         self.assertFalse(p.valid_value((1, 2, 3)))
         self.assertFalse(p.valid_value([1, 2, 3]))
 
@@ -52,11 +55,20 @@ class TestPromptValidValue(unittest.TestCase):
     def test_list_of_types_success_and_failure(self):
         p = TestPrompt("field2", ["str", "float"])
         self.assertTrue(p.valid_value("hello"))
-        self.assertTrue(p.valid_value(123))
+        self.assertFalse(p.valid_value(123))
         self.assertTrue(p.valid_value(12.3))
         self.assertTrue(p.valid_value(123.0))
         self.assertFalse(p.valid_value((1, 2, 3)))
         self.assertFalse(p.valid_value([1, 2, 3]))
+
+    def test_container_and_numeric_union_types_are_exact(self):
+        self.assertTrue(TestPrompt("field", "dict").valid_value({"a": 1}))
+        self.assertFalse(TestPrompt("field", "dict").valid_value([1]))
+        numeric = TestPrompt("field", ["int", "float"])
+        self.assertTrue(numeric.valid_value(1))
+        self.assertTrue(numeric.valid_value(1.5))
+        self.assertFalse(numeric.valid_value(True))
+        self.assertFalse(TestPrompt("field", "date").valid_value("2025-01-01"))
 
     def test_repr_contains_fields(self):
         p = TestPrompt("field_5", "int")

--- a/tests/extract/utility/test_utility.py
+++ b/tests/extract/utility/test_utility.py
@@ -135,6 +135,15 @@ class TestUtilCoerceValue(unittest.TestCase):
         self.assert_result(coerce_value(3.14, ["int", "float"]), 3.14, float, True, False)
         self.assert_result(coerce_value(3, ["float", "int"]), 3, int, True, False)
 
+    def test_integer_text_does_not_lose_precision_through_float(self) -> None:
+        self.assert_result(
+            coerce_value("9007199254740993", "int"),
+            9007199254740993,
+            int,
+            True,
+            True,
+        )
+
     def test_impossible_conversions_return_content_free_warning(self) -> None:
         cases = [
             (True, "int", "bool", "int"),

--- a/tests/extract/utility/test_utility.py
+++ b/tests/extract/utility/test_utility.py
@@ -153,6 +153,31 @@ class TestUtilCoerceValue(unittest.TestCase):
             False,
         )
 
+    def test_non_finite_numeric_text_is_unmatched(self) -> None:
+        cases = [
+            ("1e100000000", "float"),
+            ("1e100000000", ["int", "float"]),
+            (float("inf"), "float"),
+        ]
+        for value, target in cases:
+            with self.subTest(value=value, target=target):
+                self.assert_result(
+                    coerce_value(value, target),
+                    None,
+                    type(None),
+                    False,
+                    False,
+                )
+
+    def test_union_with_unknown_target_is_unmatched(self) -> None:
+        self.assert_result(
+            coerce_value("text", ["str", "unsupported"]),
+            None,
+            type(None),
+            False,
+            False,
+        )
+
     def test_impossible_conversions_return_content_free_warning(self) -> None:
         cases = [
             (True, "int", "bool", "int"),

--- a/tests/extract/utility/test_utility.py
+++ b/tests/extract/utility/test_utility.py
@@ -154,7 +154,7 @@ class TestUtilCoerceValue(unittest.TestCase):
         )
 
     def test_non_finite_numeric_text_is_unmatched(self) -> None:
-        cases = [
+        cases: typing.List[typing.Tuple[typing.Any, typing.Union[str, typing.List[str]]]] = [
             ("1e100000000", "float"),
             ("1e100000000", ["int", "float"]),
             (float("inf"), "float"),

--- a/tests/extract/utility/test_utility.py
+++ b/tests/extract/utility/test_utility.py
@@ -2,7 +2,14 @@ import json
 import typing
 import unittest
 
-from groundx.extract.utility.utility import clean_json, coerce_numeric_string
+from groundx.extract.classes.prompt import Prompt
+from groundx.extract.utility.utility import (
+    CoercionResult,
+    clean_json,
+    coerce_numeric_string,
+    coerce_value,
+    validate_confidence,
+)
 
 
 class TestUtilCleanJson(unittest.TestCase):
@@ -31,30 +38,159 @@ class TestUtilCoerceNumericString(unittest.TestCase):
         # Numeric string to int or float based on content
         self.assertEqual(coerce_numeric_string("42", "int"), 42)
         self.assertEqual(coerce_numeric_string("3.14", "int"), 3)
-        self.assertEqual(coerce_numeric_string("foo", "int"), "foo")
+        self.assertIsNone(coerce_numeric_string("foo", "int"))
         self.assertEqual(coerce_numeric_string(8, "int"), 8)
         self.assertEqual(coerce_numeric_string(3.14, "int"), 3)
-        self.assertEqual(coerce_numeric_string("", "int"), 0)
+        self.assertIsNone(coerce_numeric_string("", "int"))
         self.assertEqual(coerce_numeric_string("0", "int"), 0)
 
     def test_expected_float(self) -> None:
         self.assertEqual(coerce_numeric_string("42", "float"), 42.0)
         self.assertEqual(coerce_numeric_string("3.14", "float"), 3.14)
-        self.assertEqual(coerce_numeric_string("foo", "float"), "foo")
+        self.assertIsNone(coerce_numeric_string("foo", "float"))
         self.assertEqual(coerce_numeric_string(9.81, "float"), 9.81)
         self.assertEqual(coerce_numeric_string(10, "float"), 10)
-        self.assertEqual(coerce_numeric_string("", "float"), 0.0)
+        self.assertIsNone(coerce_numeric_string("", "float"))
         self.assertEqual(coerce_numeric_string("0.0", "float"), 0.0)
 
     def test_expected_int_float_list(self) -> None:
         types: typing.List[str] = ["int", "float"]
         self.assertEqual(coerce_numeric_string("42", types), 42)
         self.assertEqual(coerce_numeric_string("3.14", types), 3.14)
-        self.assertEqual(coerce_numeric_string("foo", types), "foo")
+        self.assertIsNone(coerce_numeric_string("foo", types))
         self.assertEqual(coerce_numeric_string(11, types), 11)
         self.assertEqual(coerce_numeric_string(2.718, types), 2.718)
         self.assertEqual(coerce_numeric_string("0.00", types), 0.0)
-        self.assertEqual(coerce_numeric_string("", types), 0.0)
+        self.assertIsNone(coerce_numeric_string("", types))
+
+
+class TestUtilCoerceValue(unittest.TestCase):
+    def assert_result(
+        self,
+        result: CoercionResult,
+        value: typing.Any,
+        expected_type: typing.Optional[type],
+        matched: bool,
+        converted: bool,
+    ) -> None:
+        self.assertEqual(result.value, value)
+        if expected_type is not None:
+            self.assertIs(type(result.value), expected_type)
+        self.assertIs(result.matched, matched)
+        self.assertIs(result.converted, converted)
+        if matched:
+            self.assertIsNone(result.warning)
+        else:
+            self.assertIsNotNone(result.warning)
+
+    def test_exact_values_and_null_are_preserved(self) -> None:
+        cases: typing.List[typing.Tuple[typing.Any, typing.Union[str, typing.List[str]]]] = [
+            ("text", "str"),
+            (7, "int"),
+            (7.5, "float"),
+            ([1], "list"),
+            ({"a": 1}, "dict"),
+            (7, ["float", "int"]),
+        ]
+        for value, target in cases:
+            with self.subTest(value=value, target=target):
+                self.assert_result(coerce_value(value, target), value, type(value), True, False)
+
+        self.assert_result(coerce_value(None, "str"), None, type(None), True, False)
+        self.assert_result(coerce_value(None, ["int", "float"]), None, type(None), True, False)
+        self.assert_result(coerce_value({"a": 1}), {"a": 1}, dict, True, False)
+
+    def test_scalar_conversions_are_deterministic(self) -> None:
+        cases = [
+            (True, "str", "true", str, True),
+            (False, "str", "false", str, True),
+            (7, "str", "7", str, True),
+            (7.5, "str", "7.5", str, True),
+            ("0", "str", "0", str, False),
+            ("1,234", "int", 1234, int, True),
+            ("3.9", "int", 3, int, True),
+            ("-3.9", "int", -3, int, True),
+            ("1,234.5", "float", 1234.5, float, True),
+            (8, "float", 8.0, float, True),
+            (8.9, "int", 8, int, True),
+        ]
+        for value, target, expected, expected_type, converted in cases:
+            with self.subTest(value=value, target=target):
+                self.assert_result(coerce_value(value, target), expected, expected_type, True, converted)
+
+    def test_container_conversions_use_json(self) -> None:
+        cases = [
+            ([1, "two"], "str", '[1,"two"]', str),
+            ({"a": True}, "str", '{"a":true}', str),
+            ('[1,"two"]', "list", [1, "two"], list),
+            ('{"a":true}', "dict", {"a": True}, dict),
+        ]
+        for value, target, expected, expected_type in cases:
+            with self.subTest(value=value, target=target):
+                self.assert_result(coerce_value(value, target), expected, expected_type, True, True)
+
+    def test_numeric_union_preserves_exact_values_and_parses_by_content(self) -> None:
+        self.assert_result(coerce_value("42", ["int", "float"]), 42, int, True, True)
+        self.assert_result(coerce_value("3.14", ["int", "float"]), 3.14, float, True, True)
+        self.assert_result(coerce_value(3.14, ["int", "float"]), 3.14, float, True, False)
+        self.assert_result(coerce_value(3, ["float", "int"]), 3, int, True, False)
+
+    def test_impossible_conversions_return_content_free_warning(self) -> None:
+        cases = [
+            (True, "int", "bool", "int"),
+            (False, "float", "bool", "float"),
+            ("", "int", "str", "int"),
+            ("secret value", "float", "str", "float"),
+            ([1], "int", "list", "int"),
+            ({"a": 1}, "float", "dict", "float"),
+            ("not json", "list", "str", "list"),
+            ('{"a":1}', "list", "str", "list"),
+            ("[1]", "dict", "str", "dict"),
+            ("secret value", "date", "str", "date"),
+        ]
+        for value, target, source_name, target_name in cases:
+            with self.subTest(value=value, target=target):
+                result = coerce_value(value, target)
+                self.assert_result(result, None, type(None), False, False)
+                assert result.warning is not None
+                self.assertIn(source_name, result.warning)
+                self.assertIn(target_name, result.warning)
+                self.assertNotIn("secret value", result.warning)
+
+
+class TestValidateConfidence(unittest.TestCase):
+    def test_uses_shared_conversion_without_warning_on_success(self) -> None:
+        prompt = Prompt(attr_name="enabled", instructions="enabled", type="str")
+
+        value, confidence, warning = validate_confidence(
+            "enabled",
+            prompt,
+            {"enabled"},
+            {"value": True, "confidence": "high"},
+            {},
+        )
+
+        self.assertEqual((value, confidence, warning), ("true", "high", None))
+
+    def test_unmatched_value_returns_null_and_field_scoped_warning(self) -> None:
+        prompt = Prompt(attr_name="amount", instructions="amount", type="float")
+
+        value, confidence, warning = validate_confidence(
+            "amount",
+            prompt,
+            {"amount"},
+            {"value": "private text", "confidence": "high"},
+            {},
+        )
+
+        self.assertIsNone(value)
+        self.assertIsNone(confidence)
+        self.assertIsNotNone(warning)
+        assert warning is not None
+        self.assertIn("amount", warning)
+        self.assertIn("str", warning)
+        self.assertIn("float", warning)
+        self.assertNotIn("private text", warning)
 
 
 if __name__ == "__main__":

--- a/tests/extract/utility/test_utility.py
+++ b/tests/extract/utility/test_utility.py
@@ -144,6 +144,15 @@ class TestUtilCoerceValue(unittest.TestCase):
             True,
         )
 
+    def test_excessive_integer_exponent_is_unmatched(self) -> None:
+        self.assert_result(
+            coerce_value("1e100000000", "int"),
+            None,
+            type(None),
+            False,
+            False,
+        )
+
     def test_impossible_conversions_return_content_free_warning(self) -> None:
         cases = [
             (True, "int", "bool", "int"),


### PR DESCRIPTION
## Summary

- Add one shared coercion contract for string, number, list, dict, union, and null values
- Preserve exact integer text without a binary floating-point round trip
- Reject unsupported union members and non-finite numeric results as unmatched nulls
- Keep `coerce_numeric_string` as a compatibility wrapper
- Route fields, prompt validation, and confidence handling through the shared contract
- Validate unwrapped agent responses before returning them
- Keep parser retries bounded and remove provider content and stack output from ordinary logs and exceptions

## Validation

- `poetry run pytest -rP -n auto`: 811 passed, 21 skipped
- `poetry run mypy .`: passed
- Changed-file Ruff check and format check: passed
- `scripts/check-line-endings.sh --all`: passed
- `git diff --check`: passed
- OpenSpec 1.3.1 strict validation: passed
- `poetry build`: passed
- Candidate source commit: `4c18c195e403cf48591aaa901b7bfdfe5364d60e`
- Local candidate wheel: `groundx-3.9.3-py3-none-any.whl`
- Candidate wheel SHA-256: `ecb57255c87291cbc8bb6df1af26ef6ea08e5152b1b52dfe94dc799fdd40945c`

The candidate wheel is local test evidence, not a release. Downstream consumer tests must be repeated against the eventual released version. Repository-wide Ruff check and format check still report pre-existing findings outside this change.