### PR TITLE
fix(extract): accept null in declared type unions

### DIFF
--- a/src/groundx/extract/utility/utility.py
+++ b/src/groundx/extract/utility/utility.py
@@ -91,8 +91,19 @@ def coerce_value(
             warning=_coercion_warning(value, []),
         )
 
-    supported_targets = [target for target in targets if target in _SUPPORTED_TYPES]
-    if len(supported_targets) != len(targets):
+    allows_null = "null" in targets
+    typed_targets = [target for target in targets if target != "null"]
+    supported_targets = [target for target in typed_targets if target in _SUPPORTED_TYPES]
+    if len(supported_targets) != len(typed_targets):
+        return CoercionResult(
+            value=None,
+            matched=False,
+            converted=False,
+            warning=_coercion_warning(value, targets),
+        )
+    if value is None and allows_null:
+        return CoercionResult(value=None, matched=True, converted=False)
+    if not supported_targets:
         return CoercionResult(
             value=None,
             matched=False,

--- a/tests/extract/utility/test_utility.py
+++ b/tests/extract/utility/test_utility.py
@@ -100,6 +100,25 @@ class TestUtilCoerceValue(unittest.TestCase):
         self.assert_result(coerce_value(None, ["int", "float"]), None, type(None), True, False)
         self.assert_result(coerce_value({"a": 1}), {"a": 1}, dict, True, False)
 
+    def test_null_in_declared_type_unions(self) -> None:
+        cases: typing.List[typing.Tuple[typing.Any, typing.List[str]]] = [
+            ("2026-06-29", ["str", "null"]),
+            (24839.43, ["int", "float", "null"]),
+            (7, ["int", "null"]),
+            ([1], ["list", "null"]),
+        ]
+        for value, target in cases:
+            with self.subTest(value=value, target=target):
+                self.assert_result(coerce_value(value, target), value, type(value), True, False)
+
+        self.assert_result(coerce_value(None, ["str", "null"]), None, type(None), True, False)
+        self.assert_result(coerce_value(None, ["null"]), None, type(None), True, False)
+        self.assert_result(coerce_value("7", ["int", "null"]), 7, int, True, True)
+
+        rejected = coerce_value("text", ["null"])
+        self.assertIsNone(rejected.value)
+        self.assertIs(rejected.matched, False)
+
     def test_scalar_conversions_are_deterministic(self) -> None:
         cases = [
             (True, "str", "true", str, True),


### PR DESCRIPTION
## Problem

`coerce_value` rejects the whole declared type list when any member is outside `_SUPPORTED_TYPES`, and `null` is not in that map. Nullable union declarations (`type: [str, null]`, the standard way to allow blank fields) therefore fail every value, including exact type matches:

```python
coerce_value("2026-06-29", ["str"])          # matched=True
coerce_value("2026-06-29", ["str", "null"])  # matched=False — cannot coerce str to str, null
```

In hosted extraction this rejects every non-null repaired statement value for any schema using nullable unions, and the repair path terminalizes the whole document with a bare `Exception` while X-Ray stays correct. That is AGE-282's batch-wide failure: reproduced live 2026-08-16 by running the reporter's exact document through a copy of their exact workflow with pipeline capture enabled; the captured `reconcile_statement` stage error lists the field rejections and the captured parsed agent response shows the rejected values were correct (`"2026-06-29"`, `24839.43`).

## Fix

Treat `null` as the union member that admits `None`: strip it from the typed targets before the supported-type check, match `None` when the union declares it, and reject non-null values when `null` is the only declared type. Single-type declarations and unions without `null` behave exactly as before.

This is inside the scope the active `normalize-extracted-value-types` change already claims (one coercion implementation covering declared type unions and null).

## Tests

`test_null_in_declared_type_unions`: exact matches through null-bearing unions, None accepted with and without other members, string-to-int conversion inside a null union, and non-null rejected when `null` is the only type. Red on main with the production warning text, green with the fix. Full suite: 940 passed, the usual intentional-red boundary gates deselected, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)