### PR TITLE
Preserve every scalar extraction candidate

### DIFF
--- a/openspec/changes/complete-scalar-candidate-provenance/.openspec.yaml
+++ b/openspec/changes/complete-scalar-candidate-provenance/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/openspec/changes/complete-scalar-candidate-provenance/design.md
+++ b/openspec/changes/complete-scalar-candidate-provenance/design.md
@@ -21,10 +21,17 @@ The narrow correction belongs at this route boundary. Changing only
 
 ## Implementation
 
-Add one shared private repeated-route predicate used by both
-`_route_containers()` and `_custom_route_values()`. A route is repeated when its
-step kind is `keys` or `summary`, or its parsed `final_path` contains `*`.
-Repeatedness must not be inferred from `final_path` alone.
+Add one shared private repeated-route predicate used by
+`_route_containers()`, `_custom_route_values()`, and final placement. A route is
+repeated when its step kind is `keys` or `summary`, or its parsed `final_path`
+contains `*`. Repeatedness must not be inferred from `final_path` alone.
+
+Pass that predicate's result into `_set_pointer()`. Existing wildcard routes
+keep their current placement. For a repeated `keys` or `summary` route without
+`*`, `_set_pointer()` treats the first path segment as the top-level list and
+the remaining segments as fields in the repeated record. This is the narrow
+implementation of the existing `custom-output-readback` requirement. It does
+not alter singular routes or invent placement from a group name.
 
 For `level: section` routes:
 
@@ -87,10 +94,11 @@ relationship, and repeated-route behavior.
 
 ## Release dependency
 
-This change joins the unpublished source candidate produced for
-`delegate-scalar-candidate-resolution-to-agents`. The candidate keeps the
-repository's generated package version and records its source commit and
-SHA-256. Internal Arcadia and Studio Harness test it on Python 3.11 before the
+This change completes Tasks 1 and 2 before
+`delegate-scalar-candidate-resolution-to-agents` builds the one unpublished
+source candidate from the combined commit. The candidate keeps the repository's
+generated package version and records its source commit and SHA-256. Internal
+Arcadia and Studio Harness test only that candidate on Python 3.11 before the
 human release owner publishes requested version 3.9.7. After publication, both
 consumers verify the released package contains the same handwritten source
 change and rerun their gates from a clean install. The differently versioned

--- a/openspec/changes/complete-scalar-candidate-provenance/design.md
+++ b/openspec/changes/complete-scalar-candidate-provenance/design.md
@@ -1,0 +1,66 @@
+# Design: Complete scalar candidate provenance
+
+## Goal
+
+Allow singular routed fields to observe every section chunk while preserving
+the existing repeated-record deduplication contract.
+
+## Current loss point
+
+`_route_containers()` uses `custom_output_section_identity()` and one
+`section_seen` set for every section route. An explicit section ID becomes the
+identity. Later chunks with that ID are discarded before `_custom_route_values()`
+or `_set_pointer()` can inspect their values or page numbers.
+
+The narrow correction belongs at this route boundary. Changing only
+`_set_pointer()` cannot recover observations already discarded.
+
+## Implementation
+
+For `level: section` routes:
+
+1. Parse `final_path` with the existing pointer helper.
+2. If the path contains `*`, preserve the current section-ID deduplication.
+3. If the path is singular, emit one `_RouteContainer` per chunk. Use the chunk
+   identity for traversal bookkeeping and retain that chunk's page numbers.
+4. Let scalar candidate collection apply its approved value identity rules.
+   Equal values merge pages. Distinct values remain candidates in traversal
+   order.
+
+No second candidate deduplicator is added. No value meaning, confidence,
+default text, or page presence participates in this routing decision.
+
+## Compatibility
+
+- Chunk-level and document-level routes are unchanged.
+- Repeated section records still deduplicate by section identity.
+- Singular section output keeps the first observed candidate in provisional
+  `final_output`, as defined by the companion scalar-candidate plan.
+- `source_provenance` may contain multiple observation records. Candidate page
+  lists remain unique and first-seen ordered.
+- The public `CustomOutputReassemblyResult` and
+  `CustomOutputScalarCandidateSet` shapes do not change.
+
+## Verification
+
+The focused regression uses three chunks with the same explicit section ID:
+
+- page 12 returns `A`;
+- page 14 returns `A`;
+- page 16 returns `B`.
+
+The selected candidate must be `A` with pages `(12, 14)`. The alternative must
+be `B` with page `(16,)`.
+
+A separate repeated-record regression uses the same section ID on multiple
+chunks and proves the existing single repeated record remains unchanged.
+
+The complete extraction suite then protects chunk, section, document,
+relationship, and repeated-route behavior.
+
+## Release dependency
+
+This change joins the exact candidate wheel produced for
+`delegate-scalar-candidate-resolution-to-agents`. Internal Arcadia and Studio
+Harness test that wheel before the human release owner publishes requested
+version 3.9.7. This repository does not publish the package.

--- a/openspec/changes/complete-scalar-candidate-provenance/design.md
+++ b/openspec/changes/complete-scalar-candidate-provenance/design.md
@@ -2,38 +2,58 @@
 
 ## Goal
 
-Allow singular routed fields to observe every section chunk while preserving
-the existing repeated-record deduplication contract.
+Allow singular routed fields to observe every section and document occurrence
+while preserving the existing repeated-record deduplication contract.
 
 ## Current loss point
 
-`_route_containers()` uses `custom_output_section_identity()` and one
-`section_seen` set for every section route. An explicit section ID becomes the
-identity. Later chunks with that ID are discarded before `_custom_route_values()`
-or `_set_pointer()` can inspect their values or page numbers.
+`_route_containers()` discards evidence in two places before
+`_custom_route_values()` or `_set_pointer()` can inspect it:
+
+- Section routes use `custom_output_section_identity()` and one `section_seen`
+  set. Later chunks with the same explicit section ID are discarded.
+- Document routes deduplicate root and chunk copies by payload identity. The
+  surviving container has no page numbers, even when the copied observations
+  came from numbered chunks.
 
 The narrow correction belongs at this route boundary. Changing only
 `_set_pointer()` cannot recover observations already discarded.
 
 ## Implementation
 
+Add one shared private repeated-route predicate used by both
+`_route_containers()` and `_custom_route_values()`. A route is repeated when its
+step kind is `keys` or `summary`, or its parsed `final_path` contains `*`.
+Repeatedness must not be inferred from `final_path` alone.
+
 For `level: section` routes:
 
-1. Parse `final_path` with the existing pointer helper.
-2. If the path contains `*`, preserve the current section-ID deduplication.
+1. Use the shared repeated-route predicate.
+2. If the route is repeated, preserve current section-ID deduplication.
 3. If the path is singular, emit one `_RouteContainer` per chunk. Use the chunk
    identity for traversal bookkeeping and retain that chunk's page numbers.
 4. Let scalar candidate collection apply its approved value identity rules.
    Equal values merge pages. Distinct values remain candidates in traversal
    order.
 
+For `level: document` routes:
+
+1. If the route is repeated, preserve current payload-identity deduplication.
+2. If the route is singular, emit the document-root observation when present
+   and every chunk observation with its page numbers.
+3. Let scalar candidate collection merge equal values and their pages. Do not
+   invent a page for a root-only observation.
+
 No second candidate deduplicator is added. No value meaning, confidence,
 default text, or page presence participates in this routing decision.
 
 ## Compatibility
 
-- Chunk-level and document-level routes are unchanged.
+- Chunk-level routes are unchanged.
 - Repeated section records still deduplicate by section identity.
+- Repeated document records still deduplicate by payload identity.
+- Direct repeated groups owned by `keys` or `summary` remain repeated even when
+  their final paths contain no `*`.
 - Singular section output keeps the first observed candidate in provisional
   `final_output`, as defined by the companion scalar-candidate plan.
 - `source_provenance` may contain multiple observation records. Candidate page
@@ -52,8 +72,15 @@ The focused regression uses three chunks with the same explicit section ID:
 The selected candidate must be `A` with pages `(12, 14)`. The alternative must
 be `B` with page `(16,)`.
 
-A separate repeated-record regression uses the same section ID on multiple
-chunks and proves the existing single repeated record remains unchanged.
+A separate repeated-record regression uses a direct top-level `keys` route with
+no `*`, copies it across chunks with the same section ID, and proves the
+existing single repeated record remains unchanged.
+
+A document-level regression uses root and chunk copies where pages 12 and 14
+return `A` and page 16 returns `B`. It proves `A` retains pages `(12, 14)`, `B`
+retains page `(16,)`, and no page is invented for a root-only observation. A
+repeated document regression proves producer-copy deduplication remains
+unchanged for both wildcard and direct `keys` routes.
 
 The complete extraction suite then protects chunk, section, document,
 relationship, and repeated-route behavior.

--- a/openspec/changes/complete-scalar-candidate-provenance/design.md
+++ b/openspec/changes/complete-scalar-candidate-provenance/design.md
@@ -87,7 +87,12 @@ relationship, and repeated-route behavior.
 
 ## Release dependency
 
-This change joins the exact candidate wheel produced for
-`delegate-scalar-candidate-resolution-to-agents`. Internal Arcadia and Studio
-Harness test that wheel before the human release owner publishes requested
-version 3.9.7. This repository does not publish the package.
+This change joins the unpublished source candidate produced for
+`delegate-scalar-candidate-resolution-to-agents`. The candidate keeps the
+repository's generated package version and records its source commit and
+SHA-256. Internal Arcadia and Studio Harness test it on Python 3.11 before the
+human release owner publishes requested version 3.9.7. After publication, both
+consumers verify the released package contains the same handwritten source
+change and rerun their gates from a clean install. The differently versioned
+wheels are not required to be byte-identical. This repository does not publish
+the package.

--- a/openspec/changes/complete-scalar-candidate-provenance/proposal.md
+++ b/openspec/changes/complete-scalar-candidate-provenance/proposal.md
@@ -29,10 +29,12 @@ shape and violates the candidate transport contract for other documents.
 - Distinct values from chunks sharing a section ID remain distinct candidates.
 - One shared route-shape helper treats `keys` and `summary` steps, or a
   `final_path` containing `*`, as repeated.
+- Direct repeated `keys` and `summary` routes without `*` use the existing
+  top-level-array contract instead of falling through scalar placement.
 - Repeated section and document routes keep their current producer-copy
   deduplication.
-- Relationship matching, repeated-record identity, route placement, and public
-  result types do not change.
+- Relationship matching, repeated-record identity, unrelated route placement,
+  and public result types do not change.
 
 ## Relationship to active plans
 
@@ -44,7 +46,8 @@ shape and violates the candidate transport contract for other documents.
   `add-extraction-certification-harness` change.
 - Implementation starts from the candidate collection behavior defined by
   `delegate-scalar-candidate-resolution-to-agents`. Both changes ship in the
-  same requested GroundX Python 3.9.7 release.
+  same requested GroundX Python 3.9.7 release. Tasks 1 and 2 here complete
+  before the single combined unpublished consumer candidate is built.
 
 ## Capabilities
 
@@ -66,9 +69,9 @@ shape and violates the candidate transport contract for other documents.
 - Public dataclasses and imports remain unchanged.
 - Singular section and document routes may expose candidates and page numbers
   that were previously lost. This is the intended correction.
-- Repeated section and document output remains byte-for-byte compatible after
-  reassembly, including direct top-level groups owned by `keys` and `summary`
-  steps.
+- Repeated section and document producer-copy deduplication remains compatible.
+  Direct top-level groups owned by `keys` and `summary` steps are emitted as
+  arrays, as the existing SDK specification already requires.
 - The implementation stays under paths protected by `.fernignore`.
 - No workflow, API, database, customer JSON, or generated Fern change.
 - Open design questions: none.

--- a/openspec/changes/complete-scalar-candidate-provenance/proposal.md
+++ b/openspec/changes/complete-scalar-candidate-provenance/proposal.md
@@ -44,6 +44,8 @@ shape and violates the candidate transport contract for other documents.
 - It does not replace or close Internal Arcadia's
   `complete-extraction-boundary-regression-coverage` change or Studio Harness's
   `add-extraction-certification-harness` change.
+- Remaining cross-repository fixture and boundary work is owned by
+  `internal-arcadia-agents/openspec/changes/complete-extraction-boundary-regression-coverage/tasks.md`.
 - Implementation starts from the candidate collection behavior defined by
   `delegate-scalar-candidate-resolution-to-agents`. Both changes ship in the
   same requested GroundX Python 3.9.7 release. Tasks 1 and 2 here complete

--- a/openspec/changes/complete-scalar-candidate-provenance/proposal.md
+++ b/openspec/changes/complete-scalar-candidate-provenance/proposal.md
@@ -3,10 +3,16 @@
 ## Why
 
 `delegate-scalar-candidate-resolution-to-agents` requires the SDK to preserve
-every scalar observation and every source page. The current section-container
-loader deduplicates chunks by explicit section ID before scalar candidates are
-collected. When multiple chunks share a section ID, only the first chunk's value
-and pages reach candidate collection.
+every scalar observation and every source page. The current route-container
+loader removes observations before scalar candidates are collected:
+
+- section routes deduplicate chunks by explicit section ID; and
+- document routes deduplicate copied payloads without retaining chunk page
+  numbers.
+
+The route boundary also cannot identify repeated output from `final_path`
+alone. `keys` and `summary` steps can produce repeated top-level groups through
+paths such as `/line_items/description`, without a `*` segment.
 
 This is not the cause of the current ADP run's failures. Its 251 chunks across
 68 pages have no top-level section identifier. It is still a supported X-Ray
@@ -16,10 +22,15 @@ shape and violates the candidate transport contract for other documents.
 
 - Singular section routes process every chunk observation, even when chunks
   share an explicit section ID.
+- Singular document routes process every root and chunk observation and retain
+  all available chunk page numbers.
 - Existing scalar candidate identity removes duplicate values and merges their
   unique page numbers.
 - Distinct values from chunks sharing a section ID remain distinct candidates.
-- Repeated section routes keep their current section-record deduplication.
+- One shared route-shape helper treats `keys` and `summary` steps, or a
+  `final_path` containing `*`, as repeated.
+- Repeated section and document routes keep their current producer-copy
+  deduplication.
 - Relationship matching, repeated-record identity, route placement, and public
   result types do not change.
 
@@ -39,8 +50,8 @@ shape and violates the candidate transport contract for other documents.
 
 ### New capabilities
 
-- `scalar-candidate-provenance`: complete page provenance for singular scalar
-  observations that share a section identity.
+- `scalar-candidate-provenance`: complete page provenance for singular section
+  and document observations without changing repeated-output behavior.
 
 ### Modified capabilities
 
@@ -53,9 +64,11 @@ shape and violates the candidate transport contract for other documents.
 - Hand-written tests:
   `tests/extract/test_custom_output_reassembly.py`.
 - Public dataclasses and imports remain unchanged.
-- Singular section routes may expose candidates and page numbers that were
-  previously lost. This is the intended correction.
-- Repeated section output remains byte-for-byte compatible after reassembly.
+- Singular section and document routes may expose candidates and page numbers
+  that were previously lost. This is the intended correction.
+- Repeated section and document output remains byte-for-byte compatible after
+  reassembly, including direct top-level groups owned by `keys` and `summary`
+  steps.
 - The implementation stays under paths protected by `.fernignore`.
 - No workflow, API, database, customer JSON, or generated Fern change.
 - Open design questions: none.

--- a/openspec/changes/complete-scalar-candidate-provenance/proposal.md
+++ b/openspec/changes/complete-scalar-candidate-provenance/proposal.md
@@ -1,0 +1,61 @@
+# Proposal: Complete scalar candidate provenance
+
+## Why
+
+`delegate-scalar-candidate-resolution-to-agents` requires the SDK to preserve
+every scalar observation and every source page. The current section-container
+loader deduplicates chunks by explicit section ID before scalar candidates are
+collected. When multiple chunks share a section ID, only the first chunk's value
+and pages reach candidate collection.
+
+This is not the cause of the current ADP run's failures. Its 251 chunks across
+68 pages have no top-level section identifier. It is still a supported X-Ray
+shape and violates the candidate transport contract for other documents.
+
+## What changes
+
+- Singular section routes process every chunk observation, even when chunks
+  share an explicit section ID.
+- Existing scalar candidate identity removes duplicate values and merges their
+  unique page numbers.
+- Distinct values from chunks sharing a section ID remain distinct candidates.
+- Repeated section routes keep their current section-record deduplication.
+- Relationship matching, repeated-record identity, route placement, and public
+  result types do not change.
+
+## Relationship to active plans
+
+- This change is a companion to
+  `delegate-scalar-candidate-resolution-to-agents`. It does not replace, edit,
+  close, or archive that change.
+- It does not replace or close Internal Arcadia's
+  `complete-extraction-boundary-regression-coverage` change or Studio Harness's
+  `add-extraction-certification-harness` change.
+- Implementation starts from the candidate collection behavior defined by
+  `delegate-scalar-candidate-resolution-to-agents`. Both changes ship in the
+  same requested GroundX Python 3.9.7 release.
+
+## Capabilities
+
+### New capabilities
+
+- `scalar-candidate-provenance`: complete page provenance for singular scalar
+  observations that share a section identity.
+
+### Modified capabilities
+
+- None.
+
+## Impact
+
+- Hand-written implementation:
+  `src/groundx/extract/custom_outputs.py`.
+- Hand-written tests:
+  `tests/extract/test_custom_output_reassembly.py`.
+- Public dataclasses and imports remain unchanged.
+- Singular section routes may expose candidates and page numbers that were
+  previously lost. This is the intended correction.
+- Repeated section output remains byte-for-byte compatible after reassembly.
+- The implementation stays under paths protected by `.fernignore`.
+- No workflow, API, database, customer JSON, or generated Fern change.
+- Open design questions: none.

--- a/openspec/changes/complete-scalar-candidate-provenance/specs/scalar-candidate-provenance/spec.md
+++ b/openspec/changes/complete-scalar-candidate-provenance/specs/scalar-candidate-provenance/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Singular section routes preserve every observation
+
+The SDK SHALL pass every singular section-route observation to scalar candidate
+collection even when multiple chunks share an explicit section identifier.
+
+#### Scenario: Shared section ID contains duplicate and competing values
+
+- **GIVEN** three section chunks share one explicit section ID
+- **AND** pages 12 and 14 return scalar value `A`
+- **AND** page 16 returns scalar value `B`
+- **WHEN** the SDK reassembles a singular routed field
+- **THEN** it retains `A` once with source pages 12 and 14
+- **AND** it retains `B` as a distinct candidate with source page 16
+- **AND** no chunk is discarded before candidate comparison.
+
+### Requirement: Repeated section deduplication remains unchanged
+
+The SDK SHALL keep existing section-identity deduplication for routed paths that
+contain a repeated-record `*` segment.
+
+#### Scenario: Copied repeated output shares a section ID
+
+- **GIVEN** multiple chunks share one explicit section ID
+- **AND** each chunk carries the same repeated section records
+- **WHEN** the SDK reassembles a routed repeated path
+- **THEN** it emits the existing single set of repeated records
+- **AND** singular candidate preservation does not duplicate those records.
+
+### Requirement: Candidate provenance remains transport-only
+
+The SDK SHALL use only the candidate identity rules owned by
+`delegate-scalar-candidate-resolution-to-agents` to merge singular values and
+pages after section routing.
+
+#### Scenario: Section observations differ in confidence or page presence
+
+- **GIVEN** singular section observations have different confidence values or
+  different source-page availability
+- **WHEN** the SDK collects candidates
+- **THEN** those metadata differences do not select, discard, replace, or order
+  candidate values
+- **AND** every observed source page remains attached to its value.

--- a/openspec/changes/complete-scalar-candidate-provenance/specs/scalar-candidate-provenance/spec.md
+++ b/openspec/changes/complete-scalar-candidate-provenance/specs/scalar-candidate-provenance/spec.md
@@ -17,8 +17,8 @@ collection even when multiple chunks share an explicit section identifier.
 
 ### Requirement: Repeated section deduplication remains unchanged
 
-The SDK SHALL keep existing section-identity deduplication for routed paths that
-contain a repeated-record `*` segment.
+The SDK SHALL keep existing section-identity deduplication for routes that are
+repeated by `keys` or `summary` step kind or by a repeated-record `*` segment.
 
 #### Scenario: Copied repeated output shares a section ID
 
