### PR TITLE
Preserve governed extraction cases in SDK candidates

### DIFF
--- a/tests/extract/build_extraction_boundary_candidates.py
+++ b/tests/extract/build_extraction_boundary_candidates.py
@@ -606,6 +606,7 @@ def build_candidates(
             "artifact_catalog_sha256": capture_manifest["artifact_catalog_sha256"],
             "source_boundary_manifest_sha256": capture_manifest["source_boundary_manifest_sha256"],
             "upstream_candidate_manifest_sha256": _sha256(xray_candidate_manifest_path),
+            "governed_test_cases": [{"case_id": _CASE_IDS[surface], "surface": surface} for surface in surfaces],
             "generator": {
                 "candidate_builder_sha256": _sha256(Path(__file__)),
                 "boundary_replay_sha256": _sha256(

--- a/tests/extract/test_extraction_boundary_candidate_builder.py
+++ b/tests/extract/test_extraction_boundary_candidate_builder.py
@@ -871,6 +871,10 @@ def test_builder_records_reassembly_when_quality_assertions_fail(
         surface,
         captured_complete_output=captured_complete_output,
     )
+    _manifest["governed_test_cases"] = [
+        {"case_id": "adp-v1", "surface": surface},
+    ]
+    _write_json(capture_manifest, _manifest)
     accepted_output = tmp_path / "accepted.json"
     _write_json(
         accepted_output,
@@ -910,6 +914,8 @@ def test_builder_records_reassembly_when_quality_assertions_fail(
     )
 
     assert manifest_path == candidate_root / "fixture_candidate_manifest.json"
+    generated_manifest = json.loads(manifest_path.read_text())
+    assert generated_manifest["governed_test_cases"] == _manifest["governed_test_cases"]
     candidate = json.loads(
         (
             candidate_root


### PR DESCRIPTION
The SDK boundary candidate builder now includes the canonical governed case ID and surface for every selected candidate. This keeps derived SDK candidates eligible for the same fail-closed promotion validation as their captured upstream evidence.\n\nRoot cause: the builder copied the exact output and provenance but omitted the governed case registration required by promotion.\n\nValidation: 57 focused candidate and source-discovery tests passed. Ruff, formatting, mypy, line-ending, and diff checks passed. A real ADP candidate retained its exact output hash and no longer reports an unregistered certification case.