@@ -28,16 +28,54 @@ contain a repeated-record `*` segment.
 - **THEN** it emits the existing single set of repeated records
 - **AND** singular candidate preservation does not duplicate those records.
 
+#### Scenario: Direct repeated group has no wildcard
+
+- **GIVEN** a `keys` or `summary` section step routes records through a direct
+  top-level path such as `/line_items/description`
+- **AND** copied chunks share one explicit section ID
+- **WHEN** the SDK reassembles the route
+- **THEN** it treats the route as repeated
+- **AND** it emits one set of repeated records.
+
+### Requirement: Singular document routes preserve every sourced observation
+
+The SDK SHALL pass every singular document-route observation to scalar
+candidate collection and preserve every available chunk page number.
+
+#### Scenario: Document output is copied to root and chunks
+
+- **GIVEN** a singular document output appears at the document root and on
+  multiple numbered chunks
+- **AND** pages 12 and 14 return scalar value `A`
+- **AND** page 16 returns scalar value `B`
+- **WHEN** the SDK reassembles the routed field
+- **THEN** it retains `A` once with source pages 12 and 14
+- **AND** it retains `B` as a distinct candidate with source page 16
+- **AND** it does not invent a page for a root-only observation.
+
+### Requirement: Repeated document deduplication remains unchanged
+
+The SDK SHALL keep existing payload-identity deduplication for document routes
+that are repeated by step kind or wildcard path.
+
+#### Scenario: Copied repeated document output
+
+- **GIVEN** repeated document output is copied to the document root and chunks
+- **WHEN** the SDK reassembles a wildcard route or a direct top-level `keys`
+  route
+- **THEN** it emits one set of repeated records
+- **AND** singular document provenance does not duplicate those records.
+
 ### Requirement: Candidate provenance remains transport-only
 
 The SDK SHALL use only the candidate identity rules owned by
 `delegate-scalar-candidate-resolution-to-agents` to merge singular values and
 pages after section routing.
 
-#### Scenario: Section observations differ in confidence or page presence
+#### Scenario: Candidate observations differ in confidence or page presence
 
-- **GIVEN** singular section observations have different confidence values or
-  different source-page availability
+- **GIVEN** singular section or document observations have different confidence values or
+  different source-page availability at section or document level
 - **WHEN** the SDK collects candidates
 - **THEN** those metadata differences do not select, discard, replace, or order
   candidate values

--- a/openspec/changes/complete-scalar-candidate-provenance/tasks.md
+++ b/openspec/changes/complete-scalar-candidate-provenance/tasks.md
@@ -1,0 +1,99 @@
+# Complete scalar candidate provenance implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:subagent-driven-development` or `superpowers:executing-plans` to
+> implement this plan task by task. Use test-first development.
+
+**Goal:** Preserve all scalar values and source pages across chunks that share a
+section ID without changing repeated-record behavior.
+
+**Architecture:** Change only the section-route container boundary. Singular
+routes emit every chunk observation. Existing candidate collection deduplicates
+values and merges pages. Repeated routes retain section-ID deduplication.
+
+**Tech stack:** Python 3.9+, pytest, Ruff, Mypy, Poetry, OpenSpec 1.3.1.
+
+## Global constraints
+
+- Base work on the implementation branch for
+  `delegate-scalar-candidate-resolution-to-agents`, not an unrelated checkout.
+- Do not edit or archive any existing OpenSpec change.
+- Do not modify generated Fern files or public dataclass shapes.
+- Do not change repeated-record, relationship, route-placement, or type-coercion
+  behavior.
+- Requested release is GroundX Python 3.9.7. Publication remains owned by the
+  human release owner.
+
+## Task 1: Lock the lost-provenance behavior
+
+**Files:**
+
+- Modify: `tests/extract/test_custom_output_reassembly.py`
+- Exercise: `src/groundx/extract/custom_outputs.py::_route_containers`
+
+**Produces:** Two regressions that distinguish singular observations from
+repeated-record copies.
+
+- [ ] Add
+  `test_singular_section_route_preserves_candidates_and_pages_across_shared_section_id`.
+  Use three chunks with `sectionId: section-1`, pages 12, 14, and 16, and values
+  `A`, `A`, and `B`. Assert selected value `A`, selected pages `(12, 14)`, one
+  alternative `B` with pages `(16,)`, and provisional final output `A`.
+- [ ] Add
+  `test_repeated_section_route_still_deduplicates_shared_section_id` using two
+  chunks with the same section ID and identical `_records`. Assert one final
+  repeated record.
+- [ ] Run:
+  `poetry run pytest -q tests/extract/test_custom_output_reassembly.py -k 'shared_section_id'`.
+  Both new tests must fail against the current route-container behavior. The
+  singular test must show missing pages or candidates. The repeated test may
+  already pass and records the protected behavior.
+- [ ] Commit only the tests with message
+  `test(extract): expose shared-section scalar provenance loss`.
+
+## Task 2: Preserve singular observations at the section boundary
+
+**Files:**
+
+- Modify: `src/groundx/extract/custom_outputs.py`
+- Test: `tests/extract/test_custom_output_reassembly.py`
+
+**Interface:** `_route_containers(xray, route) -> list[_RouteContainer]` keeps
+its signature. No public interface changes.
+
+- [ ] In the `level == "section"` branch, determine whether the parsed
+  `final_path` contains `*`.
+- [ ] For repeated paths, retain the current `custom_output_section_identity()`
+  and `section_seen` behavior.
+- [ ] For singular paths, append one `_RouteContainer` for every X-Ray chunk,
+  using `_chunk_identity(chunk)` in its internal identity and `_page_numbers(chunk)`
+  for provenance. Do not compare values in `_route_containers()`.
+- [ ] Run:
+  `poetry run pytest -q tests/extract/test_custom_output_reassembly.py -k 'shared_section_id or scalar_candidate'`.
+  All selected values, alternatives, and page assertions must pass.
+- [ ] Run:
+  `poetry run pytest -q tests/extract/test_custom_output_reassembly.py`.
+  The complete custom-output suite must pass without fixture changes.
+- [ ] Commit implementation and focused tests with message
+  `fix(extract): preserve scalar pages across section chunks`.
+
+## Task 3: Verify the combined SDK contract
+
+**Files:**
+
+- Verify only. Do not change governed fixtures without explicit human approval.
+
+- [ ] Run changed-file formatting and lint checks:
+  `poetry run ruff format --check src/groundx/extract/custom_outputs.py tests/extract/test_custom_output_reassembly.py`
+  and
+  `poetry run ruff check src/groundx/extract/custom_outputs.py tests/extract/test_custom_output_reassembly.py`.
+- [ ] Run `poetry run pytest -q tests/extract`.
+- [ ] Run `poetry run mypy .`.
+- [ ] Run `bash scripts/check-line-endings.sh` and `git diff --check`.
+- [ ] Run
+  `OPENSPEC_TELEMETRY=0 npx -y @fission-ai/openspec@1.3.1 validate complete-scalar-candidate-provenance --strict`.
+- [ ] Build the same unpublished candidate wheel used by
+  `delegate-scalar-candidate-resolution-to-agents`. Record its source commit,
+  filename, and SHA-256 in the consumer test handoff. Do not publish it.
+- [ ] Hand the exact wheel to the Internal Arcadia and Studio Harness companion
+  changes. Do not request release 3.9.7 until both consumer gates pass.

--- a/openspec/changes/complete-scalar-candidate-provenance/tasks.md
+++ b/openspec/changes/complete-scalar-candidate-provenance/tasks.md
@@ -7,8 +7,8 @@
 **Goal:** Preserve all scalar values and source pages from section and document
 observations without changing repeated-record behavior.
 
-**Architecture:** Change only the route-container boundary and share one
-repeated-route predicate with route-value loading. Singular section and document
+**Architecture:** Share one repeated-route predicate across route-container
+loading, route-value loading, and final placement. Singular section and document
 routes emit every observation. Existing candidate collection deduplicates
 values and merges pages. Repeated routes retain producer-copy deduplication.
 
@@ -20,8 +20,9 @@ values and merges pages. Repeated routes retain producer-copy deduplication.
   `delegate-scalar-candidate-resolution-to-agents`, not an unrelated checkout.
 - Do not edit or archive any existing OpenSpec change.
 - Do not modify generated Fern files or public dataclass shapes.
-- Do not change repeated-record, relationship, route-placement, or type-coercion
-  behavior.
+- Do not change relationship, type-coercion, singular placement, or wildcard
+  repeated placement behavior. Implement only the existing top-level-array
+  contract for direct `keys` and `summary` routes without `*`.
 - Requested release is GroundX Python 3.9.7. Publication remains owned by the
   human release owner.
 
@@ -73,8 +74,12 @@ metadata or one precomputed repeated flag. No public interface changes.
 - [ ] Add one private repeated-route predicate. It returns true when the step
   kind is `keys` or `summary`, or when parsed `final_path` contains `*`.
 - [ ] Use that same predicate in `_route_containers()` and
-  `_custom_route_values()` so route shape cannot disagree between the two
-  stages.
+  `_custom_route_values()`, and pass its result to `_set_pointer()` so route
+  shape cannot disagree across collection and placement.
+- [ ] When that predicate is true and `final_path` has no `*`, make
+  `_set_pointer()` emit the first path segment as a top-level list and write the
+  remaining path into one repeated record per source record. Keep wildcard and
+  singular placement unchanged.
 - [ ] For repeated section routes, retain current
   `custom_output_section_identity()` and `section_seen` behavior.
 - [ ] For singular paths, append one `_RouteContainer` for every X-Ray chunk,
@@ -109,10 +114,12 @@ metadata or one precomputed repeated flag. No public interface changes.
 - [ ] Run `bash scripts/check-line-endings.sh` and `git diff --check`.
 - [ ] Run
   `OPENSPEC_TELEMETRY=0 npx -y @fission-ai/openspec@1.3.1 validate complete-scalar-candidate-provenance --strict`.
-- [ ] Build the same unpublished source candidate used by
-  `delegate-scalar-candidate-resolution-to-agents` on Python 3.11. Keep the
-  generated package version unchanged. Record its source commit, filename, and
-  SHA-256 in the consumer test handoff. Do not publish it.
+- [ ] Finish this change's Tasks 1 and 2 on top of
+  `delegate-scalar-candidate-resolution-to-agents` before any consumer wheel is
+  built. Then let that producer plan build one unpublished source candidate
+  from the combined commit on Python 3.11. Keep the generated package version
+  unchanged. Record its source commit, filename, and SHA-256 in the consumer
+  test handoff. Do not publish it.
 - [ ] Hand the source candidate to the Internal Arcadia and Studio Harness
   companion changes. Do not request release 3.9.7 until both consumer gates
   pass.

--- a/openspec/changes/complete-scalar-candidate-provenance/tasks.md
+++ b/openspec/changes/complete-scalar-candidate-provenance/tasks.md
@@ -4,12 +4,13 @@
 > `superpowers:subagent-driven-development` or `superpowers:executing-plans` to
 > implement this plan task by task. Use test-first development.
 
-**Goal:** Preserve all scalar values and source pages across chunks that share a
-section ID without changing repeated-record behavior.
+**Goal:** Preserve all scalar values and source pages from section and document
+observations without changing repeated-record behavior.
 
-**Architecture:** Change only the section-route container boundary. Singular
-routes emit every chunk observation. Existing candidate collection deduplicates
-values and merges pages. Repeated routes retain section-ID deduplication.
+**Architecture:** Change only the route-container boundary and share one
+repeated-route predicate with route-value loading. Singular section and document
+routes emit every observation. Existing candidate collection deduplicates
+values and merges pages. Repeated routes retain producer-copy deduplication.
 
 **Tech stack:** Python 3.9+, pytest, Ruff, Mypy, Poetry, OpenSpec 1.3.1.
 
@@ -31,8 +32,8 @@ values and merges pages. Repeated routes retain section-ID deduplication.
 - Modify: `tests/extract/test_custom_output_reassembly.py`
 - Exercise: `src/groundx/extract/custom_outputs.py::_route_containers`
 
-**Produces:** Two regressions that distinguish singular observations from
-repeated-record copies.
+**Produces:** Four regressions that distinguish singular observations from
+repeated-record copies across section and document routes.
 
 - [ ] Add
   `test_singular_section_route_preserves_candidates_and_pages_across_shared_section_id`.
@@ -41,13 +42,21 @@ repeated-record copies.
   alternative `B` with pages `(16,)`, and provisional final output `A`.
 - [ ] Add
   `test_repeated_section_route_still_deduplicates_shared_section_id` using two
-  chunks with the same section ID and identical `_records`. Assert one final
-  repeated record.
+  chunks with the same section ID, a `keys` step, a direct top-level final path
+  without `*`, and identical `_records`. Assert one final repeated record.
+- [ ] Add
+  `test_singular_document_route_preserves_candidates_and_chunk_pages`. Include
+  the same value at the document root and on pages 12 and 14, plus a competing
+  value on page 16. Assert the two candidate values, complete page lists, and no
+  invented page for a root-only value.
+- [ ] Add
+  `test_repeated_document_route_still_deduplicates_copied_payloads` for both a
+  wildcard path and a direct top-level `keys` route without `*`. Assert one
+  repeated record in each case.
 - [ ] Run:
-  `poetry run pytest -q tests/extract/test_custom_output_reassembly.py -k 'shared_section_id'`.
-  Both new tests must fail against the current route-container behavior. The
-  singular test must show missing pages or candidates. The repeated test may
-  already pass and records the protected behavior.
+  `poetry run pytest -q tests/extract/test_custom_output_reassembly.py -k 'shared_section_id or document_route'`.
+  The singular tests must fail against the current route-container behavior.
+  The repeated tests may already pass and record protected behavior.
 - [ ] Commit only the tests with message
   `test(extract): expose shared-section scalar provenance loss`.
 
@@ -58,18 +67,26 @@ repeated-record copies.
 - Modify: `src/groundx/extract/custom_outputs.py`
 - Test: `tests/extract/test_custom_output_reassembly.py`
 
-**Interface:** `_route_containers(xray, route) -> list[_RouteContainer]` keeps
-its signature. No public interface changes.
+**Interface:** Private route helpers may accept the existing `step_kinds`
+metadata or one precomputed repeated flag. No public interface changes.
 
-- [ ] In the `level == "section"` branch, determine whether the parsed
-  `final_path` contains `*`.
-- [ ] For repeated paths, retain the current `custom_output_section_identity()`
-  and `section_seen` behavior.
+- [ ] Add one private repeated-route predicate. It returns true when the step
+  kind is `keys` or `summary`, or when parsed `final_path` contains `*`.
+- [ ] Use that same predicate in `_route_containers()` and
+  `_custom_route_values()` so route shape cannot disagree between the two
+  stages.
+- [ ] For repeated section routes, retain current
+  `custom_output_section_identity()` and `section_seen` behavior.
 - [ ] For singular paths, append one `_RouteContainer` for every X-Ray chunk,
   using `_chunk_identity(chunk)` in its internal identity and `_page_numbers(chunk)`
   for provenance. Do not compare values in `_route_containers()`.
+- [ ] For singular document routes, append the root observation when present
+  and each chunk observation with `_page_numbers(chunk)`. Do not invent root
+  page numbers or deduplicate by payload identity before candidate collection.
+- [ ] For repeated document routes, retain current payload-identity
+  deduplication.
 - [ ] Run:
-  `poetry run pytest -q tests/extract/test_custom_output_reassembly.py -k 'shared_section_id or scalar_candidate'`.
+  `poetry run pytest -q tests/extract/test_custom_output_reassembly.py -k 'shared_section_id or document_route or scalar_candidate'`.
   All selected values, alternatives, and page assertions must pass.
 - [ ] Run:
   `poetry run pytest -q tests/extract/test_custom_output_reassembly.py`.

--- a/openspec/changes/complete-scalar-candidate-provenance/tasks.md
+++ b/openspec/changes/complete-scalar-candidate-provenance/tasks.md
@@ -12,7 +12,7 @@ repeated-route predicate with route-value loading. Singular section and document
 routes emit every observation. Existing candidate collection deduplicates
 values and merges pages. Repeated routes retain producer-copy deduplication.
 
-**Tech stack:** Python 3.9+, pytest, Ruff, Mypy, Poetry, OpenSpec 1.3.1.
+**Tech stack:** Python 3.11, pytest, Ruff, Mypy, Poetry, OpenSpec 1.3.1.
 
 ## Global constraints
 
@@ -109,8 +109,13 @@ metadata or one precomputed repeated flag. No public interface changes.
 - [ ] Run `bash scripts/check-line-endings.sh` and `git diff --check`.
 - [ ] Run
   `OPENSPEC_TELEMETRY=0 npx -y @fission-ai/openspec@1.3.1 validate complete-scalar-candidate-provenance --strict`.
-- [ ] Build the same unpublished candidate wheel used by
-  `delegate-scalar-candidate-resolution-to-agents`. Record its source commit,
-  filename, and SHA-256 in the consumer test handoff. Do not publish it.
-- [ ] Hand the exact wheel to the Internal Arcadia and Studio Harness companion
-  changes. Do not request release 3.9.7 until both consumer gates pass.
+- [ ] Build the same unpublished source candidate used by
+  `delegate-scalar-candidate-resolution-to-agents` on Python 3.11. Keep the
+  generated package version unchanged. Record its source commit, filename, and
+  SHA-256 in the consumer test handoff. Do not publish it.
+- [ ] Hand the source candidate to the Internal Arcadia and Studio Harness
+  companion changes. Do not request release 3.9.7 until both consumer gates
+  pass.
+- [ ] After 3.9.7 is published, verify it contains the tested handwritten source
+  change and rerun the clean-install consumer gates. Do not require byte
+  identity with the differently versioned source candidate.

--- a/openspec/changes/delegate-scalar-candidate-resolution-to-agents/.openspec.yaml
+++ b/openspec/changes/delegate-scalar-candidate-resolution-to-agents/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/openspec/changes/delegate-scalar-candidate-resolution-to-agents/design.md
+++ b/openspec/changes/delegate-scalar-candidate-resolution-to-agents/design.md
@@ -1,0 +1,283 @@
+# Design: Delegate scalar candidate resolution to agents
+
+## Goals
+
+- Preserve every distinct scalar value and all source pages until an agent has
+  reviewed them.
+- Keep the SDK deterministic without encoding business meaning in code.
+- Make reconciliation, not SDK ranking, the value-selection boundary.
+- Keep the public SDK dataclass shape compatible.
+- Build on Internal Arcadia PR 102 batching and its 30-image request limit.
+
+## Non-goals
+
+- Do not add multi-pass or recursive reconciliation.
+- Do not increase the 30-image limit.
+- Do not put candidate diagnostics in customer final JSON.
+- Do not change repeated-record dedupe or relationship matching.
+- Do not change field type coercion, prompt schemas, workflow routes, or agent
+  response JSON.
+- Do not create a new confidence score or make confidence persistence a release
+  gate.
+
+## Decisions and rejected alternatives
+
+- Keep the public name `final_output`. Renaming it would break callers. Define
+  it as final SDK route reassembly but provisional input to downstream agents
+  when alternatives exist.
+- Keep `selected` and `alternatives`. Adding a second public candidate-list
+  model is unnecessary. Change their documented meaning and retain every value.
+- Remove code ranking entirely. Adjusting the ranking would still make business
+  decisions before the agent sees the evidence.
+- Keep one reconciliation pass. Multi-pass review would add orchestration,
+  retries, merged traces, and another agent decision.
+- Keep the 30-image limit. Complete page references remain in the prompt, while
+  attached images are selected fairly and identified explicitly.
+
+## Ownership
+
+GroundX Python owns generic candidate collection because it reads all X-Ray
+custom-output observations and applies workflow routes. Internal Arcadia owns
+business interpretation because it has the field prompt, source images,
+reconciliation agent, and QA agent.
+
+The cross-repository contract lives in this producer plan. Internal Arcadia
+implements the consumer tasks after testing the exact candidate wheel.
+
+## Current behavior
+
+For singular routed fields, GroundX Python calculates a quality tuple from:
+
+1. whether the value looks more specific than hardcoded defaults such as
+   `N/A`, `Not Applicable`, or `Not Indicated`;
+2. whether source pages exist;
+3. confidence.
+
+Lower-ranked values are ignored. Equal-ranked values are retained as
+alternatives. A higher-ranked value replaces the selected value and clears the
+existing alternatives. Null, empty string, and empty list are skipped before
+candidate collection.
+
+Internal Arcadia PR 102 converts retained SDK alternatives into statement
+conflicts. Its reconcile prompt renders competing values as an array. Candidate
+evidence selects page images, but the prompt does not show which value came from
+which pages. Reconciliation clears the pending conflict and writes the agent
+value. It does not preserve a previous provisional value when that value was
+not already retained by the SDK.
+
+## Candidate identity and order
+
+Candidate collection uses the existing deterministic X-Ray and route traversal
+order.
+
+For strings:
+
+- remove leading and trailing whitespace before storing the candidate;
+- compare the trimmed value with `casefold()`;
+- preserve the first candidate's casing;
+- preserve internal whitespace exactly.
+
+For known extracted-field envelopes containing `value` plus metadata such as
+`confidence`, candidate identity uses the inner `value`. The first envelope is
+retained unchanged except for trimming an inner string value. Later duplicate
+envelopes contribute source pages but do not replace the first envelope.
+Confidence remains present in the retained envelope when supplied.
+
+For other JSON values, identity is exact and type-sensitive:
+
+- booleans, integers, and floats are distinct types;
+- list order is significant;
+- mapping key order is not significant;
+- nested values remain type-sensitive;
+- no scalar, date, number, enum, empty, or default-like coercion is applied.
+
+The first unique candidate becomes `selected` and the field's provisional
+`final_output`. Every later unique candidate becomes an `alternative` in first
+observed order. A duplicate merges its unique source pages into the existing
+candidate in first-seen page order.
+
+## Presence and empty values
+
+Presence is determined before value filtering:
+
+- a missing output key produces no candidate;
+- an output key present with null produces a null candidate;
+- an output key present with empty string produces an empty-string candidate;
+- an output key present with empty list produces an empty-list candidate.
+
+This change applies to singular routed scalar fields. Existing repeated-row
+empty-record handling remains unchanged.
+
+## Public SDK compatibility
+
+The public dataclasses remain:
+
+```python
+CustomOutputScalarCandidateSet(
+    selected=CustomOutputScalarCandidate(...),
+    alternatives=(...),
+)
+```
+
+No new required field is added. The semantic contract changes:
+
+- `selected` means first observed provisional candidate;
+- `alternatives` means all later unique candidates;
+- `final_output` uses `selected` before downstream reconciliation.
+
+This avoids a generated API or public shape change. Documentation and tests
+must stop calling `selected` the best or final value.
+
+## Reconciliation payload
+
+Internal Arcadia builds one review object per conflicting field. The prompt
+shows every candidate and its evidence:
+
+```json
+[
+  {
+    "value": "N/A",
+    "source_pages": [18],
+    "provided_pages": [18]
+  },
+  {
+    "value": "100% immediate",
+    "source_pages": [32, 43],
+    "provided_pages": [32]
+  }
+]
+```
+
+`source_pages` contains every available page associated with that candidate.
+`provided_pages` contains only pages whose images are attached to this model
+request. The prompt must tell the agent that unprovided source pages are known
+provenance, not visible evidence.
+
+The agent response remains the existing plain field-to-value JSON object. This
+keeps parser and retry behavior unchanged.
+
+## Image selection
+
+Image selection is evidence transport, not value selection.
+
+For each field:
+
+1. Deduplicate page images by document page number or canonical page URL.
+2. Select the first available page for each unique candidate.
+3. If candidate coverage uses fewer than 30 images, add remaining candidate
+   pages round-robin in candidate order until the request reaches 30 images or
+   no pages remain.
+4. Keep every `source_pages` entry in candidate metadata even when its image is
+   not attached.
+5. Record exact `provided_pages` after image selection.
+
+Candidates with no source page remain in the prompt. If more than 30 candidates
+for one field each require a distinct image, raise a clear `ImageEvidenceError`
+before the model call. Do not silently omit candidates. Batching may combine
+fields only while preserving this per-field coverage.
+
+Multi-pass reconciliation is deferred. It would add orchestration, retry,
+trace-merging, and second-decision semantics without evidence that the edge
+case occurs often enough to justify that cost.
+
+## Reconcile and QA state
+
+Candidate history and unresolved conflicts are separate concepts:
+
+- candidate history contains all observed values and pages;
+- unresolved conflicts indicate that reconciliation still needs to run;
+- reconciliation clears the unresolved marker after a valid agent response;
+- reconciliation never clears candidate history.
+
+When the reconciliation agent returns a value:
+
+1. Coerce and validate it through the existing field type boundary.
+2. Set it as the current routed value.
+3. Keep the previous provisional value in candidate history.
+4. If the returned value matches an existing candidate, retain that candidate
+   and its source pages.
+5. If it is novel, append it with `origin: reconcile_agent` and no invented
+   source pages.
+
+QA receives the reconciled current value and relevant images. QA must not erase
+candidate history. If QA returns a novel value, append it with
+`origin: qa_agent` and no invented source pages. The existing customer output
+continues to contain the current field value, not the candidate history.
+
+## Confidence
+
+Confidence may remain inside raw candidate envelopes and existing diagnostic
+or final-field metadata. It is never used to choose the provisional value,
+deduplicate candidates, order candidates, decide whether reconciliation runs,
+select images, accept an agent response, or control QA.
+
+Implementation must audit this candidate path for confidence-based branching.
+Adding a new customer-facing confidence field is out of scope because it is not
+needed to fix evidence loss.
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    participant X as X-Ray outputs
+    participant S as GroundX Python SDK
+    participant A as Arcadia runtime
+    participant R as Arcadia reconcile agent
+    participant Q as Arcadia QA agent
+    participant O as Final customer output
+
+    X->>S: Ordered scalar observations and page numbers
+    S->>S: Keep first provisional value and all unique candidates
+    S->>A: Provisional output and candidate evidence
+    A->>R: Candidate objects plus up to 30 selected page images
+    R-->>A: One selected value per reviewed field
+    A->>A: Set current value, retain candidate history
+    A->>Q: Current value, prompt, images, candidate history in runtime context
+    Q-->>A: Verified or revised current value
+    A->>O: Current values only
+```
+
+## Error handling
+
+- Missing field: no candidate and no reconcile trigger.
+- One unique candidate: no reconcile trigger for candidate conflict alone.
+- More than one unique candidate: reconciliation is required regardless of
+  value content or confidence.
+- Candidate without an image: keep it in the prompt with empty page lists.
+- More than 30 distinct candidate images for one field: fail before the model
+  call with field name, candidate count, and limit.
+- Invalid agent value: preserve existing retry and type-coercion behavior. Do
+  not clear pending conflict or candidate history until a valid response is
+  accepted.
+- Missing candidate metadata after a consumer version mismatch: keep the
+  existing non-candidate reconciliation path for legacy field conflicts. Do not
+  infer candidate pages.
+
+## Compatibility and rollout
+
+The SDK change intentionally alters which provisional value appears in
+`final_output` when candidates compete. Existing consumers that incorrectly
+treat SDK `final_output` as agent-resolved may observe a different value. The
+public type shape remains compatible, but release notes must call out the
+semantic change.
+
+Internal Arcadia must test the exact candidate wheel before the SDK release is
+published. After release, it pins that version and reruns the same tests from a
+clean install. Deploy only after current reproduction, Arcadia legacy, Arcadia
+v1, generic v1, and ADP protected cases pass.
+
+Rollback uses the prior SDK pin and prior Internal Arcadia container image. No
+stored data needs migration or repair.
+
+## Interaction with active work
+
+`normalize-extracted-value-types` remains the owner of value type coercion and
+parser-output safety. This change must not duplicate or weaken that contract.
+Its confidence conversion is metadata validation only and cannot be reused for
+candidate ranking. Candidate implementation may share the same released SDK
+only if both plans pass their isolated and combined consumer gates.
+
+## No ADR
+
+This is a narrow correction to an existing SDK-to-consumer evidence boundary.
+It adds no service, storage system, generated API, or deployment architecture.

--- a/openspec/changes/delegate-scalar-candidate-resolution-to-agents/design.md
+++ b/openspec/changes/delegate-scalar-candidate-resolution-to-agents/design.md
@@ -39,10 +39,14 @@
 GroundX Python owns generic candidate collection because it reads all X-Ray
 custom-output observations and applies workflow routes. Internal Arcadia owns
 business interpretation because it has the field prompt, source images,
-reconciliation agent, and QA agent.
+reconciliation agent, and QA agent. Its
+`complete-scalar-reconcile-disposition` change is the sole owner of Arcadia
+code, prompts, tests, and terminal-save behavior.
 
-The cross-repository contract lives in this producer plan. Internal Arcadia
-implements the consumer tasks after testing the exact candidate wheel.
+The cross-repository contract and release order live in this producer plan.
+Internal Arcadia implements the consumer tasks after testing the source
+candidate built from the recorded SDK commit. This plan does not duplicate
+those implementation tasks.
 
 ## Current behavior
 
@@ -104,6 +108,13 @@ Presence is determined before value filtering:
 - an output key present with null produces a null candidate;
 - an output key present with empty string produces an empty-string candidate;
 - an output key present with empty list produces an empty-list candidate.
+
+Candidate presence and required-route satisfaction are separate. Explicit null
+remains in candidate evidence, but it does not satisfy a required route. The SDK
+must still emit its existing required-field diagnostic when null is the only
+observation for a required route. Empty string, `false`, `0`, and empty list are
+not rejected by generic truthiness checks; their validity comes from the
+authored field contract.
 
 This change applies to singular routed scalar fields. Existing repeated-row
 empty-record handling remains unchanged.
@@ -240,6 +251,9 @@ sequenceDiagram
 ## Error handling
 
 - Missing field: no candidate and no reconcile trigger.
+- One explicit null candidate: preserve the null candidate. It does not satisfy
+  a required route. For a nullable route, the consumer omits the field from
+  customer output without treating null as a selected business value.
 - One unique candidate: no reconcile trigger for candidate conflict alone.
 - More than one unique candidate: reconciliation is required regardless of
   value content or confidence.
@@ -261,10 +275,14 @@ treat SDK `final_output` as agent-resolved may observe a different value. The
 public type shape remains compatible, but release notes must call out the
 semantic change.
 
-Internal Arcadia must test the exact candidate wheel before the SDK release is
-published. After release, it pins that version and reruns the same tests from a
-clean install. Deploy only after current reproduction, Arcadia legacy, Arcadia
-v1, generic v1, and ADP protected cases pass.
+Internal Arcadia and Studio Harness must test an unpublished source candidate
+built from the recorded SDK commit on Python 3.11 before the release is
+published. After the human release owner publishes requested version 3.9.7,
+both consumers verify that the published package contains the same handwritten
+source change and rerun their gates from clean installs. Candidate and published
+wheels may differ in version metadata and bytes. Deploy only after the current
+reproduction, Arcadia legacy, Arcadia v1, generic v1, and ADP protected cases
+pass.
 
 Rollback uses the prior SDK pin and prior Internal Arcadia container image. No
 stored data needs migration or repair.

--- a/openspec/changes/delegate-scalar-candidate-resolution-to-agents/design.md
+++ b/openspec/changes/delegate-scalar-candidate-resolution-to-agents/design.md
@@ -275,9 +275,11 @@ treat SDK `final_output` as agent-resolved may observe a different value. The
 public type shape remains compatible, but release notes must call out the
 semantic change.
 
-Internal Arcadia and Studio Harness must test an unpublished source candidate
-built from the recorded SDK commit on Python 3.11 before the release is
-published. After the human release owner publishes requested version 3.9.7,
+Internal Arcadia and Studio Harness must test one unpublished source candidate
+built on Python 3.11 from the combined commit after this change's Tasks 0
+through 2 and `complete-scalar-candidate-provenance` Tasks 1 and 2 are complete.
+No earlier SDK wheel is a consumer candidate. After the human release owner
+publishes requested version 3.9.7,
 both consumers verify that the published package contains the same handwritten
 source change and rerun their gates from clean installs. Candidate and published
 wheels may differ in version metadata and bytes. Deploy only after the current
@@ -293,7 +295,9 @@ stored data needs migration or repair.
 parser-output safety. This change must not duplicate or weaken that contract.
 Its confidence conversion is metadata validation only and cannot be reused for
 candidate ranking. Candidate implementation may share the same released SDK
-only if both plans pass their isolated and combined consumer gates.
+only if both plans pass their isolated and combined consumer gates. The
+companion provenance work must be present before the single unpublished
+consumer candidate is built.
 
 ## No ADR
 

--- a/openspec/changes/delegate-scalar-candidate-resolution-to-agents/proposal.md
+++ b/openspec/changes/delegate-scalar-candidate-resolution-to-agents/proposal.md
@@ -45,9 +45,9 @@ complete value-to-page mapping.
   select, order, filter, or branch on candidate values.
 - Reconciliation remains single-pass. Arcadia attaches at least one available
   page for each candidate, then fills remaining slots fairly up to the existing
-  30-image limit. Full source-page lists remain in the prompt. A field requiring
-  more than 30 distinct candidate images fails clearly instead of hiding a
-  candidate.
+  30-image limit. Full source-page lists remain in the prompt. A field with more
+  than 30 candidates that each require a distinct available image fails clearly
+  instead of hiding a candidate.
 
 ## Capabilities
 
@@ -86,17 +86,20 @@ complete value-to-page mapping.
 
 ## Release order
 
-1. Implement and test the SDK contract on Python 3.11. Build an unpublished
-   source-candidate wheel using the repository's generated package version and
-   record its source commit and SHA-256.
-2. Install that source candidate in isolated Internal Arcadia and Studio
+1. Implement and test Tasks 0 through 2 in this change on Python 3.11.
+2. Implement and test Tasks 1 and 2 in the companion
+   `complete-scalar-candidate-provenance` change on top of the same branch.
+3. Only after both SDK changes are complete, build one unpublished
+   source-candidate wheel from the combined commit using the repository's
+   generated package version. Record that commit, filename, and SHA-256.
+4. Install only that source candidate in isolated Internal Arcadia and Studio
    Harness checkouts. Internal Arcadia implements its consumer contract only
    through `complete-scalar-reconcile-disposition`.
-3. Merge the SDK changes and give the merged handwritten source commit and
+5. Merge both SDK changes and give the merged handwritten source commit and
    validation evidence to the human release owner for requested version 3.9.7.
-4. After 3.9.7 is published, verify that it contains the tested handwritten
+6. After 3.9.7 is published, verify that it contains the tested handwritten
    source change. Clean-install the published artifact and rerun both consumer
    gates. Do not require wheel-byte identity across different package versions.
-5. Pin the published SDK in both Internal Arcadia dependency writers, rerun
+7. Pin the published SDK in both Internal Arcadia dependency writers, rerun
    protected tests, build and inspect the extract container, then merge and
    deploy Internal Arcadia.

--- a/openspec/changes/delegate-scalar-candidate-resolution-to-agents/proposal.md
+++ b/openspec/changes/delegate-scalar-candidate-resolution-to-agents/proposal.md
@@ -1,0 +1,91 @@
+# Proposal: Delegate scalar candidate resolution to agents
+
+## Why
+
+GroundX Python currently ranks competing scalar extraction values in code. It
+prefers values that look more specific, have source pages, or have higher
+confidence. A later higher-ranked value replaces the selected value and clears
+lower-ranked alternatives. This hides evidence before the reconciliation agent
+can review it.
+
+Internal Arcadia already has a reconciliation agent whose main job is to select
+the correct value from competing values and source pages. It now consumes the
+SDK candidate sidecar, but the SDK can omit candidates and Arcadia sends only a
+plain value array with representative images. The agent does not receive the
+complete value-to-page mapping.
+
+## What changes
+
+- GroundX Python keeps the first observed scalar value as a provisional value.
+- It retains every later unique value in observation order. Code does not rank,
+  replace, or discard values based on meaning, source-page presence, or
+  confidence.
+- String comparison trims leading and trailing whitespace and ignores case.
+  No other normalization is used to decide whether values are duplicates.
+- Explicit null, empty-string, and empty-list outputs remain candidates. A
+  missing field remains no candidate.
+- Duplicate values merge all source page numbers into the retained candidate.
+- The existing public `selected` and `alternatives` shape remains unchanged.
+  `selected` means first observed, not best or final.
+- SDK `final_output` keeps the first observed value for compatibility. For a
+  field with multiple candidates, it is provisional until the consumer runs
+  reconciliation.
+- Internal Arcadia reconciles every statement field with more than one unique
+  candidate. It sends every candidate, every source-page number, and the pages
+  actually attached to the model request.
+- The reconciliation response becomes the current routed value. Candidate
+  evidence remains intact. A novel agent value is appended as agent-produced
+  evidence without invented source pages.
+- QA may verify or change the current value, but it cannot erase candidate
+  history. A novel QA value is recorded the same way.
+- Confidence remains transport metadata. Neither repository may use it to
+  select, order, filter, or branch on candidate values.
+- Reconciliation remains single-pass. Arcadia attaches at least one available
+  page for each candidate, then fills remaining slots fairly up to the existing
+  30-image limit. Full source-page lists remain in the prompt. A field requiring
+  more than 30 distinct candidate images fails clearly instead of hiding a
+  candidate.
+
+## Capabilities
+
+### New capabilities
+
+- `scalar-candidate-evidence`: deterministic collection, transport, agent
+  review, and preservation of competing scalar extraction values.
+
+### Modified capabilities
+
+- None. The existing public SDK result shape is preserved.
+
+## Impact
+
+- SDK implementation:
+  `src/groundx/extract/custom_outputs.py` and its hand-written tests.
+- SDK public behavior: `CustomOutputScalarCandidateSet.selected` becomes the
+  first observed candidate. `alternatives` contains every later unique
+  candidate. The dataclass shape and imports do not change.
+- Consumer implementation: Internal Arcadia statement load, reconcile, QA,
+  candidate-evidence serialization, image selection, prompt rendering, and
+  tests.
+- Downstream consumers: `internal-arcadia-agents` must pin the released SDK
+  before deploying this behavior. Other consumers receive the same public
+  types but may observe different `selected`, `alternatives`, and provisional
+  `final_output` values when candidates compete.
+- Generated Fern code is not affected. All SDK changes stay under paths
+  protected by `.fernignore`, including `src/groundx/extract/`,
+  `tests/extract/`, and `openspec/`.
+- No workflow schema, stored workflow, customer output schema, database, or
+  data migration changes.
+- Rollback is the prior SDK pin and prior Internal Arcadia container image.
+- Open design questions: none.
+
+## Release order
+
+1. Implement and test the SDK contract on a candidate wheel.
+2. Install that exact wheel in an isolated Internal Arcadia checkout based on
+   the pushed branch containing PR 102.
+3. Implement and test the consumer contract against the candidate wheel.
+4. Merge the SDK change and hand the tested commit and wheel evidence to the
+   human release owner.
+5. Pin the released SDK version in Internal Arcadia, rerun protected tests, then
+   merge and deploy Internal Arcadia.

--- a/openspec/changes/delegate-scalar-candidate-resolution-to-agents/proposal.md
+++ b/openspec/changes/delegate-scalar-candidate-resolution-to-agents/proposal.md
@@ -24,6 +24,9 @@ complete value-to-page mapping.
   No other normalization is used to decide whether values are duplicates.
 - Explicit null, empty-string, and empty-list outputs remain candidates. A
   missing field remains no candidate.
+- Explicit null remains diagnostic evidence but does not satisfy a required
+  route. A sole nullable null is omitted from customer output by the consumer
+  from the authored field contract, without an agent value decision.
 - Duplicate values merge all source page numbers into the retained candidate.
 - The existing public `selected` and `alternatives` shape remains unchanged.
   `selected` means first observed, not best or final.
@@ -66,7 +69,9 @@ complete value-to-page mapping.
   candidate. The dataclass shape and imports do not change.
 - Consumer implementation: Internal Arcadia statement load, reconcile, QA,
   candidate-evidence serialization, image selection, prompt rendering, and
-  tests.
+  tests are owned only by its `complete-scalar-reconcile-disposition` change.
+  This SDK change owns the producer contract and coordinated acceptance gates,
+  not Arcadia code.
 - Downstream consumers: `internal-arcadia-agents` must pin the released SDK
   before deploying this behavior. Other consumers receive the same public
   types but may observe different `selected`, `alternatives`, and provisional
@@ -81,11 +86,17 @@ complete value-to-page mapping.
 
 ## Release order
 
-1. Implement and test the SDK contract on a candidate wheel.
-2. Install that exact wheel in an isolated Internal Arcadia checkout based on
-   the pushed branch containing PR 102.
-3. Implement and test the consumer contract against the candidate wheel.
-4. Merge the SDK change and hand the tested commit and wheel evidence to the
-   human release owner.
-5. Pin the released SDK version in Internal Arcadia, rerun protected tests, then
-   merge and deploy Internal Arcadia.
+1. Implement and test the SDK contract on Python 3.11. Build an unpublished
+   source-candidate wheel using the repository's generated package version and
+   record its source commit and SHA-256.
+2. Install that source candidate in isolated Internal Arcadia and Studio
+   Harness checkouts. Internal Arcadia implements its consumer contract only
+   through `complete-scalar-reconcile-disposition`.
+3. Merge the SDK changes and give the merged handwritten source commit and
+   validation evidence to the human release owner for requested version 3.9.7.
+4. After 3.9.7 is published, verify that it contains the tested handwritten
+   source change. Clean-install the published artifact and rerun both consumer
+   gates. Do not require wheel-byte identity across different package versions.
+5. Pin the published SDK in both Internal Arcadia dependency writers, rerun
+   protected tests, build and inspect the extract container, then merge and
+   deploy Internal Arcadia.

--- a/openspec/changes/delegate-scalar-candidate-resolution-to-agents/proposal.md
+++ b/openspec/changes/delegate-scalar-candidate-resolution-to-agents/proposal.md
@@ -86,6 +86,9 @@ complete value-to-page mapping.
 
 ## Release order
 
+Remaining cross-repository fixture and boundary work is owned by
+`internal-arcadia-agents/openspec/changes/complete-extraction-boundary-regression-coverage/tasks.md`.
+
 1. Implement and test Tasks 0 through 2 in this change on Python 3.11.
 2. Implement and test Tasks 1 and 2 in the companion
    `complete-scalar-candidate-provenance` change on top of the same branch.

--- a/openspec/changes/delegate-scalar-candidate-resolution-to-agents/specs/scalar-candidate-evidence/spec.md
+++ b/openspec/changes/delegate-scalar-candidate-resolution-to-agents/specs/scalar-candidate-evidence/spec.md
@@ -1,0 +1,226 @@
+## ADDED Requirements
+
+### Requirement: Singular scalar observations are preserved without semantic ranking
+
+The SDK SHALL keep the first observed singular routed scalar value as the
+provisional selected value and SHALL retain every later unique value in
+observation order. It SHALL NOT select, replace, filter, or order candidates
+using value meaning, default-like text, source-page presence, or confidence.
+
+#### Scenario: Later value looks more specific
+
+- **GIVEN** the first candidate is `N/A`
+- **AND** a later candidate is `100% immediate`
+- **WHEN** the SDK reassembles the routed scalar field
+- **THEN** `N/A` remains the provisional selected value
+- **AND** `100% immediate` is retained as an alternative
+- **AND** both values are available to the downstream reconciliation agent.
+
+#### Scenario: Later value has source pages or higher confidence
+
+- **GIVEN** a first candidate has no pages or lower confidence
+- **AND** a later distinct candidate has pages or higher confidence
+- **WHEN** the SDK reassembles the routed scalar field
+- **THEN** the first candidate remains selected
+- **AND** the later candidate remains an alternative
+- **AND** neither page presence nor confidence changes their order.
+
+### Requirement: Candidate deduplication uses only value identity
+
+The SDK SHALL deduplicate string candidates after trimming leading and trailing
+whitespace and comparing case-insensitively. It SHALL preserve internal string
+whitespace. Other JSON values SHALL compare exactly and type-sensitively. A
+known extracted-field envelope SHALL compare by its inner `value` while
+retaining the first envelope and its metadata.
+
+#### Scenario: String differs only by case and outer whitespace
+
+- **GIVEN** candidates `" January 1 "` and `"january 1"`
+- **WHEN** the SDK reassembles the field
+- **THEN** it retains one candidate with the first casing and trimmed outer
+  whitespace.
+
+#### Scenario: String has different internal whitespace
+
+- **GIVEN** candidates `"January 1"` and `"January  1"`
+- **WHEN** the SDK reassembles the field
+- **THEN** it retains both candidates.
+
+#### Scenario: JSON values have different types
+
+- **GIVEN** candidates `true`, `1`, and `1.0`
+- **WHEN** the SDK reassembles the field
+- **THEN** it retains all three as distinct candidates.
+
+#### Scenario: Envelopes have equal values and different confidence
+
+- **GIVEN** two extracted-field envelopes have the same inner value after
+  string comparison
+- **AND** the envelopes have different confidence values
+- **WHEN** the SDK reassembles the field
+- **THEN** it retains the first envelope
+- **AND** confidence does not create, remove, reorder, or replace a candidate.
+
+### Requirement: Explicit empty values remain candidates
+
+For a singular routed scalar field, the SDK SHALL distinguish a missing output
+key from a key present with null, empty string, or empty list. It SHALL preserve
+each present value as a candidate.
+
+#### Scenario: Output key is missing
+
+- **WHEN** a routed output container has no key for the field
+- **THEN** the SDK creates no candidate from that container.
+
+#### Scenario: Output key contains an explicit empty value
+
+- **GIVEN** separate observations contain null, empty string, and empty list
+- **WHEN** the SDK reassembles the routed scalar field
+- **THEN** each present value is retained according to candidate identity rules
+- **AND** none is discarded as absence.
+
+### Requirement: Duplicate observations retain all source pages
+
+The SDK SHALL merge every unique source page associated with duplicate
+candidate observations. It SHALL preserve first-seen page order and SHALL NOT
+discard pages because the candidate value is duplicated.
+
+#### Scenario: Duplicate value appears on multiple pages
+
+- **GIVEN** equal candidate observations occur on pages 12, 14, and 12
+- **WHEN** the SDK reassembles the field
+- **THEN** one candidate remains
+- **AND** its page numbers are `[12, 14]`.
+
+### Requirement: Existing public result shape exposes provisional candidates
+
+The SDK SHALL preserve the public `CustomOutputScalarCandidateSet` shape.
+`selected` SHALL contain the first observed candidate, `alternatives` SHALL
+contain every later unique candidate, and `final_output` SHALL contain the
+selected candidate before downstream reconciliation.
+
+#### Scenario: Consumer reads a multi-candidate result
+
+- **GIVEN** a routed field has three unique candidates
+- **WHEN** the consumer reads the reassembly result
+- **THEN** the first candidate appears in `selected` and `final_output`
+- **AND** the second and third appear in `alternatives` in observation order
+- **AND** no candidate is described or represented as SDK-resolved.
+
+### Requirement: Reconciliation receives complete candidate provenance
+
+The Internal Arcadia consumer SHALL reconcile every statement field with more
+than one unique candidate. Its prompt SHALL include every candidate value,
+every known source page, and the subset of pages whose images are attached to
+the request.
+
+#### Scenario: Candidate has more pages than are attached
+
+- **GIVEN** a candidate has source pages 32 and 43
+- **AND** only page 32 is attached under the image limit
+- **WHEN** Arcadia renders the reconcile prompt
+- **THEN** the candidate object contains `source_pages: [32, 43]`
+- **AND** it contains `provided_pages: [32]`
+- **AND** the prompt does not imply that page 43 is visible to the agent.
+
+#### Scenario: Values include default-like text
+
+- **GIVEN** the candidate set contains `N/A` and another value
+- **WHEN** Arcadia prepares reconciliation
+- **THEN** it runs the reconciliation agent
+- **AND** it does not suppress either value based on meaning or confidence.
+
+### Requirement: Image selection covers candidates fairly within 30 images
+
+The Internal Arcadia consumer SHALL attach at least one available page image per
+candidate before adding additional pages. It SHALL then add remaining candidate
+pages round-robin in candidate order, deduplicate page images, and stop at the
+configured 30-image limit.
+
+#### Scenario: Total source pages exceed the image limit
+
+- **GIVEN** a field has fewer than or equal to 30 candidates
+- **AND** their combined source pages exceed 30 images
+- **WHEN** Arcadia selects reconcile images
+- **THEN** every candidate with an available page receives at least one image
+- **AND** remaining slots are distributed round-robin
+- **AND** every omitted page remains listed in `source_pages`.
+
+#### Scenario: Candidate coverage itself exceeds the image limit
+
+- **GIVEN** one field has more than 30 candidates that each require a distinct
+  available page
+- **WHEN** Arcadia prepares reconciliation
+- **THEN** it raises a clear image-evidence error before the model call
+- **AND** it does not hide a candidate or run a partial reconciliation.
+
+### Requirement: Agent decisions update output without erasing evidence
+
+After a valid reconciliation response, Internal Arcadia SHALL make the returned
+value current, clear the pending conflict marker, and preserve candidate
+history. QA SHALL preserve the same history.
+
+#### Scenario: Reconcile selects an existing candidate
+
+- **GIVEN** the provisional value is `A` and another candidate is `B`
+- **AND** the reconciliation agent returns `B`
+- **WHEN** Arcadia applies the response
+- **THEN** `B` becomes the current routed value
+- **AND** `A` and `B` remain in candidate history with their source pages
+- **AND** the pending conflict marker is cleared.
+
+#### Scenario: Reconcile returns a novel value
+
+- **GIVEN** candidate history contains `A` and `B`
+- **AND** the reconciliation agent returns `C`
+- **WHEN** Arcadia applies the response
+- **THEN** `C` becomes the current routed value
+- **AND** `C` is appended to candidate history with reconcile-agent origin
+- **AND** Arcadia invents no source page for `C`.
+
+#### Scenario: QA changes the reconciled value
+
+- **GIVEN** reconciliation has selected a current value and preserved candidate
+  history
+- **WHEN** QA returns a different valid value
+- **THEN** the QA value becomes current
+- **AND** the previous history remains
+- **AND** a novel QA value is appended without invented source pages.
+
+### Requirement: Confidence is metadata only
+
+GroundX Python and Internal Arcadia SHALL NOT use confidence to select, replace,
+filter, order, deduplicate, reconcile, accept, or reject a candidate, or to
+select its evidence images.
+
+#### Scenario: Candidate confidence values disagree
+
+- **GIVEN** otherwise distinct candidates have different confidence values
+- **WHEN** the SDK and Arcadia process them
+- **THEN** observation order and agent decisions alone determine the
+  provisional and reconciled values
+- **AND** confidence may be preserved as metadata
+- **AND** it causes no code branch affecting value or evidence selection.
+
+### Requirement: Protected extraction paths retain behavior outside candidate selection
+
+The coordinated SDK and Internal Arcadia change SHALL preserve workflow routes,
+relationships, agent response parsing, type coercion, retry ownership, and final
+customer JSON shape across the current reproduction, Arcadia legacy, Arcadia
+v1, generic v1, and ADP protected cases.
+
+#### Scenario: Field has one candidate
+
+- **GIVEN** a protected extraction field has one unique candidate
+- **WHEN** the coordinated pipeline runs
+- **THEN** candidate conflict alone does not invoke reconciliation
+- **AND** existing routing and output behavior remains unchanged.
+
+#### Scenario: Field has competing candidates
+
+- **GIVEN** a protected extraction field has more than one unique candidate
+- **WHEN** the coordinated pipeline runs
+- **THEN** reconciliation receives all candidates and available provenance
+- **AND** the reconciled current value reaches the existing final output path
+- **AND** candidate history remains diagnostic runtime state rather than a new
+  customer output field.

--- a/openspec/changes/delegate-scalar-candidate-resolution-to-agents/specs/scalar-candidate-evidence/spec.md
+++ b/openspec/changes/delegate-scalar-candidate-resolution-to-agents/specs/scalar-candidate-evidence/spec.md
@@ -79,6 +79,24 @@ each present value as a candidate.
 - **THEN** each present value is retained according to candidate identity rules
 - **AND** none is discarded as absence.
 
+#### Scenario: Required route contains only explicit null
+
+- **GIVEN** a singular routed field is required by the authored field contract
+- **AND** its only observed value is explicit null
+- **WHEN** the SDK reassembles the routed scalar field
+- **THEN** null remains in candidate evidence
+- **AND** null does not satisfy the required route
+- **AND** the SDK emits its required-field diagnostic independently of
+  candidate count.
+
+#### Scenario: Required route contains a contract-valid falsey value
+
+- **GIVEN** a singular routed field is required
+- **AND** its observed value is empty string, `false`, `0`, or empty list
+- **WHEN** the SDK reassembles the routed scalar field
+- **THEN** generic truthiness does not classify the value as missing
+- **AND** validity remains governed by the authored field contract.
+
 ### Requirement: Duplicate observations retain all source pages
 
 The SDK SHALL merge every unique source page associated with duplicate
@@ -215,6 +233,23 @@ v1, generic v1, and ADP protected cases.
 - **WHEN** the coordinated pipeline runs
 - **THEN** candidate conflict alone does not invoke reconciliation
 - **AND** existing routing and output behavior remains unchanged.
+
+#### Scenario: Sole nullable null is omitted from customer output
+
+- **GIVEN** a protected extraction field is nullable
+- **AND** its only candidate is explicit null
+- **WHEN** the coordinated pipeline completes
+- **THEN** null remains available as diagnostic evidence
+- **AND** the consumer omits the field from customer JSON without invoking
+  scalar value-selection logic.
+
+#### Scenario: Sole required null fails independently of reconciliation
+
+- **GIVEN** a protected extraction field is required
+- **AND** its only candidate is explicit null
+- **WHEN** the coordinated pipeline validates required output
+- **THEN** the run cannot succeed
+- **AND** the absence of a multi-candidate conflict does not bypass requiredness.
 
 #### Scenario: Field has competing candidates
 

--- a/openspec/changes/delegate-scalar-candidate-resolution-to-agents/tasks.md
+++ b/openspec/changes/delegate-scalar-candidate-resolution-to-agents/tasks.md
@@ -31,6 +31,10 @@
 - [ ] 1.5 Add presence tests proving a missing key creates no candidate while an
   explicit null, empty string, or empty list does. Prove repeated-row empty
   handling is unchanged.
+- [ ] 1.5a Add requiredness tests proving a sole explicit null remains candidate
+  evidence but does not satisfy a required route. Prove a required-field
+  diagnostic is emitted independently of candidate count, while empty string,
+  `false`, `0`, and empty list are not rejected by generic truthiness.
 - [ ] 1.6 Add duplicate-observation tests proving all unique source pages merge
   in first-seen order for the selected candidate and every alternative.
 - [ ] 1.7 Add public contract tests proving dataclass fields and imports remain
@@ -49,7 +53,8 @@
   envelope metadata outside the identity decision.
 - [ ] 2.3 Make singular route loading presence-aware so explicit null, empty
   string, and empty list reach candidate collection while missing keys do not.
-  Keep repeated route behavior unchanged.
+  Track required-route satisfaction separately so a sole null still emits the
+  existing required-field diagnostic. Keep repeated route behavior unchanged.
 - [ ] 2.4 Keep the first unique candidate as selected and provisional
   `final_output`. Append all later unique candidates without semantic ranking.
 - [ ] 2.5 Merge all unique source pages for duplicate observations without
@@ -61,80 +66,50 @@
   `final_output` are described as provisional when alternatives exist.
 - [ ] 2.8 Run focused custom-output and route-reassembly tests until green.
 
-## 3. Build and prove an exact SDK candidate wheel
+## 3. Build and prove an SDK source candidate
 
 - [ ] 3.1 Run changed-file Ruff checks and formatting checks, focused extraction
   tests, the full hand-written extraction test suite, Mypy, line-ending checks,
   and `git diff --check`.
-- [ ] 3.2 Build one candidate wheel without publishing it. Record source commit,
+- [ ] 3.2 Build one candidate wheel on Python 3.11 without publishing it. Keep
+  the repository's generated package version unchanged. Record source commit,
   filename, and SHA-256.
-- [ ] 3.3 Install the exact wheel into an isolated Internal Arcadia environment
-  based on the pushed PR 102 branch and verify the installed wheel hash.
+- [ ] 3.3 Install that source candidate into isolated Internal Arcadia and
+  Studio Harness environments based on their required pushed refs. Verify the
+  installed candidate hash in both environments.
 
-## 4. Lock the Internal Arcadia consumer contract with failing tests
+## 4. Hand off Internal Arcadia implementation to its owning plan
 
-- [ ] 4.1 Add SDK handoff tests proving every candidate and all page numbers
-  survive `_sdk_scalar_candidate_sets`, Celery serialization, statement branch
-  copies, reconcile, QA, and save diagnostics.
-- [ ] 4.2 Add prompt snapshot tests proving each conflicted field renders an
-  ordered candidate object array with `value`, complete `source_pages`, and
-  exact `provided_pages`.
-- [ ] 4.3 Add reconcile-trigger tests for default-like and empty candidates.
-  Prove two unique candidates always invoke reconcile and one unique candidate
-  does not.
-- [ ] 4.4 Add image-selection tests proving canonical page dedupe, one available
-  page per candidate first, round-robin fill, complete source-page metadata,
-  and a hard maximum of 30 attached images.
-- [ ] 4.5 Add a failure test for more than 30 candidates requiring distinct
-  images. Assert no model call occurs and the error names the field, candidate
-  count, and limit.
-- [ ] 4.6 Add reconcile-application tests proving an existing or novel returned
-  value becomes current, the provisional value remains in candidate history,
-  pending conflicts clear only after valid application, and no source page is
-  invented for an agent-created value.
-- [ ] 4.7 Add QA tests proving candidate history survives unchanged and a novel
-  QA value is appended without invented source pages.
-- [ ] 4.8 Add a trace test proving exact prompt, candidate mapping, attached
-  image count, source page count, agent response, current value, and candidate
-  history can be reconstructed without exposing candidate history in customer
-  JSON.
-- [ ] 4.9 Run the focused tests and confirm they fail for the current plain value
-  array, first-page-only evidence selection, and history-clearing behavior.
+- [ ] 4.1 Record the pushed `complete-scalar-reconcile-disposition` branch and
+  commit used for consumer implementation. That plan is the sole owner of
+  Arcadia code, prompts, tests, serialization, container pins, and terminal-save
+  behavior.
+- [ ] 4.2 Confirm the Arcadia plan covers candidate arrays and pages, image
+  selection, reconcile and QA disposition, sole-null handling, branch merge,
+  compact terminal-save evidence, persistence, and confidence neutrality.
+- [ ] 4.3 Do not implement or commit Internal Arcadia files from this SDK plan.
+  Use the SDK source candidate and this plan's cross-repository contract as the
+  Arcadia plan's inputs.
 
-## 5. Implement agent-owned reconciliation in Internal Arcadia
+## 5. Accept the Internal Arcadia consumer implementation
 
-- [ ] 5.1 Keep `_routed_final_candidate_evidence` as durable runtime candidate
-  history and `_routed_final_conflicts` as pending reconciliation state. Do not
-  use one structure for both meanings.
-- [ ] 5.2 Build reconciliation fields directly from complete candidate history.
-  Trigger on more than one unique candidate without semantic or confidence
-  filtering.
-- [ ] 5.3 Render each candidate with `value`, `source_pages`, and
-  `provided_pages`. Update the reconcile prompt to explain that only provided
-  pages are visible. Keep the existing plain JSON response shape.
-- [ ] 5.4 Replace first-page-only selection with candidate-first, round-robin
-  page selection. Deduplicate actual images and retain every source-page number
-  in prompt metadata.
-- [ ] 5.5 Reuse PR 102 field batching. Keep the existing 30-image maximum. Fail
-  one oversized field before the model call rather than adding multi-pass
-  orchestration or silently hiding evidence.
-- [ ] 5.6 Apply a valid reconcile response through one helper that sets the
-  current routed value, preserves all prior candidates, appends a novel agent
-  value with `origin: reconcile_agent`, and clears only pending conflict state.
-- [ ] 5.7 Reuse the same evidence-preservation helper for QA updates, using
-  `origin: qa_agent` for novel values.
-- [ ] 5.8 Preserve candidate history across `to_celery`, `from_celery`, branch
-  merges, save, and authorized diagnostic traces. Do not add it to customer
-  final JSON.
-- [ ] 5.9 Audit statement candidate, reconcile, QA, image, and save code for
-  confidence-based decisions. Confidence may be copied as metadata but must not
-  affect any branch.
+- [ ] 5.1 Install the recorded SDK source candidate in the Arcadia plan's clean
+  environment and verify its hash before consumer tests run.
+- [ ] 5.2 Require the Arcadia plan's focused tests to prove all candidate values
+  and pages survive reconcile, QA, branch merge, compact terminal save, and
+  authorized diagnostics without entering customer JSON.
+- [ ] 5.3 Require Arcadia end-to-end cases for a sole required null, sole
+  nullable null, two competing candidates, novel reconcile and QA values, and
+  more than 30 candidate images.
+- [ ] 5.4 Accept the consumer handoff only after the Arcadia plan records its
+  exact pushed commit and passing focused, full-suite, protected-case, payload,
+  type, and line-ending gates.
 
 ## 6. Verify the coordinated behavior
 
 - [ ] 6.1 Run focused Internal Arcadia statement, reconcile prompt, image
-  selection, serialization, route merge, save, and trace tests against the exact
-  candidate wheel.
+  selection, serialization, route merge, save, and trace tests against the
+  recorded SDK source candidate.
 - [ ] 6.2 Run the full Internal Arcadia unit suite, Pyright checks, line-ending
   checks, and `git diff --check`.
 - [ ] 6.3 Run protected offline regressions for the current reproduction,
@@ -153,19 +128,24 @@
 
 ## 7. Release, pin, and deploy reversibly
 
-- [ ] 7.1 Merge the SDK PR only after the exact candidate wheel passes the
-  consumer gates. Give the human Fern release owner the requested next version,
-  merged commit, wheel hash, validation evidence, semantic compatibility note,
-  and Internal Arcadia pin requirement. Do not publish from this repo.
-- [ ] 7.2 Pin the released SDK version in Internal Arcadia and reinstall from
-  the package index. Repeat focused, full-suite, protected-case, type,
-  line-ending, and container checks from a clean environment.
-- [ ] 7.3 Merge and deploy Internal Arcadia. Record the new and prior image
+- [ ] 7.1 Merge the SDK PR only after the source candidate passes both consumer
+  gates. Give the human Fern release owner requested version 3.9.7, the merged
+  handwritten source commit, candidate hash, validation evidence, semantic
+  compatibility note, and consumer pin requirements. Do not publish from this
+  repo.
+- [ ] 7.2 After 3.9.7 is published, verify it contains the tested handwritten
+  source change. Clean-install it in both consumers and rerun their gates. Do
+  not require byte identity with the differently versioned source candidate.
+- [ ] 7.3 Require the Internal Arcadia plan to update both dependency writers,
+  `requirements.txt` and `Dockerfile.extract`, to the released SDK version.
+  Accept the release gate only after that plan builds `Dockerfile.extract`,
+  inspects the installed GroundX version, and records the image identity.
+- [ ] 7.4 Merge and deploy Internal Arcadia. Record the new and prior image
   identities before rollout.
-- [ ] 7.4 Rerun the ADP side-by-side extraction and capture exact reconcile and
+- [ ] 7.5 Rerun the ADP side-by-side extraction and capture exact reconcile and
   QA requests, responses, candidate mappings, total document pages, candidate
   source pages, attached pages, and final field values.
-- [ ] 7.5 Roll Internal Arcadia back to the prior image and SDK pin if the
+- [ ] 7.6 Roll Internal Arcadia back to the prior image and both SDK pins if the
   current reproduction or any protected surface regresses. No data rollback is
   required.
 

--- a/openspec/changes/delegate-scalar-candidate-resolution-to-agents/tasks.md
+++ b/openspec/changes/delegate-scalar-candidate-resolution-to-agents/tasks.md
@@ -68,12 +68,15 @@
 
 ## 3. Build and prove an SDK source candidate
 
+- [ ] 3.0 Complete and validate Tasks 1 and 2 in
+  `complete-scalar-candidate-provenance` on top of this change. Record the one
+  combined SDK commit. Do not build or certify an earlier wheel.
 - [ ] 3.1 Run changed-file Ruff checks and formatting checks, focused extraction
-  tests, the full hand-written extraction test suite, Mypy, line-ending checks,
-  and `git diff --check`.
+  tests from both SDK changes, the full hand-written extraction test suite,
+  Mypy, line-ending checks, and `git diff --check`.
 - [ ] 3.2 Build one candidate wheel on Python 3.11 without publishing it. Keep
-  the repository's generated package version unchanged. Record source commit,
-  filename, and SHA-256.
+  the repository's generated package version unchanged. Build only from the
+  combined commit recorded in 3.0. Record source commit, filename, and SHA-256.
 - [ ] 3.3 Install that source candidate into isolated Internal Arcadia and
   Studio Harness environments based on their required pushed refs. Verify the
   installed candidate hash in both environments.
@@ -100,7 +103,9 @@
   authorized diagnostics without entering customer JSON.
 - [ ] 5.3 Require Arcadia end-to-end cases for a sole required null, sole
   nullable null, two competing candidates, novel reconcile and QA values, and
-  more than 30 candidate images.
+  more than 30 combined candidate pages. Prove it caps fairly without error,
+  and separately prove more than 30 candidates needing distinct images fails
+  before the model call.
 - [ ] 5.4 Accept the consumer handoff only after the Arcadia plan records its
   exact pushed commit and passing focused, full-suite, protected-case, payload,
   type, and line-ending gates.
@@ -120,7 +125,8 @@
   their evidence, and its selected value reaches final output.
 - [ ] 6.5 Prove the 30-image request contains no duplicate page images, records
   total document pages, total candidate source pages, attached page count, and
-  the exact page numbers attached.
+  the exact page numbers attached. Prove `provided_pages` matches only attached
+  images and every omitted page remains in `source_pages`.
 - [ ] 6.6 Strictly validate this producer OpenSpec change and any consumer
   tracking plan created during implementation. Confirm no customer documents,
   X-Rays, prompts, responses, credentials, or local run artifacts are
@@ -140,8 +146,10 @@
   `requirements.txt` and `Dockerfile.extract`, to the released SDK version.
   Accept the release gate only after that plan builds `Dockerfile.extract`,
   inspects the installed GroundX version, and records the image identity.
-- [ ] 7.4 Merge and deploy Internal Arcadia. Record the new and prior image
-  identities before rollout.
+- [ ] 7.4 Merge Internal Arcadia, then complete its Task 7 operator handoff
+  against `groundx-on-prem` `origin/0.2.7`. Require one immutable image identity
+  across all four extract workloads, the prior Helm revision and image digest,
+  readiness and installed-SDK proof, and the exact rollback receipt.
 - [ ] 7.5 Rerun the ADP side-by-side extraction and capture exact reconcile and
   QA requests, responses, candidate mappings, total document pages, candidate
   source pages, attached pages, and final field values.

--- a/openspec/changes/delegate-scalar-candidate-resolution-to-agents/tasks.md
+++ b/openspec/changes/delegate-scalar-candidate-resolution-to-agents/tasks.md
@@ -1,0 +1,180 @@
+# Tasks
+
+## 0. Establish pushed baselines
+
+- [ ] 0.1 Create the SDK implementation branch from the then-current pushed
+  `groundx-python` `origin/main`. Verify the reviewed candidate symbols and
+  tests still match this plan before editing.
+- [ ] 0.2 Base Internal Arcadia consumer work on the pushed branch containing
+  merged PR 102, not an unrelated local checkout. Record the exact SDK and
+  Internal Arcadia source commits.
+- [ ] 0.3 Confirm `src/groundx/extract/`, `tests/extract/`, and `openspec/` remain
+  protected by `.fernignore`. Do not edit generated Fern code.
+- [ ] 0.4 Reconcile this plan with active `normalize-extracted-value-types` work.
+  Keep type coercion there and candidate preservation here. Prove confidence is
+  metadata only when both changes are installed together.
+
+## 1. Lock the SDK candidate contract with failing tests
+
+- [ ] 1.1 Replace the test that requires higher-ranked candidates to clear
+  lower-ranked alternatives with tests proving the first observed candidate
+  remains selected and every later unique candidate remains available.
+- [ ] 1.2 Add table-driven string identity tests for outer-whitespace trimming,
+  case-insensitive comparison, preserved first casing, and significant internal
+  whitespace.
+- [ ] 1.3 Add exact type-sensitive identity tests for null, booleans, integers,
+  floats, lists, mappings, and nested JSON values. Prove `true`, `1`, and `1.0`
+  remain distinct.
+- [ ] 1.4 Add extracted-field envelope tests proving identity uses the inner
+  value, the first envelope is retained, and different confidence values do not
+  affect selection, ordering, or dedupe.
+- [ ] 1.5 Add presence tests proving a missing key creates no candidate while an
+  explicit null, empty string, or empty list does. Prove repeated-row empty
+  handling is unchanged.
+- [ ] 1.6 Add duplicate-observation tests proving all unique source pages merge
+  in first-seen order for the selected candidate and every alternative.
+- [ ] 1.7 Add public contract tests proving dataclass fields and imports remain
+  unchanged, `selected` is first observed, `alternatives` retain all later
+  unique values, and provisional `final_output` matches `selected`.
+- [ ] 1.8 Run the focused SDK tests and confirm they fail for the current
+  ranking, empty-value filtering, and alternative-clearing behavior.
+
+## 2. Implement transport-only SDK candidate collection
+
+- [ ] 2.1 Remove scalar candidate quality, hardcoded default-value ranking,
+  source-page ranking, confidence ranking, and higher-ranked replacement from
+  `src/groundx/extract/custom_outputs.py`.
+- [ ] 2.2 Add one private candidate-identity helper implementing only the
+  approved string and exact JSON equality rules. Keep confidence and other
+  envelope metadata outside the identity decision.
+- [ ] 2.3 Make singular route loading presence-aware so explicit null, empty
+  string, and empty list reach candidate collection while missing keys do not.
+  Keep repeated route behavior unchanged.
+- [ ] 2.4 Keep the first unique candidate as selected and provisional
+  `final_output`. Append all later unique candidates without semantic ranking.
+- [ ] 2.5 Merge all unique source pages for duplicate observations without
+  replacing the retained value or envelope.
+- [ ] 2.6 Audit the full SDK custom-output reassembly path for confidence-based
+  candidate branching. Remove any such branch and add a regression for each
+  removed decision.
+- [ ] 2.7 Update SDK docstrings and readback documentation so `selected` and
+  `final_output` are described as provisional when alternatives exist.
+- [ ] 2.8 Run focused custom-output and route-reassembly tests until green.
+
+## 3. Build and prove an exact SDK candidate wheel
+
+- [ ] 3.1 Run changed-file Ruff checks and formatting checks, focused extraction
+  tests, the full hand-written extraction test suite, Mypy, line-ending checks,
+  and `git diff --check`.
+- [ ] 3.2 Build one candidate wheel without publishing it. Record source commit,
+  filename, and SHA-256.
+- [ ] 3.3 Install the exact wheel into an isolated Internal Arcadia environment
+  based on the pushed PR 102 branch and verify the installed wheel hash.
+
+## 4. Lock the Internal Arcadia consumer contract with failing tests
+
+- [ ] 4.1 Add SDK handoff tests proving every candidate and all page numbers
+  survive `_sdk_scalar_candidate_sets`, Celery serialization, statement branch
+  copies, reconcile, QA, and save diagnostics.
+- [ ] 4.2 Add prompt snapshot tests proving each conflicted field renders an
+  ordered candidate object array with `value`, complete `source_pages`, and
+  exact `provided_pages`.
+- [ ] 4.3 Add reconcile-trigger tests for default-like and empty candidates.
+  Prove two unique candidates always invoke reconcile and one unique candidate
+  does not.
+- [ ] 4.4 Add image-selection tests proving canonical page dedupe, one available
+  page per candidate first, round-robin fill, complete source-page metadata,
+  and a hard maximum of 30 attached images.
+- [ ] 4.5 Add a failure test for more than 30 candidates requiring distinct
+  images. Assert no model call occurs and the error names the field, candidate
+  count, and limit.
+- [ ] 4.6 Add reconcile-application tests proving an existing or novel returned
+  value becomes current, the provisional value remains in candidate history,
+  pending conflicts clear only after valid application, and no source page is
+  invented for an agent-created value.
+- [ ] 4.7 Add QA tests proving candidate history survives unchanged and a novel
+  QA value is appended without invented source pages.
+- [ ] 4.8 Add a trace test proving exact prompt, candidate mapping, attached
+  image count, source page count, agent response, current value, and candidate
+  history can be reconstructed without exposing candidate history in customer
+  JSON.
+- [ ] 4.9 Run the focused tests and confirm they fail for the current plain value
+  array, first-page-only evidence selection, and history-clearing behavior.
+
+## 5. Implement agent-owned reconciliation in Internal Arcadia
+
+- [ ] 5.1 Keep `_routed_final_candidate_evidence` as durable runtime candidate
+  history and `_routed_final_conflicts` as pending reconciliation state. Do not
+  use one structure for both meanings.
+- [ ] 5.2 Build reconciliation fields directly from complete candidate history.
+  Trigger on more than one unique candidate without semantic or confidence
+  filtering.
+- [ ] 5.3 Render each candidate with `value`, `source_pages`, and
+  `provided_pages`. Update the reconcile prompt to explain that only provided
+  pages are visible. Keep the existing plain JSON response shape.
+- [ ] 5.4 Replace first-page-only selection with candidate-first, round-robin
+  page selection. Deduplicate actual images and retain every source-page number
+  in prompt metadata.
+- [ ] 5.5 Reuse PR 102 field batching. Keep the existing 30-image maximum. Fail
+  one oversized field before the model call rather than adding multi-pass
+  orchestration or silently hiding evidence.
+- [ ] 5.6 Apply a valid reconcile response through one helper that sets the
+  current routed value, preserves all prior candidates, appends a novel agent
+  value with `origin: reconcile_agent`, and clears only pending conflict state.
+- [ ] 5.7 Reuse the same evidence-preservation helper for QA updates, using
+  `origin: qa_agent` for novel values.
+- [ ] 5.8 Preserve candidate history across `to_celery`, `from_celery`, branch
+  merges, save, and authorized diagnostic traces. Do not add it to customer
+  final JSON.
+- [ ] 5.9 Audit statement candidate, reconcile, QA, image, and save code for
+  confidence-based decisions. Confidence may be copied as metadata but must not
+  affect any branch.
+
+## 6. Verify the coordinated behavior
+
+- [ ] 6.1 Run focused Internal Arcadia statement, reconcile prompt, image
+  selection, serialization, route merge, save, and trace tests against the exact
+  candidate wheel.
+- [ ] 6.2 Run the full Internal Arcadia unit suite, Pyright checks, line-ending
+  checks, and `git diff --check`.
+- [ ] 6.3 Run protected offline regressions for the current reproduction,
+  Arcadia legacy, Arcadia v1, generic v1, and ADP. Name the exact test or fixture
+  and result for every surface.
+- [ ] 6.4 Add a targeted regression using the known default-like conflicts that
+  motivated this change. Prove reconcile is called, receives both values and
+  their evidence, and its selected value reaches final output.
+- [ ] 6.5 Prove the 30-image request contains no duplicate page images, records
+  total document pages, total candidate source pages, attached page count, and
+  the exact page numbers attached.
+- [ ] 6.6 Strictly validate this producer OpenSpec change and any consumer
+  tracking plan created during implementation. Confirm no customer documents,
+  X-Rays, prompts, responses, credentials, or local run artifacts are
+  committed.
+
+## 7. Release, pin, and deploy reversibly
+
+- [ ] 7.1 Merge the SDK PR only after the exact candidate wheel passes the
+  consumer gates. Give the human Fern release owner the requested next version,
+  merged commit, wheel hash, validation evidence, semantic compatibility note,
+  and Internal Arcadia pin requirement. Do not publish from this repo.
+- [ ] 7.2 Pin the released SDK version in Internal Arcadia and reinstall from
+  the package index. Repeat focused, full-suite, protected-case, type,
+  line-ending, and container checks from a clean environment.
+- [ ] 7.3 Merge and deploy Internal Arcadia. Record the new and prior image
+  identities before rollout.
+- [ ] 7.4 Rerun the ADP side-by-side extraction and capture exact reconcile and
+  QA requests, responses, candidate mappings, total document pages, candidate
+  source pages, attached pages, and final field values.
+- [ ] 7.5 Roll Internal Arcadia back to the prior image and SDK pin if the
+  current reproduction or any protected surface regresses. No data rollback is
+  required.
+
+## 8. Close evidence safely
+
+- [ ] 8.1 Store run evidence only under the approved ignored private artifact
+  root with owner, reason, expiry, and source hashes.
+- [ ] 8.2 Settle evidence as accepted, rejected, or superseded. Remove local raw
+  prompts, responses, images, X-Rays, and customer files after disposition.
+- [ ] 8.3 Archive this change only after the SDK release, Internal Arcadia pin
+  and deployment, protected certification, ADP rerun, and evidence cleanup are
+  complete.

--- a/openspec/specs/custom-output-readback/spec.md
+++ b/openspec/specs/custom-output-readback/spec.md
@@ -3,6 +3,37 @@
 ## Purpose
 TBD - created by archiving change generalize-v1-custom-output-reassembly. Update Purpose after archive.
 ## Requirements
+### Requirement: Scalar candidate readback is provisional and transport-only
+
+For each singular routed field, the SDK SHALL keep the first observed unique
+candidate in `selected` and `final_output`, and SHALL keep every later unique
+candidate in `alternatives` in observation order. When alternatives exist,
+`selected` and `final_output` are provisional inputs to downstream
+reconciliation, not SDK-resolved values.
+
+Candidate identity SHALL use only outer trimming and case-insensitive comparison
+for string candidates, or exact type-sensitive JSON equality for other values.
+Known extracted-field envelopes compare by their inner `value` and retain the
+first envelope. Duplicate observations merge all unique source pages in
+first-seen order. Value meaning, default-like text, page presence, confidence,
+and other envelope metadata SHALL NOT select, replace, filter, order, or
+deduplicate candidates.
+
+#### Scenario: Multiple singular values remain available
+
+- **GIVEN** one singular route observes distinct values in multiple output containers
+- **WHEN** the SDK reassembles custom output
+- **THEN** the first value remains in `selected` and `final_output`
+- **AND** every later unique value appears in `alternatives` in observation order
+- **AND** downstream reconciliation receives the complete candidate evidence.
+
+#### Scenario: Duplicate values merge provenance without replacement
+
+- **GIVEN** equivalent candidate values occur on different source pages
+- **WHEN** the SDK reassembles custom output
+- **THEN** the first value or extracted-field envelope remains retained
+- **AND** its source pages contain every unique observed page in first-seen order.
+
 ### Requirement: Custom output readback treats records-wrapped rows as generic v1 output
 
 The SDK SHALL treat `_records[]` inside custom output maps as a supported

--- a/src/groundx/extract/custom_outputs.py
+++ b/src/groundx/extract/custom_outputs.py
@@ -599,7 +599,9 @@ def _custom_route_values(
     if not isinstance(output_map, typing.Mapping):
         return []
 
-    step_value = output_map.get(step_name)
+    if step_name not in output_map:
+        return []
+    step_value = output_map[step_name]
     route_repeats = _repeated_route(route, step_kinds)
 
     if isinstance(step_value, typing.Mapping):
@@ -655,8 +657,6 @@ def _custom_route_values(
                 values.append(_RouteValue(value=record, record_index=index, repeated=True))
         return values
 
-    if step_value is None:
-        return []
     return [
         _RouteValue(
             value=step_value,

--- a/src/groundx/extract/custom_outputs.py
+++ b/src/groundx/extract/custom_outputs.py
@@ -39,6 +39,13 @@ class CustomOutputScalarCandidate:
 
 @dataclasses.dataclass(frozen=True)
 class CustomOutputScalarCandidateSet:
+    """Observed values for one singular route in traversal order.
+
+    ``selected`` is the first observed candidate and remains provisional when
+    ``alternatives`` is non-empty. Later unique observations appear in
+    ``alternatives`` without SDK value selection.
+    """
+
     output_source: str
     workflow_group: str
     workflow_field: str
@@ -49,6 +56,12 @@ class CustomOutputScalarCandidateSet:
 
 @dataclasses.dataclass(frozen=True)
 class CustomOutputReassemblyResult:
+    """Custom-output route reassembly and diagnostic evidence.
+
+    ``final_output`` contains the first observed scalar candidate. A scalar
+    value remains provisional when its candidate set has alternatives.
+    """
+
     final_output: typing.Dict[str, typing.Any]
     relationship_output: typing.Optional[typing.Dict[str, typing.Any]]
     diagnostics: typing.List[CustomOutputDiagnostic]
@@ -89,7 +102,6 @@ class _RouteContainer:
 @dataclasses.dataclass(frozen=True)
 class _ScalarCandidate:
     value: typing.Any
-    quality: typing.Tuple[int, int, float]
     page_numbers: typing.Tuple[int, ...]
 
 
@@ -107,19 +119,6 @@ _RELATIONSHIP_PACKET_CAMEL_KEYS = {
     "match_attrs": "matchAttrs",
     "parent_passthrough_attrs": "parentPassthroughAttrs",
     "multiple_match_strategy": "multipleMatchStrategy",
-}
-_DEFAULT_CANDIDATE_VALUES = {
-    "n/a",
-    "na",
-    "none",
-    "not applicable",
-    "not found",
-    "not indicated",
-    "not provided",
-    "not specified",
-    "not stated",
-    "null",
-    "unknown",
 }
 _GET_ALIASES = {
     "chunkId": ("chunk_id",),
@@ -150,7 +149,7 @@ def reassemble_custom_outputs_from_xray(
     final_output: typing.Dict[str, typing.Any] = {}
     workflow_output: typing.Dict[str, typing.Any] = {}
     source_provenance: typing.List[CustomOutputSourceProvenance] = []
-    route_hits: typing.Dict[int, bool] = {}
+    route_satisfied: typing.Dict[int, bool] = {}
     repeated_records: typing.Dict[
         typing.Tuple[typing.Tuple[str, ...], typing.Tuple[typing.Any, ...]],
         typing.Dict[str, typing.Any],
@@ -167,7 +166,7 @@ def reassemble_custom_outputs_from_xray(
     diagnostics: typing.List[CustomOutputDiagnostic] = []
 
     for route_index, route in enumerate(routes):
-        route_hits[route_index] = False
+        route_satisfied[route_index] = False
         if not isinstance(route, dict):
             continue
         route_map = typing.cast(typing.Mapping[str, typing.Any], route)
@@ -187,8 +186,8 @@ def reassemble_custom_outputs_from_xray(
                     route_map.get("step_name"),
                     route_value.record_index,
                 )
-                if _is_empty_output(route_value.value):
-                    if route_value.repeated and route_value.conflicts:
+                if route_value.repeated and _is_empty_output(route_value.value):
+                    if route_value.conflicts:
                         _set_pointer(
                             final_output,
                             f"{pointer}{_CONFLICTS_SIBLING_SUFFIX}",
@@ -201,7 +200,8 @@ def reassemble_custom_outputs_from_xray(
                             diagnostics=diagnostics,
                         )
                     continue
-                route_hits[route_index] = True
+                if route_value.repeated or route_value.value is not None:
+                    route_satisfied[route_index] = True
                 if route_value.repeated:
                     _record_repeated_group_path(
                         repeated_group_paths,
@@ -258,7 +258,7 @@ def reassemble_custom_outputs_from_xray(
     diagnostics.extend(
         _missing_required_route_diagnostics(
             typing.cast(typing.Sequence[typing.Any], routes),
-            route_hits,
+            route_satisfied,
             workflow_extract,
         )
     )
@@ -752,47 +752,55 @@ def _scalar_candidate(
     value: typing.Any,
     page_numbers: typing.Tuple[int, ...],
 ) -> _ScalarCandidate:
+    retained_value = value
+    if isinstance(value, str):
+        retained_value = value.strip()
+    elif isinstance(value, typing.Mapping) and _unwrap_match_value(value) is not value:
+        retained_value = copy.deepcopy(dict(value))
+        inner_value = retained_value.get("value")
+        if isinstance(inner_value, str):
+            retained_value["value"] = inner_value.strip()
     return _ScalarCandidate(
-        value=value,
-        quality=_scalar_candidate_quality(value, page_numbers),
+        value=retained_value,
         page_numbers=page_numbers,
     )
 
 
-def _scalar_candidate_quality(
-    value: typing.Any,
-    page_numbers: typing.Tuple[int, ...],
-) -> typing.Tuple[int, int, float]:
-    normalized = _normalized_candidate_value(value)
-    is_specific = 0 if _is_default_candidate_value(normalized) else 1
-    has_source_pages = 1 if page_numbers else 0
-    return (is_specific, has_source_pages, _candidate_confidence(value))
-
-
-def _normalized_candidate_value(value: typing.Any) -> typing.Any:
+def _scalar_candidate_identity(value: typing.Any) -> typing.Any:
+    """Return transport-only identity for one scalar candidate value."""
     unwrapped = _unwrap_match_value(value)
     if isinstance(unwrapped, str):
-        return " ".join(unwrapped.strip().casefold().split())
-    if isinstance(unwrapped, numbers.Real):
-        return float(unwrapped)
-    return unwrapped
+        return ("string", unwrapped.strip().casefold())
 
+    def exact_json_identity(item: typing.Any) -> typing.Any:
+        if item is None:
+            return ("null",)
+        if type(item) is bool:
+            return ("boolean", item)
+        if type(item) is int:
+            return ("integer", item)
+        if type(item) is float:
+            return ("float", item)
+        if isinstance(item, str):
+            return ("string", item)
+        if isinstance(item, list):
+            return ("list", tuple(exact_json_identity(value) for value in item))
+        if isinstance(item, typing.Mapping):
+            return (
+                "object",
+                tuple(
+                    sorted(
+                        (
+                            (type(key).__name__, repr(key)),
+                            exact_json_identity(nested_value),
+                        )
+                        for key, nested_value in item.items()
+                    )
+                ),
+            )
+        return (type(item).__module__, type(item).__qualname__, repr(item))
 
-def _is_default_candidate_value(value: typing.Any) -> bool:
-    if value is None:
-        return True
-    if isinstance(value, str):
-        return value in _DEFAULT_CANDIDATE_VALUES
-    return False
-
-
-def _candidate_confidence(value: typing.Any) -> float:
-    if not isinstance(value, typing.Mapping):
-        return 0.0
-    confidence = value.get("confidence")
-    if not isinstance(confidence, numbers.Real):
-        return 0.0
-    return max(0.0, min(1.0, float(confidence)))
+    return exact_json_identity(unwrapped)
 
 
 def _string_value(value: typing.Any) -> typing.Optional[str]:
@@ -856,49 +864,45 @@ def _set_pointer(
     state = scalar_candidates.get(pointer)
     if state is not None:
         existing = state.selected
-        if candidate.quality < existing.quality:
-            return
-        if candidate.quality == existing.quality:
-            normalized_candidate = _normalized_candidate_value(candidate.value)
-            if normalized_candidate == _normalized_candidate_value(existing.value):
-                scalar_candidates[pointer] = dataclasses.replace(
-                    state,
-                    selected=dataclasses.replace(
-                        existing,
-                        page_numbers=_merge_page_numbers(existing.page_numbers, candidate.page_numbers),
-                    ),
-                )
-                return
-
-            diagnostics.append(
-                CustomOutputDiagnostic(
-                    code="conflicting_output_candidates",
-                    message=f"multiple equal-quality candidates for [{pointer}]",
-                    severity="warning",
-                    workflow_group=_string_value(route.get("workflow_group")),
-                    workflow_field=_string_value(route.get("workflow_field")),
-                    final_path=pointer,
-                )
-            )
-            for index, alternative in enumerate(state.alternatives):
-                if normalized_candidate != _normalized_candidate_value(alternative.value):
-                    continue
-                alternatives = list(state.alternatives)
-                alternatives[index] = dataclasses.replace(
-                    alternative,
-                    page_numbers=_merge_page_numbers(alternative.page_numbers, candidate.page_numbers),
-                )
-                scalar_candidates[pointer] = dataclasses.replace(
-                    state,
-                    alternatives=tuple(alternatives),
-                )
-                return
+        candidate_identity = _scalar_candidate_identity(candidate.value)
+        if candidate_identity == _scalar_candidate_identity(existing.value):
             scalar_candidates[pointer] = dataclasses.replace(
                 state,
-                alternatives=(*state.alternatives, candidate),
+                selected=dataclasses.replace(
+                    existing,
+                    page_numbers=_merge_page_numbers(existing.page_numbers, candidate.page_numbers),
+                ),
             )
             return
-    current[parts[-1]] = value
+        for index, alternative in enumerate(state.alternatives):
+            if candidate_identity != _scalar_candidate_identity(alternative.value):
+                continue
+            alternatives = list(state.alternatives)
+            alternatives[index] = dataclasses.replace(
+                alternative,
+                page_numbers=_merge_page_numbers(alternative.page_numbers, candidate.page_numbers),
+            )
+            scalar_candidates[pointer] = dataclasses.replace(
+                state,
+                alternatives=tuple(alternatives),
+            )
+            return
+        diagnostics.append(
+            CustomOutputDiagnostic(
+                code="conflicting_output_candidates",
+                message=f"multiple candidates for [{pointer}]",
+                severity="warning",
+                workflow_group=_string_value(route.get("workflow_group")),
+                workflow_field=_string_value(route.get("workflow_field")),
+                final_path=pointer,
+            )
+        )
+        scalar_candidates[pointer] = dataclasses.replace(
+            state,
+            alternatives=(*state.alternatives, candidate),
+        )
+        return
+    current[parts[-1]] = copy.deepcopy(candidate.value)
     scalar_candidates[pointer] = _ScalarCandidateState(
         selected=candidate,
         alternatives=(),
@@ -1031,7 +1035,7 @@ def _set_nested_value(
 
 def _missing_required_route_diagnostics(
     routes: typing.Sequence[typing.Any],
-    route_hits: typing.Mapping[int, bool],
+    route_satisfied: typing.Mapping[int, bool],
     workflow_extract: typing.Optional[typing.Mapping[str, typing.Any]],
 ) -> typing.List[CustomOutputDiagnostic]:
     if not isinstance(workflow_extract, typing.Mapping):
@@ -1040,11 +1044,11 @@ def _missing_required_route_diagnostics(
     hit_workflow_groups = {
         str(route.get("workflow_group"))
         for index, route in enumerate(routes)
-        if route_hits.get(index) and isinstance(route, typing.Mapping)
+        if route_satisfied.get(index) and isinstance(route, typing.Mapping)
     }
     diagnostics: typing.List[CustomOutputDiagnostic] = []
     for index, route in enumerate(routes):
-        if route_hits.get(index):
+        if route_satisfied.get(index):
             continue
         if not isinstance(route, typing.Mapping):
             continue

--- a/src/groundx/extract/custom_outputs.py
+++ b/src/groundx/extract/custom_outputs.py
@@ -200,7 +200,7 @@ def reassemble_custom_outputs_from_xray(
                             diagnostics=diagnostics,
                         )
                     continue
-                if route_value.repeated or route_value.value is not None:
+                if route_value.repeated or _unwrap_match_value(route_value.value) is not None:
                     route_satisfied[route_index] = True
                 if route_value.repeated:
                     _record_repeated_group_path(

--- a/src/groundx/extract/custom_outputs.py
+++ b/src/groundx/extract/custom_outputs.py
@@ -639,6 +639,14 @@ def _custom_route_values(
         ]
 
     if isinstance(step_value, list):
+        if not route_repeats:
+            return [
+                _RouteValue(
+                    value=step_value,
+                    record_index=None,
+                    repeated=False,
+                )
+            ]
         values: typing.List[_RouteValue] = []
         for index, record in enumerate(step_value):
             if isinstance(record, typing.Mapping):

--- a/src/groundx/extract/custom_outputs.py
+++ b/src/groundx/extract/custom_outputs.py
@@ -203,12 +203,12 @@ def reassemble_custom_outputs_from_xray(
                             page_numbers=route_container.page_numbers,
                             scalar_candidates=scalar_candidates,
                             diagnostics=diagnostics,
-                            repeated=route_repeats and route_value.repeated,
+                            repeated=route_repeats,
                         )
                     continue
                 if route_value.repeated or _unwrap_match_value(route_value.value) is not None:
                     route_satisfied[route_index] = True
-                if route_value.repeated:
+                if route_repeats:
                     _record_repeated_group_path(
                         repeated_group_paths,
                         pointer,
@@ -237,7 +237,7 @@ def reassemble_custom_outputs_from_xray(
                     page_numbers=route_container.page_numbers,
                     scalar_candidates=scalar_candidates,
                     diagnostics=diagnostics,
-                    repeated=route_repeats and route_value.repeated,
+                    repeated=route_repeats,
                 )
                 if route_value.repeated and route_value.conflicts is not None:
                     # Task 3.2a7b: carry the generic `<field>__conflicts`
@@ -253,7 +253,7 @@ def reassemble_custom_outputs_from_xray(
                         page_numbers=route_container.page_numbers,
                         scalar_candidates=scalar_candidates,
                         diagnostics=diagnostics,
-                        repeated=route_repeats and route_value.repeated,
+                        repeated=route_repeats,
                     )
 
     _dedupe_repeated_group_outputs(
@@ -884,7 +884,7 @@ def _set_pointer(
             _set_nested_value(record, field_path, value)
         return
 
-    if repeated and parts[0] == route.get("workflow_group"):
+    if repeated:
         records = result.setdefault(parts[0], [])
         if not isinstance(records, list):
             return

--- a/src/groundx/extract/custom_outputs.py
+++ b/src/groundx/extract/custom_outputs.py
@@ -173,8 +173,13 @@ def reassemble_custom_outputs_from_xray(
         final_path = route_map.get("final_path")
         if not isinstance(final_path, str):
             continue
+        route_repeats = _repeated_route(route_map, step_kinds)
 
-        for route_container in _route_containers(xray, route_map):
+        for route_container in _route_containers(
+            xray,
+            route_map,
+            repeated=route_repeats,
+        ):
             for route_value in _custom_route_values(
                 route_container.value,
                 route_map,
@@ -198,6 +203,7 @@ def reassemble_custom_outputs_from_xray(
                             page_numbers=route_container.page_numbers,
                             scalar_candidates=scalar_candidates,
                             diagnostics=diagnostics,
+                            repeated=route_repeats and route_value.repeated,
                         )
                     continue
                 if route_value.repeated or _unwrap_match_value(route_value.value) is not None:
@@ -231,6 +237,7 @@ def reassemble_custom_outputs_from_xray(
                     page_numbers=route_container.page_numbers,
                     scalar_candidates=scalar_candidates,
                     diagnostics=diagnostics,
+                    repeated=route_repeats and route_value.repeated,
                 )
                 if route_value.repeated and route_value.conflicts is not None:
                     # Task 3.2a7b: carry the generic `<field>__conflicts`
@@ -246,6 +253,7 @@ def reassemble_custom_outputs_from_xray(
                         page_numbers=route_container.page_numbers,
                         scalar_candidates=scalar_candidates,
                         diagnostics=diagnostics,
+                        repeated=route_repeats and route_value.repeated,
                     )
 
     _dedupe_repeated_group_outputs(
@@ -337,25 +345,15 @@ def select_relationship_parent(
     if not isinstance(child, typing.Mapping):
         return no_selection
 
-    match_attrs = _relationship_attr_list(
-        _relationship_packet_value(relationship, "match_attrs")
-    )
+    match_attrs = _relationship_attr_list(_relationship_packet_value(relationship, "match_attrs"))
     if not match_attrs:
         return no_selection
 
-    parent_list = [
-        parent
-        for parent in (parents or [])
-        if isinstance(parent, typing.Mapping)
-    ]
+    parent_list = [parent for parent in (parents or []) if isinstance(parent, typing.Mapping)]
     if not parent_list:
         return no_selection
 
-    populated_keys = {
-        attr: child.get(attr)
-        for attr in match_attrs
-        if not _relationship_value_absent(child.get(attr))
-    }
+    populated_keys = {attr: child.get(attr) for attr in match_attrs if not _relationship_value_absent(child.get(attr))}
     if not populated_keys:
         return no_selection
 
@@ -375,11 +373,7 @@ def select_relationship_parent(
 
     direct_matches: typing.List[typing.Mapping[str, typing.Any]] = []
     for parent in parent_list:
-        parent_key_count = sum(
-            1
-            for attr in match_attrs
-            if not _relationship_value_absent(parent.get(attr))
-        )
+        parent_key_count = sum(1 for attr in match_attrs if not _relationship_value_absent(parent.get(attr)))
         if parent_key_count == len(populated_keys) and matches_attrs(
             parent,
             tuple(populated_keys),
@@ -396,19 +390,13 @@ def select_relationship_parent(
             )
         return RelationshipParentSelection(parent=None, ambiguous=True)
 
-    passthrough_attrs = _relationship_attr_list(
-        _relationship_packet_value(relationship, "parent_passthrough_attrs")
-    )
-    stable_match_attrs = tuple(
-        attr for attr in match_attrs if attr not in passthrough_attrs
-    )
+    passthrough_attrs = _relationship_attr_list(_relationship_packet_value(relationship, "parent_passthrough_attrs"))
+    stable_match_attrs = tuple(attr for attr in match_attrs if attr not in passthrough_attrs)
     if len(stable_match_attrs) == len(match_attrs):
         return no_selection
     if not stable_match_attrs:
         return no_selection
-    ignored_match_attrs = tuple(
-        attr for attr in match_attrs if attr not in stable_match_attrs
-    )
+    ignored_match_attrs = tuple(attr for attr in match_attrs if attr not in stable_match_attrs)
 
     def has_ignored_match_conflict(
         parent: typing.Mapping[str, typing.Any],
@@ -494,9 +482,22 @@ def _custom_step_kinds(workflow: typing.Mapping[str, typing.Any]) -> typing.Dict
     return step_kinds
 
 
+def _repeated_route(
+    route: typing.Mapping[str, typing.Any],
+    step_kinds: typing.Mapping[str, str],
+) -> bool:
+    step_name = route.get("step_name")
+    final_path = route.get("final_path")
+    return (isinstance(step_name, str) and step_kinds.get(step_name) in _REPEATED_STEP_KINDS) or (
+        isinstance(final_path, str) and "*" in _pointer_parts(final_path)
+    )
+
+
 def _route_containers(
     xray: typing.Any,
     route: typing.Mapping[str, typing.Any],
+    *,
+    repeated: bool,
 ) -> typing.List[_RouteContainer]:
     level = route.get("level")
     output_map_name = route.get("output_map")
@@ -504,6 +505,27 @@ def _route_containers(
         if not isinstance(output_map_name, str):
             return [_RouteContainer(identity=("document",), value=xray)]
         document_containers: typing.List[_RouteContainer] = []
+        if not repeated:
+            root_output_payload = _get(xray, output_map_name)
+            if isinstance(root_output_payload, typing.Mapping):
+                document_containers.append(
+                    _RouteContainer(
+                        identity=("document", output_map_name, "root"),
+                        value=xray,
+                    )
+                )
+            for chunk in _iter_chunks(xray):
+                output_payload = _get(chunk, output_map_name)
+                if not isinstance(output_payload, typing.Mapping):
+                    continue
+                document_containers.append(
+                    _RouteContainer(
+                        identity=("document", output_map_name, _chunk_identity(chunk)),
+                        value=chunk,
+                        page_numbers=_page_numbers(chunk),
+                    )
+                )
+            return document_containers
         document_seen: typing.Set[str] = set()
         for container in [xray, *_iter_chunks(xray)]:
             output_payload = _get(container, output_map_name)
@@ -530,6 +552,15 @@ def _route_containers(
             for chunk in _iter_chunks(xray)
         ]
     if level == "section" and isinstance(output_map_name, str):
+        if not repeated:
+            return [
+                _RouteContainer(
+                    identity=("section", output_map_name, _chunk_identity(chunk)),
+                    value=chunk,
+                    page_numbers=_page_numbers(chunk),
+                )
+                for chunk in _iter_chunks(xray)
+            ]
         section_containers: typing.List[_RouteContainer] = []
         section_seen: typing.Set[str] = set()
         for chunk in _iter_chunks(xray):
@@ -569,9 +600,7 @@ def _custom_route_values(
         return []
 
     step_value = output_map.get(step_name)
-    is_repeated_step = step_kinds.get(step_name) in _REPEATED_STEP_KINDS
-    final_path = route.get("final_path")
-    route_repeats = is_repeated_step or (isinstance(final_path, str) and "*" in final_path)
+    route_repeats = _repeated_route(route, step_kinds)
 
     if isinstance(step_value, typing.Mapping):
         records = step_value.get("_records")
@@ -631,8 +660,8 @@ def _custom_route_values(
     return [
         _RouteValue(
             value=step_value,
-            record_index=0 if is_repeated_step else None,
-            repeated=is_repeated_step,
+            record_index=0 if route_repeats else None,
+            repeated=route_repeats,
         )
     ]
 
@@ -821,6 +850,7 @@ def _set_pointer(
     page_numbers: typing.Tuple[int, ...],
     scalar_candidates: typing.Dict[str, _ScalarCandidateState],
     diagnostics: typing.List[CustomOutputDiagnostic],
+    repeated: bool,
 ) -> None:
     parts = _pointer_parts(pointer)
     if not parts:
@@ -852,6 +882,20 @@ def _set_pointer(
         field_path = parts[star_index + 1 :]
         if field_path:
             _set_nested_value(record, field_path, value)
+        return
+
+    if repeated and parts[0] == route.get("workflow_group"):
+        records = result.setdefault(parts[0], [])
+        if not isinstance(records, list):
+            return
+        item_key = ((parts[0],), record_key)
+        record = repeated_records.get(item_key)
+        if record is None:
+            record = {}
+            repeated_records[item_key] = record
+            records.append(record)
+        if len(parts) > 1:
+            _set_nested_value(record, parts[1:], value)
         return
 
     current = result
@@ -1502,17 +1546,11 @@ class _AdvancedIdentityIndex:
         self.exact_attrs = _identity_exact_attrs(identity_match, unique_attrs)
         self.records: typing.List[typing.Dict[str, typing.Any]] = []
         self.presence_bits = {attr: 0 for attr in self.threshold_attrs}
-        self.value_bits: typing.Dict[str, typing.Dict[typing.Any, int]] = {
-            attr: {} for attr in self.threshold_attrs
-        }
-        self.indexed_values: typing.List[
-            typing.Dict[str, typing.Tuple[bool, typing.Any]]
-        ] = []
+        self.value_bits: typing.Dict[str, typing.Dict[typing.Any, int]] = {attr: {} for attr in self.threshold_attrs}
+        self.indexed_values: typing.List[typing.Dict[str, typing.Tuple[bool, typing.Any]]] = []
         shortcuts = identity_match.get("equal_value_shortcuts", {})
         shortcut_map = (
-            typing.cast(typing.Mapping[str, typing.Any], shortcuts)
-            if isinstance(shortcuts, typing.Mapping)
-            else {}
+            typing.cast(typing.Mapping[str, typing.Any], shortcuts) if isinstance(shortcuts, typing.Mapping) else {}
         )
         self.shortcut_values = {
             attr: {
@@ -1610,11 +1648,7 @@ class _AdvancedIdentityIndex:
         )
         remaining_presence_limit = self.activate_threshold_at - len(present_attrs) - 1
         underactivation_bits = _at_most_count_bits(
-            [
-                self.presence_bits[attr]
-                for attr in self.threshold_attrs
-                if attr not in present_attrs
-            ],
+            [self.presence_bits[attr] for attr in self.threshold_attrs if attr not in present_attrs],
             remaining_presence_limit,
             universe,
         )
@@ -1652,9 +1686,7 @@ def _at_most_count_bits(
         next_exact = [0] * (maximum + 1)
         next_exact[0] = exact[0] & without_bits
         for count in range(1, maximum + 1):
-            next_exact[count] = (exact[count] & without_bits) | (
-                exact[count - 1] & bits
-            )
+            next_exact[count] = (exact[count] & without_bits) | (exact[count - 1] & bits)
         exact = next_exact
     result = 0
     for bits in exact:
@@ -1841,11 +1873,7 @@ def _identity_exact_attrs(
     identity_match: typing.Mapping[str, typing.Any],
     unique_attrs: typing.Sequence[str],
 ) -> typing.FrozenSet[str]:
-    configured = (
-        identity_match["exact_attrs"]
-        if "exact_attrs" in identity_match
-        else unique_attrs
-    )
+    configured = identity_match["exact_attrs"] if "exact_attrs" in identity_match else unique_attrs
     return frozenset(
         _unique_strings(
             typing.cast(typing.Iterable[typing.Any], configured),

--- a/tests/extract/test_custom_output_reassembly.py
+++ b/tests/extract/test_custom_output_reassembly.py
@@ -120,6 +120,25 @@ def _reassemble_scalar_observations(
     )
 
 
+def _reassemble_direct_scalar_value(
+    value: typing.Any,
+    *,
+    required: bool = False,
+):
+    return reassemble_custom_outputs_from_xray(
+        {
+            "chunks": [
+                {
+                    "chunkId": "direct-value",
+                    "pageNumbers": [7],
+                    "customChunkOutputs": {"scalar_step": value},
+                }
+            ]
+        },
+        workflow_extract=_scalar_candidate_workflow(required=required),
+    )
+
+
 def _candidate_values(result) -> list[typing.Any]:
     assert len(result.scalar_candidate_sets) == 1
     candidate_set = result.scalar_candidate_sets[0]
@@ -3041,6 +3060,29 @@ def test_scalar_candidate_direct_step_presence_distinguishes_missing_null_and_fa
     candidates = [candidate_set.selected, *candidate_set.alternatives]
     assert [candidate.value for candidate in candidates] == [None, False]
     assert [candidate.page_numbers for candidate in candidates] == [(2,), (3,)]
+
+
+def test_direct_singular_empty_list_is_retained_as_one_candidate() -> None:
+    result = _reassemble_direct_scalar_value([])
+
+    assert _candidate_values(result) == [[]]
+    assert result.scalar_candidate_sets[0].selected.page_numbers == (7,)
+    assert result.final_output == {"scalar_group": {"scalar_field": []}}
+
+
+def test_direct_singular_nonempty_list_preserves_list_identity() -> None:
+    result = _reassemble_direct_scalar_value(["first", "second"])
+
+    assert _candidate_values(result) == [["first", "second"]]
+    assert result.scalar_candidate_sets[0].selected.page_numbers == (7,)
+    assert result.final_output == {"scalar_group": {"scalar_field": ["first", "second"]}}
+
+
+def test_required_direct_singular_empty_list_satisfies_route() -> None:
+    result = _reassemble_direct_scalar_value([], required=True)
+
+    assert _candidate_values(result) == [[]]
+    assert not [diagnostic for diagnostic in result.diagnostics if diagnostic.code.startswith("missing_workflow_")]
 
 
 @pytest.mark.parametrize(

--- a/tests/extract/test_custom_output_reassembly.py
+++ b/tests/extract/test_custom_output_reassembly.py
@@ -234,7 +234,7 @@ def test_reassembles_complete_destination_trees_without_depth_inference(
     assert result.final_output == expected
 
 
-def test_compiled_final_path_does_not_infer_repetition_from_observed_records() -> None:
+def test_compiled_final_path_uses_declared_repeated_step_kind() -> None:
     workflow_extract = {
         "workflow": {
             "custom_steps": [
@@ -269,7 +269,7 @@ def test_compiled_final_path_does_not_infer_repetition_from_observed_records() -
     )
 
     assert result.final_output == {
-        "group": {"object": {"field": "compiled scalar"}},
+        "group": [{"object": {"field": "compiled scalar"}}],
     }
 
 
@@ -2004,7 +2004,7 @@ def test_records_wrapper_preserves_direct_outputs_next_to_records() -> None:
     )
 
     assert result.final_output == {
-        "statement": {"account_number": "A-123"},
+        "statement": [{"account_number": "A-123"}],
         "charges": [{"description": "Admin fee"}],
     }
 
@@ -2283,6 +2283,89 @@ def test_repeated_section_route_still_deduplicates_shared_section_id() -> None:
 
     assert result.final_output == {
         "line_items": [{"description": "Admin fee"}],
+    }
+
+
+def test_direct_repeated_route_uses_destination_root_when_workflow_group_differs() -> None:
+    workflow_extract = {
+        "workflow": {
+            "custom_steps": [
+                {"name": "line_item_rows", "level": "chunk", "kind": "keys"},
+            ],
+            "output_routes": [
+                {
+                    "workflow_group": "source_records",
+                    "workflow_field": "description",
+                    "final_path": "/line_items/description",
+                    "step_name": "line_item_rows",
+                    "level": "chunk",
+                    "output_map": "customChunkOutputs",
+                    "output_key": "description",
+                },
+            ],
+        }
+    }
+    xray = {
+        "chunks": [
+            {
+                "customChunkOutputs": {
+                    "line_item_rows": {
+                        "_records": [{"description": "Admin fee"}],
+                    }
+                }
+            }
+        ]
+    }
+
+    result = reassemble_custom_outputs_from_xray(
+        xray,
+        workflow_extract=workflow_extract,
+    )
+
+    assert result.final_output == {
+        "line_items": [{"description": "Admin fee"}],
+    }
+
+
+def test_direct_repeated_route_uses_sibling_fallback_when_records_do_not_match() -> None:
+    workflow_extract = {
+        "workflow": {
+            "custom_steps": [
+                {"name": "line_item_rows", "level": "chunk", "kind": "keys"},
+            ],
+            "output_routes": [
+                {
+                    "workflow_group": "line_items",
+                    "workflow_field": "code",
+                    "final_path": "/line_items/code",
+                    "step_name": "line_item_rows",
+                    "level": "chunk",
+                    "output_map": "customChunkOutputs",
+                    "output_key": "code",
+                },
+            ],
+        }
+    }
+    xray = {
+        "chunks": [
+            {
+                "customChunkOutputs": {
+                    "line_item_rows": {
+                        "code": "A-1",
+                        "_records": [{"description": "Admin fee"}],
+                    }
+                }
+            }
+        ]
+    }
+
+    result = reassemble_custom_outputs_from_xray(
+        xray,
+        workflow_extract=workflow_extract,
+    )
+
+    assert result.final_output == {
+        "line_items": [{"code": "A-1"}],
     }
 
 

--- a/tests/extract/test_custom_output_reassembly.py
+++ b/tests/extract/test_custom_output_reassembly.py
@@ -2461,6 +2461,43 @@ def test_scalar_candidate_sidecar_keeps_first_observation_and_all_later_unique_v
     }
 
 
+def test_scalar_candidate_selection_ignores_later_source_page_presence() -> None:
+    result = _reassemble_scalar_observations(
+        [
+            ({"scalar_field": "first without a page"}, []),
+            ({"scalar_field": "later with a page"}, [8]),
+        ]
+    )
+
+    assert len(result.scalar_candidate_sets) == 1
+    candidate_set = result.scalar_candidate_sets[0]
+    assert (candidate_set.selected.value, candidate_set.selected.page_numbers) == (
+        "first without a page",
+        (),
+    )
+    assert [(candidate.value, candidate.page_numbers) for candidate in candidate_set.alternatives] == [
+        ("later with a page", (8,)),
+    ]
+    assert result.final_output == {"scalar_group": {"scalar_field": "first without a page"}}
+
+
+def test_scalar_candidate_selection_ignores_default_like_value_meaning() -> None:
+    result = _reassemble_scalar_observations(
+        [
+            ({"scalar_field": "N/A"}, [3]),
+            ({"scalar_field": "100% immediate"}, [5]),
+        ]
+    )
+
+    assert len(result.scalar_candidate_sets) == 1
+    candidate_set = result.scalar_candidate_sets[0]
+    assert (candidate_set.selected.value, candidate_set.selected.page_numbers) == ("N/A", (3,))
+    assert [(candidate.value, candidate.page_numbers) for candidate in candidate_set.alternatives] == [
+        ("100% immediate", (5,)),
+    ]
+    assert result.final_output == {"scalar_group": {"scalar_field": "N/A"}}
+
+
 @pytest.mark.parametrize(
     ("observations", "expected_values", "expected_pages"),
     [

--- a/tests/extract/test_custom_output_reassembly.py
+++ b/tests/extract/test_custom_output_reassembly.py
@@ -3012,6 +3012,37 @@ def test_scalar_candidate_presence_distinguishes_missing_from_explicit_empty_val
     assert [candidate.page_numbers for candidate in candidates] == [(2,), (3,), (4,)]
 
 
+def test_scalar_candidate_direct_step_presence_distinguishes_missing_null_and_false() -> None:
+    result = reassemble_custom_outputs_from_xray(
+        {
+            "chunks": [
+                {
+                    "chunkId": "missing-step",
+                    "pageNumbers": [1],
+                    "customChunkOutputs": {},
+                },
+                {
+                    "chunkId": "null-step",
+                    "pageNumbers": [2],
+                    "customChunkOutputs": {"scalar_step": None},
+                },
+                {
+                    "chunkId": "false-step",
+                    "pageNumbers": [3],
+                    "customChunkOutputs": {"scalar_step": False},
+                },
+            ]
+        },
+        workflow_extract=_scalar_candidate_workflow(),
+    )
+
+    assert len(result.scalar_candidate_sets) == 1
+    candidate_set = result.scalar_candidate_sets[0]
+    candidates = [candidate_set.selected, *candidate_set.alternatives]
+    assert [candidate.value for candidate in candidates] == [None, False]
+    assert [candidate.page_numbers for candidate in candidates] == [(2,), (3,)]
+
+
 @pytest.mark.parametrize(
     "value",
     ["", False, 0, []],

--- a/tests/extract/test_custom_output_reassembly.py
+++ b/tests/extract/test_custom_output_reassembly.py
@@ -1,3 +1,4 @@
+import dataclasses
 import json
 import pathlib
 import typing
@@ -67,6 +68,62 @@ def _provenance_dicts(result) -> list[dict]:
         }
         for provenance in result.source_provenance
     ]
+
+
+def _scalar_candidate_workflow(*, required: bool = False) -> dict:
+    workflow_extract = {
+        "workflow": {
+            "custom_steps": [
+                {"name": "scalar_step", "level": "chunk", "kind": "instruct"},
+            ],
+            "output_routes": [
+                {
+                    "workflow_group": "scalar_group",
+                    "workflow_field": "scalar_field",
+                    "final_path": "/scalar_group/scalar_field",
+                    "step_name": "scalar_step",
+                    "level": "chunk",
+                    "output_map": "customChunkOutputs",
+                    "output_key": "scalar_field",
+                },
+            ],
+        }
+    }
+    if required:
+        workflow_extract["_groundx_persisted_extract"] = {
+            "scalar_group": {
+                "fields": {
+                    "scalar_field": {"required": True},
+                }
+            }
+        }
+    return workflow_extract
+
+
+def _reassemble_scalar_observations(
+    observations: typing.Sequence[typing.Tuple[typing.Mapping[str, typing.Any], typing.Sequence[int]]],
+    *,
+    required: bool = False,
+):
+    return reassemble_custom_outputs_from_xray(
+        {
+            "chunks": [
+                {
+                    "chunkId": f"chunk-{index}",
+                    "pageNumbers": list(page_numbers),
+                    "customChunkOutputs": {"scalar_step": dict(step_output)},
+                }
+                for index, (step_output, page_numbers) in enumerate(observations)
+            ]
+        },
+        workflow_extract=_scalar_candidate_workflow(required=required),
+    )
+
+
+def _candidate_values(result) -> list[typing.Any]:
+    assert len(result.scalar_candidate_sets) == 1
+    candidate_set = result.scalar_candidate_sets[0]
+    return [candidate_set.selected.value, *(candidate.value for candidate in candidate_set.alternatives)]
 
 
 def test_reassemble_custom_outputs_public_alias() -> None:
@@ -2311,7 +2368,7 @@ def test_scalar_candidate_sidecar_preserves_equal_quality_conflicts_and_pages() 
             {
                 "chunkId": "duplicate",
                 "pageNumbers": [14, 12],
-                "customSectionOutputs": {"eligibility": {"entry_date": " january   1 "}},
+                "customSectionOutputs": {"eligibility": {"entry_date": " january 1 "}},
             },
             {
                 "chunkId": "conflict",
@@ -2340,7 +2397,7 @@ def test_scalar_candidate_sidecar_preserves_equal_quality_conflicts_and_pages() 
     ]
 
 
-def test_scalar_candidate_sidecar_clears_inferior_candidates_after_replacement() -> None:
+def test_scalar_candidate_sidecar_keeps_first_observation_and_all_later_unique_values() -> None:
     workflow_extract = {
         "workflow": {
             "custom_steps": [
@@ -2390,16 +2447,277 @@ def test_scalar_candidate_sidecar_clears_inferior_candidates_after_replacement()
     )
 
     candidate_set = result.scalar_candidate_sets[0]
-    assert candidate_set.selected.value == {"value": "July 1", "confidence": 0.9}
-    assert candidate_set.selected.page_numbers == (3,)
+    assert candidate_set.selected.value == {"value": "January 1", "confidence": 0.4}
+    assert candidate_set.selected.page_numbers == (1,)
     assert [(candidate.value, candidate.page_numbers) for candidate in candidate_set.alternatives] == [
+        ({"value": "April 8", "confidence": 0.4}, (2,)),
+        ({"value": "July 1", "confidence": 0.9}, (3,)),
         ({"value": "October 1", "confidence": 0.9}, (4,)),
     ]
     assert result.final_output == {
         "eligibility_requirements": {
-            "entry_date": {"value": "July 1", "confidence": 0.9},
+            "entry_date": {"value": "January 1", "confidence": 0.4},
         }
     }
+
+
+@pytest.mark.parametrize(
+    ("observations", "expected_values", "expected_pages"),
+    [
+        (
+            [
+                ({"scalar_field": " Alpha "}, [1]),
+                ({"scalar_field": "alpha"}, [2]),
+            ],
+            ["Alpha"],
+            [(1, 2)],
+        ),
+        (
+            [
+                ({"scalar_field": "first  value"}, [3]),
+                ({"scalar_field": " FIRST VALUE "}, [4]),
+            ],
+            ["first  value", "FIRST VALUE"],
+            [(3,), (4,)],
+        ),
+    ],
+    ids=["outer-whitespace-casefold-first-casing", "internal-whitespace-significant"],
+)
+def test_scalar_candidate_string_identity_is_transport_only(
+    observations: list[tuple[dict, list[int]]],
+    expected_values: list[str],
+    expected_pages: list[tuple[int, ...]],
+) -> None:
+    result = _reassemble_scalar_observations(observations)
+
+    assert len(result.scalar_candidate_sets) == 1
+    candidate_set = result.scalar_candidate_sets[0]
+    candidates = [candidate_set.selected, *candidate_set.alternatives]
+    assert [candidate.value for candidate in candidates] == expected_values
+    assert [candidate.page_numbers for candidate in candidates] == expected_pages
+    assert result.final_output == {"scalar_group": {"scalar_field": expected_values[0]}}
+
+
+def test_scalar_candidate_json_identity_is_exact_and_type_sensitive() -> None:
+    result = _reassemble_scalar_observations(
+        [
+            ({"scalar_field": None}, [1]),
+            ({"scalar_field": False}, [2]),
+            ({"scalar_field": 0}, [3]),
+            ({"scalar_field": 0.0}, [4]),
+            ({"scalar_field": True}, [5]),
+            ({"scalar_field": 1}, [6]),
+            ({"scalar_field": 1.0}, [7]),
+            ({"scalar_field": ["item", 1]}, [8]),
+            ({"scalar_field": ["item", 1.0]}, [9]),
+            ({"scalar_field": {"count": 1, "flags": [True]}}, [10]),
+            ({"scalar_field": {"flags": [True], "count": 1}}, [11]),
+            ({"scalar_field": {"count": 1, "flags": [1]}}, [12]),
+        ]
+    )
+
+    assert len(result.scalar_candidate_sets) == 1
+    candidate_set = result.scalar_candidate_sets[0]
+    candidates = [candidate_set.selected, *candidate_set.alternatives]
+    assert len(candidates) == 11
+    assert candidates[0].value is None
+    assert candidates[1].value is False
+    assert type(candidates[2].value) is int and candidates[2].value == 0
+    assert type(candidates[3].value) is float and candidates[3].value == 0.0
+    assert candidates[4].value is True
+    assert type(candidates[5].value) is int and candidates[5].value == 1
+    assert type(candidates[6].value) is float and candidates[6].value == 1.0
+    assert candidates[7].value == ["item", 1]
+    assert type(candidates[7].value[1]) is int
+    assert candidates[8].value == ["item", 1.0]
+    assert type(candidates[8].value[1]) is float
+    assert candidates[9].value == {"count": 1, "flags": [True]}
+    assert candidates[9].page_numbers == (10, 11)
+    assert candidates[10].value == {"count": 1, "flags": [1]}
+    assert [candidate.page_numbers for candidate in candidates] == [
+        (1,),
+        (2,),
+        (3,),
+        (4,),
+        (5,),
+        (6,),
+        (7,),
+        (8,),
+        (9,),
+        (10, 11),
+        (12,),
+    ]
+
+
+def test_scalar_candidate_envelope_identity_uses_inner_value_and_retains_first_envelope() -> None:
+    result = _reassemble_scalar_observations(
+        [
+            (
+                {
+                    "scalar_field": {
+                        "value": " Alpha ",
+                        "confidence": 0.2,
+                        "_raw_text": "first observation",
+                    }
+                },
+                [4],
+            ),
+            (
+                {
+                    "scalar_field": {
+                        "value": "alpha",
+                        "confidence": 0.99,
+                        "_raw_text": "later duplicate",
+                    }
+                },
+                [7],
+            ),
+            (
+                {
+                    "scalar_field": {
+                        "value": "Beta",
+                        "confidence": 0.1,
+                    }
+                },
+                [9],
+            ),
+        ]
+    )
+
+    assert len(result.scalar_candidate_sets) == 1
+    candidate_set = result.scalar_candidate_sets[0]
+    assert candidate_set.selected.value == {
+        "value": "Alpha",
+        "confidence": 0.2,
+        "_raw_text": "first observation",
+    }
+    assert candidate_set.selected.page_numbers == (4, 7)
+    assert [(candidate.value, candidate.page_numbers) for candidate in candidate_set.alternatives] == [
+        ({"value": "Beta", "confidence": 0.1}, (9,)),
+    ]
+    assert result.final_output == {
+        "scalar_group": {
+            "scalar_field": {
+                "value": "Alpha",
+                "confidence": 0.2,
+                "_raw_text": "first observation",
+            }
+        }
+    }
+
+
+def test_scalar_candidate_presence_distinguishes_missing_from_explicit_empty_values() -> None:
+    result = _reassemble_scalar_observations(
+        [
+            ({}, [1]),
+            ({"scalar_field": None}, [2]),
+            ({"scalar_field": ""}, [3]),
+            ({"scalar_field": []}, [4]),
+        ]
+    )
+
+    assert len(result.scalar_candidate_sets) == 1
+    candidate_set = result.scalar_candidate_sets[0]
+    candidates = [candidate_set.selected, *candidate_set.alternatives]
+    assert [candidate.value for candidate in candidates] == [None, "", []]
+    assert [candidate.page_numbers for candidate in candidates] == [(2,), (3,), (4,)]
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", False, 0, []],
+    ids=["empty-string", "false", "zero", "empty-list"],
+)
+def test_required_scalar_route_does_not_use_generic_truthiness(value: typing.Any) -> None:
+    result = _reassemble_scalar_observations(
+        [({"scalar_field": value}, [1])],
+        required=True,
+    )
+
+    assert _candidate_values(result) == [value]
+    assert not [diagnostic for diagnostic in result.diagnostics if diagnostic.code.startswith("missing_workflow_")]
+
+
+@pytest.mark.parametrize("observation_count", [1, 3])
+def test_required_scalar_route_keeps_null_evidence_but_reports_missing_independently_of_observation_count(
+    observation_count: int,
+) -> None:
+    result = _reassemble_scalar_observations(
+        [({"scalar_field": None}, [page]) for page in range(1, observation_count + 1)],
+        required=True,
+    )
+
+    assert len(result.scalar_candidate_sets) == 1
+    candidate_set = result.scalar_candidate_sets[0]
+    assert candidate_set.selected.value is None
+    assert candidate_set.selected.page_numbers == tuple(range(1, observation_count + 1))
+    assert candidate_set.alternatives == ()
+    assert [diagnostic.code for diagnostic in result.diagnostics] == ["missing_workflow_group"]
+
+
+def test_repeated_route_empty_record_handling_is_unchanged() -> None:
+    workflow_extract = {
+        "workflow": {
+            "custom_steps": [
+                {"name": "rows", "level": "chunk", "kind": "keys"},
+            ],
+            "output_routes": [
+                {
+                    "workflow_group": "rows",
+                    "workflow_field": "value",
+                    "final_path": "/rows/*/value",
+                    "step_name": "rows",
+                    "level": "chunk",
+                    "output_map": "customChunkOutputs",
+                    "output_key": "value",
+                }
+            ],
+        }
+    }
+    result = reassemble_custom_outputs_from_xray(
+        {
+            "chunks": [
+                {
+                    "customChunkOutputs": {
+                        "rows": {
+                            "_records": [
+                                {"value": None},
+                                {"value": ""},
+                                {"value": []},
+                                {"value": False},
+                                {"value": 0},
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        workflow_extract=workflow_extract,
+    )
+
+    assert result.final_output == {"rows": [{"value": False}, {"value": 0}]}
+    assert result.scalar_candidate_sets == []
+
+
+def test_duplicate_scalar_observations_merge_pages_for_selected_and_every_alternative() -> None:
+    result = _reassemble_scalar_observations(
+        [
+            ({"scalar_field": "Alpha"}, [3, 1, 3]),
+            ({"scalar_field": "Beta"}, [5]),
+            ({"scalar_field": " alpha "}, [1, 4]),
+            ({"scalar_field": "beta"}, [6, 5]),
+            ({"scalar_field": "Gamma"}, [7]),
+            ({"scalar_field": "GAMMA"}, [8, 7]),
+        ]
+    )
+
+    assert len(result.scalar_candidate_sets) == 1
+    candidate_set = result.scalar_candidate_sets[0]
+    assert (candidate_set.selected.value, candidate_set.selected.page_numbers) == ("Alpha", (3, 1, 4))
+    assert [(candidate.value, candidate.page_numbers) for candidate in candidate_set.alternatives] == [
+        ("Beta", (5, 6)),
+        ("Gamma", (7, 8)),
+    ]
 
 
 def test_scalar_candidate_sidecar_types_are_public_exports() -> None:
@@ -2407,6 +2725,35 @@ def test_scalar_candidate_sidecar_types_are_public_exports() -> None:
     assert "CustomOutputScalarCandidateSet" in extract.__all__
     assert extract.CustomOutputScalarCandidate is custom_outputs.CustomOutputScalarCandidate
     assert extract.CustomOutputScalarCandidateSet is custom_outputs.CustomOutputScalarCandidateSet
+
+
+def test_scalar_candidate_public_dataclass_contract_and_provisional_output_are_unchanged() -> None:
+    assert [field.name for field in dataclasses.fields(custom_outputs.CustomOutputScalarCandidate)] == [
+        "value",
+        "page_numbers",
+    ]
+    assert [field.name for field in dataclasses.fields(custom_outputs.CustomOutputScalarCandidateSet)] == [
+        "output_source",
+        "workflow_group",
+        "workflow_field",
+        "final_path",
+        "selected",
+        "alternatives",
+    ]
+
+    result = _reassemble_scalar_observations(
+        [
+            ({"scalar_field": "first"}, [1]),
+            ({"scalar_field": "second"}, [2]),
+            ({"scalar_field": "third"}, [3]),
+        ]
+    )
+
+    assert len(result.scalar_candidate_sets) == 1
+    candidate_set = result.scalar_candidate_sets[0]
+    assert candidate_set.selected.value == "first"
+    assert [candidate.value for candidate in candidate_set.alternatives] == ["second", "third"]
+    assert result.final_output == {"scalar_group": {"scalar_field": candidate_set.selected.value}}
 
 
 def test_non_repeated_section_list_value_remains_scalar_field() -> None:

--- a/tests/extract/test_custom_output_reassembly.py
+++ b/tests/extract/test_custom_output_reassembly.py
@@ -71,7 +71,7 @@ def _provenance_dicts(result) -> list[dict]:
 
 
 def _scalar_candidate_workflow(*, required: bool = False) -> dict:
-    workflow_extract = {
+    workflow_extract: dict[str, typing.Any] = {
         "workflow": {
             "custom_steps": [
                 {"name": "scalar_step", "level": "chunk", "kind": "instruct"},
@@ -2254,7 +2254,7 @@ def test_reassembly_reports_source_provenance_for_routed_outputs() -> None:
     ]
 
 
-def test_adp_scalar_reducer_prefers_source_backed_positive_over_later_default() -> None:
+def test_adp_scalar_candidates_preserve_source_backed_and_default_like_values() -> None:
     workflow_extract = {
         "workflow": {
             "custom_steps": [
@@ -2334,9 +2334,37 @@ def test_adp_scalar_reducer_prefers_source_backed_positive_over_later_default() 
             "entry_date": "2026-01-01",
         }
     }
-    assert [diagnostic.code for diagnostic in result.diagnostics] == ["conflicting_output_candidates"]
-    assert result.diagnostics[0].severity == "warning"
-    assert result.diagnostics[0].final_path == "/eligibility_requirements/entry_date"
+    assert [
+        (
+            candidate_set.final_path,
+            candidate_set.selected.value,
+            [candidate.value for candidate in candidate_set.alternatives],
+        )
+        for candidate_set in result.scalar_candidate_sets
+    ] == [
+        (
+            "/eligibility_requirements/predecessor_service",
+            "Service with predecessor employer counts",
+            [
+                "Not specified",
+                {
+                    "value": "Not Indicated",
+                    "_raw_text": "No predecessor-service section visible.",
+                },
+            ],
+        ),
+        (
+            "/eligibility_requirements/entry_date",
+            "2026-01-01",
+            ["2026-02-01"],
+        ),
+    ]
+    assert [diagnostic.code for diagnostic in result.diagnostics] == [
+        "conflicting_output_candidates",
+        "conflicting_output_candidates",
+        "conflicting_output_candidates",
+    ]
+    assert all(diagnostic.severity == "warning" for diagnostic in result.diagnostics)
 
 
 def test_scalar_candidate_sidecar_preserves_equal_quality_conflicts_and_pages() -> None:

--- a/tests/extract/test_custom_output_reassembly.py
+++ b/tests/extract/test_custom_output_reassembly.py
@@ -2720,6 +2720,21 @@ def test_required_scalar_route_keeps_null_evidence_but_reports_missing_independe
     assert [diagnostic.code for diagnostic in result.diagnostics] == ["missing_workflow_group"]
 
 
+def test_required_scalar_route_keeps_null_envelope_evidence_but_reports_missing() -> None:
+    null_envelope = {"value": None, "confidence": 0.8}
+    result = _reassemble_scalar_observations(
+        [({"scalar_field": null_envelope}, [6])],
+        required=True,
+    )
+
+    assert len(result.scalar_candidate_sets) == 1
+    candidate_set = result.scalar_candidate_sets[0]
+    assert candidate_set.selected.value == null_envelope
+    assert candidate_set.selected.page_numbers == (6,)
+    assert candidate_set.alternatives == ()
+    assert [diagnostic.code for diagnostic in result.diagnostics] == ["missing_workflow_group"]
+
+
 def test_repeated_route_empty_record_handling_is_unchanged() -> None:
     workflow_extract = {
         "workflow": {

--- a/tests/extract/test_custom_output_reassembly.py
+++ b/tests/extract/test_custom_output_reassembly.py
@@ -2371,25 +2371,36 @@ def test_repeated_document_route_still_deduplicates_copied_payloads(
             ],
         }
     }
-    copied_document_outputs = {
-        "line_item_rows": {
-            "_records": [
-                {"description": "Admin fee"},
-            ]
-        }
-    }
     xray = {
-        "customDocumentOutputs": copied_document_outputs,
+        "customDocumentOutputs": {
+            "line_item_rows": {
+                "_records": [
+                    {"description": "Admin fee"},
+                ]
+            }
+        },
         "chunks": [
             {
                 "chunkId": "chunk-12",
                 "pageNumbers": [12],
-                "customDocumentOutputs": copied_document_outputs,
+                "customDocumentOutputs": {
+                    "line_item_rows": {
+                        "_records": [
+                            {"description": "Admin fee"},
+                        ]
+                    }
+                },
             },
             {
                 "chunkId": "chunk-14",
                 "pageNumbers": [14],
-                "customDocumentOutputs": copied_document_outputs,
+                "customDocumentOutputs": {
+                    "line_item_rows": {
+                        "_records": [
+                            {"description": "Admin fee"},
+                        ]
+                    }
+                },
             },
         ],
     }

--- a/tests/extract/test_custom_output_reassembly.py
+++ b/tests/extract/test_custom_output_reassembly.py
@@ -2174,6 +2174,236 @@ def test_identical_section_payloads_on_different_pages_are_not_collapsed() -> No
     assert [provenance.page_numbers for provenance in result.source_provenance] == [(1,), (2,)]
 
 
+def test_singular_section_route_preserves_candidates_and_pages_across_shared_section_id() -> None:
+    workflow_extract = {
+        "workflow": {
+            "custom_steps": [
+                {"name": "eligibility", "level": "section", "kind": "instruct"},
+            ],
+            "output_routes": [
+                {
+                    "workflow_group": "eligibility",
+                    "workflow_field": "entry_date",
+                    "final_path": "/eligibility/entry_date",
+                    "step_name": "eligibility",
+                    "level": "section",
+                    "output_map": "customSectionOutputs",
+                    "output_key": "entry_date",
+                },
+            ],
+        }
+    }
+    xray = {
+        "chunks": [
+            {
+                "chunkId": "chunk-12",
+                "sectionId": "section-1",
+                "pageNumbers": [12],
+                "customSectionOutputs": {"eligibility": {"entry_date": "A"}},
+            },
+            {
+                "chunkId": "chunk-14",
+                "sectionId": "section-1",
+                "pageNumbers": [14],
+                "customSectionOutputs": {"eligibility": {"entry_date": "A"}},
+            },
+            {
+                "chunkId": "chunk-16",
+                "sectionId": "section-1",
+                "pageNumbers": [16],
+                "customSectionOutputs": {"eligibility": {"entry_date": "B"}},
+            },
+        ]
+    }
+
+    result = reassemble_custom_outputs_from_xray(
+        xray,
+        workflow_extract=workflow_extract,
+    )
+
+    assert len(result.scalar_candidate_sets) == 1
+    candidate_set = result.scalar_candidate_sets[0]
+    assert (candidate_set.selected.value, candidate_set.selected.page_numbers) == (
+        "A",
+        (12, 14),
+    )
+    assert [(candidate.value, candidate.page_numbers) for candidate in candidate_set.alternatives] == [
+        ("B", (16,)),
+    ]
+    assert result.final_output == {"eligibility": {"entry_date": "A"}}
+
+
+def test_repeated_section_route_still_deduplicates_shared_section_id() -> None:
+    workflow_extract = {
+        "workflow": {
+            "custom_steps": [
+                {"name": "line_item_rows", "level": "section", "kind": "keys"},
+            ],
+            "output_routes": [
+                {
+                    "workflow_group": "line_items",
+                    "workflow_field": "description",
+                    "final_path": "/line_items/description",
+                    "step_name": "line_item_rows",
+                    "level": "section",
+                    "output_map": "customSectionOutputs",
+                    "output_key": "description",
+                },
+            ],
+        }
+    }
+    copied_section_outputs = {
+        "line_item_rows": {
+            "_records": [
+                {"description": "Admin fee"},
+            ]
+        }
+    }
+    xray = {
+        "chunks": [
+            {
+                "chunkId": "chunk-12",
+                "sectionId": "section-1",
+                "pageNumbers": [12],
+                "customSectionOutputs": copied_section_outputs,
+            },
+            {
+                "chunkId": "chunk-14",
+                "sectionId": "section-1",
+                "pageNumbers": [14],
+                "customSectionOutputs": copied_section_outputs,
+            },
+        ]
+    }
+
+    result = reassemble_custom_outputs_from_xray(
+        xray,
+        workflow_extract=workflow_extract,
+    )
+
+    assert result.final_output == {
+        "line_items": [{"description": "Admin fee"}],
+    }
+
+
+def test_singular_document_route_preserves_candidates_and_chunk_pages() -> None:
+    workflow_extract = {
+        "workflow": {
+            "custom_steps": [
+                {"name": "document_summary", "level": "document", "kind": "instruct"},
+            ],
+            "output_routes": [
+                {
+                    "workflow_group": "document",
+                    "workflow_field": "status",
+                    "final_path": "/document/status",
+                    "step_name": "document_summary",
+                    "level": "document",
+                    "output_map": "customDocumentOutputs",
+                    "output_key": "status",
+                },
+            ],
+        }
+    }
+    xray = {
+        "customDocumentOutputs": {"document_summary": {"status": "A"}},
+        "chunks": [
+            {
+                "chunkId": "chunk-12",
+                "pageNumbers": [12],
+                "customDocumentOutputs": {"document_summary": {"status": "A"}},
+            },
+            {
+                "chunkId": "chunk-14",
+                "pageNumbers": [14],
+                "customDocumentOutputs": {"document_summary": {"status": "A"}},
+            },
+            {
+                "chunkId": "chunk-16",
+                "pageNumbers": [16],
+                "customDocumentOutputs": {"document_summary": {"status": "B"}},
+            },
+        ],
+    }
+
+    result = reassemble_custom_outputs_from_xray(
+        xray,
+        workflow_extract=workflow_extract,
+    )
+
+    assert len(result.scalar_candidate_sets) == 1
+    candidate_set = result.scalar_candidate_sets[0]
+    assert (candidate_set.selected.value, candidate_set.selected.page_numbers) == (
+        "A",
+        (12, 14),
+    )
+    assert [(candidate.value, candidate.page_numbers) for candidate in candidate_set.alternatives] == [
+        ("B", (16,)),
+    ]
+    assert result.final_output == {"document": {"status": "A"}}
+
+
+@pytest.mark.parametrize(
+    "final_path",
+    [
+        "/line_items/*/description",
+        "/line_items/description",
+    ],
+)
+def test_repeated_document_route_still_deduplicates_copied_payloads(
+    final_path: str,
+) -> None:
+    workflow_extract = {
+        "workflow": {
+            "custom_steps": [
+                {"name": "line_item_rows", "level": "document", "kind": "keys"},
+            ],
+            "output_routes": [
+                {
+                    "workflow_group": "line_items",
+                    "workflow_field": "description",
+                    "final_path": final_path,
+                    "step_name": "line_item_rows",
+                    "level": "document",
+                    "output_map": "customDocumentOutputs",
+                    "output_key": "description",
+                },
+            ],
+        }
+    }
+    copied_document_outputs = {
+        "line_item_rows": {
+            "_records": [
+                {"description": "Admin fee"},
+            ]
+        }
+    }
+    xray = {
+        "customDocumentOutputs": copied_document_outputs,
+        "chunks": [
+            {
+                "chunkId": "chunk-12",
+                "pageNumbers": [12],
+                "customDocumentOutputs": copied_document_outputs,
+            },
+            {
+                "chunkId": "chunk-14",
+                "pageNumbers": [14],
+                "customDocumentOutputs": copied_document_outputs,
+            },
+        ],
+    }
+
+    result = reassemble_custom_outputs_from_xray(
+        xray,
+        workflow_extract=workflow_extract,
+    )
+
+    assert result.final_output == {
+        "line_items": [{"description": "Admin fee"}],
+    }
+
+
 def test_reassembly_reports_source_provenance_for_routed_outputs() -> None:
     workflow_extract = {
         "workflow": {


### PR DESCRIPTION
## Summary

- keep the first observed scalar as the provisional value
- preserve every distinct later value and its source pages
- deduplicate strings only after outer-whitespace trimming and case folding
- preserve null, empty strings, false, zero, lists, and type identity
- keep repeated-route placement unchanged

## Validation

- custom-output tests: 79 passed, 4 governed skips
- Ruff and Mypy passed
- both scalar OpenSpec changes passed strict validation
- unpublished Python 3.11 wheel verified from commit 9847740f, SHA-256 7ea67241ecfbff1ea5a8db121fae8ca4d1454e7acc4c9e50b895ede397904ebb

The complete extract suite retains seven governed intentional-red fixture sentinels. This PR does not publish a package or change the generated version.