### PR TITLE
Default multiple_match_strategy to first_stable

### DIFF
--- a/openspec/changes/default-first-stable-ties/proposal.md
+++ b/openspec/changes/default-first-stable-ties/proposal.md
@@ -1,0 +1,46 @@
+# Proposal — default-first-stable-ties
+
+## Why
+
+`select_relationship_parent` resolves multiple exact parent candidates by the
+packet's declared `multiple_match_strategy`. `first_stable` is the only legal
+declared value; an absent declaration made the tie ambiguous and left the child
+unmatched. The original Arcadia matcher (`Statement.get_charge_meter` on
+`internal-arcadia-agents` `origin/main`) attaches the child to the first
+matching parent unconditionally, so absence silently selected a behavior the
+original algorithm never had. Live extraction hit this: sibling parents that
+legitimately share every declared match attribute (supply and delivery meters)
+sent their charges to the account level, while the governed answer keys expect
+every charge nested.
+
+Ruled by Benjamin Fletcher on 2026-08-17, superseding the
+undeclared-equals-ambiguous half of ruling 7b (2026-08-05): an absent
+`multiple_match_strategy` defaults to `first_stable`. The field stays on the
+packet and in YAML validation for future strategy extension.
+
+## What changes
+
+1. `select_relationship_parent` treats an absent strategy as `first_stable` on
+   multiple direct matches. An explicitly declared strategy other than
+   `first_stable` still yields no selection with `ambiguous=True` (YAML
+   validation continues to reject such values at authoring time).
+2. The matcher docstring corrects its baseline citation: the ported legacy
+   matcher is `get_charge_meter` on `origin/main`; the previously cited
+   `2797b5e` is a plan-branch checkpoint, not main.
+3. Behavior-table row R16 and the reassembly and seam tests flip from
+   undeclared-equals-ambiguous to the `first_stable` default.
+4. The promotion-time acceptance check no longer requires accepted inputs to
+   declare `first_stable`; it now rejects only a foreign declared strategy.
+
+## Impact
+
+- Affected specs: `custom-output-readback` (tie scenarios and the exported
+  primitive's `ambiguous` semantics).
+- Affected code: `src/groundx/extract/custom_outputs.py`; tests
+  `test_relationship_parent_selection_red.py`,
+  `test_relationship_parent_selection_seam_red.py`,
+  `test_custom_output_reassembly.py`.
+- Consumers: undeclared ties now attach the child to the first stable parent
+  instead of emitting `ambiguous_relationship_match` and leaving it unmatched.
+  Workflows with genuine ties change output shape; the extraction-boundary
+  capture rerun and answer keys are the verification.

--- a/openspec/changes/default-first-stable-ties/specs/custom-output-readback/spec.md
+++ b/openspec/changes/default-first-stable-ties/specs/custom-output-readback/spec.md
@@ -1,0 +1,223 @@
+## MODIFIED Requirements
+
+### Requirement: Relationship metadata can create nested list output
+
+The SDK SHALL support generic parent/child list relationships through
+metadata rather than hardcoded final group names.
+
+#### Scenario: Child records attach to matching parent records
+
+- **GIVEN** a v1 workflow reassembles one parent final group and one child final
+  group as arrays
+- **AND** `workflow.output_relationships` declares the parent group, child group,
+  parent output field, and `match_attrs`
+- **WHEN** the SDK reassembles custom output
+- **THEN** child records whose present non-blank match fields equal the parent's
+  same present non-blank fields are placed in the parent output field
+- **AND** the behavior does not depend on final groups named `meters` or
+  `charges`.
+
+#### Scenario: Match semantics are Arcadia-compatible
+
+- **GIVEN** relationship metadata declares multiple `match_attrs`
+- **AND** parent and child records include extracted-field wrappers, strings,
+  integers, floats, blanks, and missing values
+- **WHEN** the SDK applies relationship metadata
+- **THEN** extracted-field wrappers are compared by their `value`
+- **AND** strings compare case-insensitively
+- **AND** leading and trailing string whitespace is removed before comparison
+- **AND** internal string whitespace remains significant
+- **AND** integers and floats compare by numeric value
+- **AND** blank or missing fields do not participate
+- **AND** the parent and child only match when they have the same non-empty set
+  of present match fields
+- **AND** date-style strings are not normalized by the relationship matcher.
+
+Benjamin Fletcher resolved R25b on 2026-08-05: surrounding extraction
+whitespace is formatting noise, not identifier identity. The matcher trims only
+leading and trailing string whitespace. If trimming creates multiple parent
+matches, the tie resolves to the first parent in stable input order: the
+2026-08-17 ruling makes an absent `multiple_match_strategy` default to
+`first_stable`.
+
+#### Scenario: Match attrs without a present key do not match
+
+- **GIVEN** relationship metadata declares `match_attrs`
+- **AND** a child and parent both have no non-blank values for those fields
+- **WHEN** the SDK applies relationship metadata
+- **THEN** the child does not match that parent.
+
+#### Scenario: Unmatched child records are preserved
+
+- **GIVEN** relationship metadata declares `unmatched_child_group`
+- **AND** a child record does not match any parent record across all configured
+  `match_attrs`
+- **WHEN** the SDK applies relationship metadata
+- **THEN** the child record remains in the configured unmatched child group.
+
+#### Scenario: Missing relationship list groups become empty lists
+
+- **GIVEN** relationship metadata declares parent and child list groups
+- **AND** custom output produces no non-empty records for one or both groups
+- **WHEN** the SDK applies relationship metadata
+- **THEN** the absent relationship groups are treated as empty lists
+- **AND** no invalid relationship output diagnostic is emitted.
+
+#### Scenario: Undeclared ties attach to the first stable parent
+
+- **GIVEN** one child record matches more than one parent record
+- **AND** the relationship declares no `multiple_match_strategy`
+- **WHEN** the SDK applies relationship metadata
+- **THEN** the child attaches to the first matching parent in input order
+- **AND** no ambiguity diagnostic is emitted
+- **AND** the behavior equals a declared `multiple_match_strategy: first_stable`
+  (2026-08-17 ruling: absence defaults to `first_stable`, the original Arcadia
+  tie behavior).
+
+#### Scenario: Ambiguous child matches fail clearly
+
+- **GIVEN** one child record matches more than one parent record
+- **AND** the relationship explicitly declares a `multiple_match_strategy`
+  other than `first_stable` (rejected at YAML authoring time, but possible on
+  an unvalidated runtime packet)
+- **WHEN** the SDK applies relationship metadata
+- **THEN** the helper returns a diagnostic that names the relationship and child
+  record
+- **AND** the child stays in the unmatched child group
+- **AND** it does not silently attach the child to an arbitrary parent.
+
+#### Scenario: A declared strategy resolves an exact tie
+
+- **GIVEN** one child record matches more than one parent record
+- **AND** the relationship declares `multiple_match_strategy: first_stable`
+- **WHEN** the SDK applies relationship metadata
+- **THEN** the child attaches to the first matching parent in input order
+- **AND** no ambiguity diagnostic is emitted.
+
+#### Scenario: Ignored passthrough fields are the only fallback
+
+- **GIVEN** relationship metadata declares `parent_passthrough_attrs` that
+  overlap `match_attrs`
+- **AND** no parent matches the child on the full populated match-key shape
+- **WHEN** the SDK applies relationship metadata
+- **THEN** the SDK retries comparison with exactly those passthrough attrs
+  removed
+- **AND** the child attaches only when exactly one parent survives that retry
+- **AND** more than one surviving parent leaves the child unmatched without an
+  ambiguity diagnostic
+- **AND** `parent_passthrough_attrs` never changes the outcome of the full
+  match-key pass
+- **AND** removing every match attr, or removing none, performs no retry.
+
+#### Scenario: Chained relationships create arrays inside arrays
+
+- **GIVEN** relationship metadata declares one child group nested under a parent
+  group
+- **AND** another relationship declares a grandchild group nested under that
+  child group
+- **WHEN** the SDK applies relationship metadata
+- **THEN** the final output can contain a list inside another list item.
+
+#### Scenario: Relationship view is the SDK final output
+
+- **GIVEN** a v1 workflow reassembles parent and child final groups as arrays
+- **AND** `workflow.output_relationships` declares how to nest child records
+- **WHEN** the SDK reassembles custom output
+- **THEN** `final_output` contains the nested relationship-applied view
+- **AND** `relationship_output` matches `final_output`
+- **AND** `workflow_output` preserves the pre-relationship route output for
+  diagnostics.
+
+#### Scenario: Relationship metadata selects the shared v1 output shape
+
+- **GIVEN** a v1 workflow has relationship metadata
+- **WHEN** the SDK reassembles custom output
+- **THEN** the SDK returns relationship-applied `final_output`
+- **AND** the SDK returns matching `relationship_output`
+- **AND** generic v1 and Arcadia v1 callers can consume the same SDK
+  `final_output` shape.
+
+### Requirement: Parent selection is one exported SDK primitive
+
+The SDK SHALL expose relationship parent selection as exactly one public
+primitive and SHALL use that same primitive for every workflow it reassembles.
+No caller and no workflow SHALL get a second matcher, a per-workflow variant, or
+a copied selection algorithm.
+
+The public surface is:
+
+```python
+from groundx.extract import select_relationship_parent, RelationshipParentSelection
+
+selection = select_relationship_parent(parents, child, relationship)
+```
+
+- `parents` is an ordered sequence of parent records (mappings), `child` is one
+  child record, and `relationship` is the relationship packet.
+- The packet is accepted in persisted snake_case or dispatched camelCase
+  spelling. `match_attrs`/`matchAttrs`,
+  `parent_passthrough_attrs`/`parentPassthroughAttrs`, and
+  `multiple_match_strategy`/`multipleMatchStrategy` are the selection-relevant
+  fields; snake_case wins when both spellings are present.
+- The return value is the frozen dataclass
+  `RelationshipParentSelection(parent, ambiguous)`. `parent` is the selected
+  parent record object itself — identity-preserving, so a caller can map it back
+  to its own domain object — or `None`. `ambiguous` is `True` only for multiple
+  exact candidates under an explicitly declared `multiple_match_strategy`
+  other than `first_stable`; an absent strategy defaults to `first_stable`
+  (2026-08-17 ruling), so undeclared ties select the first parent and are
+  never ambiguous.
+- The primitive is total: it never raises for unsupported value types.
+- Both names are exported from `groundx.extract`.
+
+#### Scenario: Consumers call the selection primitive directly
+
+- **GIVEN** a consumer holds its own parent and child records and a relationship
+  packet
+- **WHEN** it calls `select_relationship_parent(parents, child, relationship)`
+- **THEN** it receives a `RelationshipParentSelection`
+- **AND** `parent` is the selected parent record object or `None`
+- **AND** `ambiguous` distinguishes an unresolved declared-strategy tie from an
+  ordinary no-match
+- **AND** the consumer needs no reassembly, X-Ray, or `Document` state to select.
+
+#### Scenario: One primitive serves every workflow
+
+- **GIVEN** pure Arcadia legacy, authored Arcadia v1, authored mechanically
+  renamed generic v1, and any other canonical v1 relationship packet
+- **WHEN** the SDK selects a parent for a child record
+- **THEN** every case is served by the one exported primitive
+- **AND** reassembly's `_apply_relationships` delegates to it rather than
+  matching inline
+- **AND** the selection outcome depends only on the packet's selection-relevant
+  fields and the record values, never on group names, final field names,
+  workflow identity, or compiler provenance.
+
+#### Scenario: Renamed generic workflows select identically
+
+- **GIVEN** two relationship packets differ only by a one-to-one rename of their
+  group names and match-attr names
+- **WHEN** the same records are selected through both under that rename
+- **THEN** the selected parent and the ambiguity result are the same.
+
+#### Scenario: Retained parent conflicts ride as record siblings
+
+- **GIVEN** a parent record carries retained conflict state for a field the
+  passthrough fallback would ignore
+- **AND** that state is supplied as the record sibling key `<field>__conflicts`
+  holding a list of conflicting values
+- **WHEN** the fallback pass would otherwise accept that parent
+- **THEN** the SDK rejects that parent and leaves the child unmatched
+- **AND** an empty `<field>__conflicts` list does not reject the parent
+- **AND** the convention is read-side only: the SDK consumes
+  `<field>__conflicts` for selection and defines no policy for writing it.
+
+#### Scenario: Empty routed values retain non-empty conflict siblings
+
+- **GIVEN** a repeated custom-output record has an empty routed field value and
+  a non-empty `<field>__conflicts` sibling
+- **WHEN** the SDK reassembles custom output
+- **THEN** it omits the empty field value
+- **AND** it retains the conflict sibling on the same final record
+- **AND** fallback parent selection consumes that sibling exactly as it would
+  when supplied directly.

--- a/openspec/changes/default-first-stable-ties/tasks.md
+++ b/openspec/changes/default-first-stable-ties/tasks.md
@@ -1,0 +1,18 @@
+# Tasks — default-first-stable-ties
+
+- [x] 1.1 Flip behavior-table row R16, the seam reassembly tie test, the
+      duplicate-parents reassembly test, and the at-scale strategy test to the
+      `first_stable` default, red before the source change.
+- [x] 1.2 `select_relationship_parent`: treat an absent
+      `multiple_match_strategy` as `first_stable` on multiple direct matches;
+      update the primitive and result-dataclass docstrings, including the
+      corrected `origin/main` baseline citation.
+- [x] 1.3 Rewrite `test_pending_accepted_inputs_declare_one_ambiguity_strategy`
+      to reject only a foreign declared strategy; drop its `pending_decision`
+      marker and the promotion-time declaration requirement.
+- [x] 1.4 Full `tests/extract` suite: no failures beyond the 14 pre-existing
+      on `origin/main` (verified by identical baseline run in the same venv).
+- [ ] 1.5 Release the change (next patch after 3.9.9) and update consumer pins
+      (internal-arcadia-agents `requirements.txt` and `Dockerfile.extract`;
+      Studio Harness `templates/requirements.txt` floor). Gated on Benjamin's
+      release approval; tracked in the extraction-boundary closeout plan.

--- a/src/groundx/extract/custom_outputs.py
+++ b/src/groundx/extract/custom_outputs.py
@@ -76,8 +76,10 @@ class RelationshipParentSelection:
 
     ``parent`` is the selected parent record, or ``None`` when no parent was
     selected.  ``ambiguous`` is ``True`` only when more than one parent matched
-    the child exactly and the relationship packet declared no
-    ``multiple_match_strategy`` to resolve the tie.
+    the child exactly and the relationship packet explicitly declared a
+    ``multiple_match_strategy`` other than ``first_stable``.  An absent
+    strategy defaults to ``first_stable`` (2026-08-17 ruling), so undeclared
+    ties select the first parent and are never ambiguous.
     """
 
     parent: typing.Optional[typing.Mapping[str, typing.Any]] = None
@@ -315,8 +317,10 @@ def select_relationship_parent(
 
     This is the one exported relationship parent-selection primitive.  It ports
     the legacy charge-to-meter matcher
-    (``internal-arcadia classes/statement.py::Statement.get_charge_meter`` at
-    ``main`` @ ``2797b5e``, semantics adopted by owner RULING 7a, 2026-08-05)
+    (``internal-arcadia classes/statement.py::Statement.get_charge_meter`` on
+    ``origin/main``, with the populated-keys filter and empty-value-is-absent
+    semantics adopted by owner RULING 7a, 2026-08-05; the ``2797b5e`` commit an
+    earlier revision cited as "main" is a plan-branch checkpoint, not main)
     onto the generic relationship packet:
 
     * ``parents`` is an ordered sequence of parent records, ``child`` is one
@@ -326,10 +330,12 @@ def select_relationship_parent(
       child's populated (non-empty) values; an empty value counts as absent.
     * Exact pass: a parent is an exact candidate when it populates exactly the
       same match attrs the child populates, with equal values.  A single exact
-      candidate wins.  Multiple exact candidates follow only the packet's
-      declared ``multiple_match_strategy`` (``first_stable`` selects the first
-      parent in order); with no declared strategy the outcome is ambiguous and
-      no parent is selected.
+      candidate wins.  Multiple exact candidates select the first parent in
+      stable input order, matching the legacy matcher, whether the packet
+      declares ``multiple_match_strategy: first_stable`` or declares no
+      strategy at all (2026-08-17 ruling; ``first_stable`` is the only legal
+      declared value).  Only an explicitly declared unrecognized strategy
+      leaves the tie ambiguous with no parent selected.
     * Fallback pass: only the match attrs also named by the packet's
       ``parent_passthrough_attrs`` are removed from comparison.  If that
       removes nothing, or removes everything, there is no fallback.  A parent
@@ -383,7 +389,7 @@ def select_relationship_parent(
         return RelationshipParentSelection(parent=direct_matches[0], ambiguous=False)
     if len(direct_matches) > 1:
         strategy = _relationship_packet_value(relationship, "multiple_match_strategy")
-        if strategy == "first_stable":
+        if strategy is None or strategy == "first_stable":
             return RelationshipParentSelection(
                 parent=direct_matches[0],
                 ambiguous=False,

--- a/tests/extract/test_custom_output_reassembly.py
+++ b/tests/extract/test_custom_output_reassembly.py
@@ -3380,19 +3380,19 @@ def test_duplicate_parents_without_unique_attrs_are_not_collapsed() -> None:
 
     result = reassemble_custom_outputs_from_xray(xray, workflow_extract=workflow_extract)
 
-    assert [diagnostic.code for diagnostic in result.diagnostics] == ["ambiguous_relationship_match"]
+    assert result.diagnostics == []
     assert result.final_output == {
         "accounts": [
             {
                 "account_id": "A-1",
-                "transactions": [],
+                "transactions": [{"account_id": "a-1", "amount": 10}],
             },
             {
                 "account_id": "A-1",
                 "transactions": [],
             },
         ],
-        "transactions": [{"account_id": "a-1", "amount": 10}],
+        "transactions": [],
     }
 
 
@@ -3563,12 +3563,12 @@ def test_compiled_relationship_can_attach_ambiguous_child_to_first_parent() -> N
 @pytest.mark.parametrize(
     "multiple_match_strategy",
     ["first_stable", None],
-    ids=["first-stable", "strict-ambiguity"],
+    ids=["first-stable", "undeclared-defaults-first-stable"],
 )
 def test_relationship_matching_at_scale_follows_declared_strategy(
     multiple_match_strategy: str | None,
 ) -> None:
-    """Large parent/child sets follow only the declared ambiguity strategy.
+    """Large parent/child sets resolve exact ties to the first stable parent.
 
     This test previously monkeypatched the `_match_key` index helper and
     bounded its call count to O(parents + children).  Task 3.2a7b replaced
@@ -3578,9 +3578,9 @@ def test_relationship_matching_at_scale_follows_declared_strategy(
     3803-3817`), so `_match_key` was deleted and the key-computation bound
     with it; no comparable budget exists on the primitive path to re-point
     the guard at.  The behavioral half of the original test is retained:
-    at scale, multiple exact candidates follow a declared `first_stable`
-    strategy, and with no declared strategy every such child is reported
-    ambiguous and stays unmatched.
+    at scale, multiple exact candidates select the first parent in stable
+    input order, whether `first_stable` is declared or absent (the
+    2026-08-17 ruling makes the undeclared default first_stable).
     """
     relationship = {
         "parent_group": "parents",
@@ -3639,15 +3639,10 @@ def test_relationship_matching_at_scale_follows_declared_strategy(
         workflow_extract=workflow_extract,
     )
 
-    if multiple_match_strategy == "first_stable":
-        assert result.diagnostics == []
-        assert result.final_output["parents"][0]["children"] == [children[0]]
-        assert result.final_output["parents"][1]["children"] == []
-        assert result.final_output["children"] == []
-    else:
-        assert len(result.diagnostics) == record_count
-        assert all(diagnostic.code == "ambiguous_relationship_match" for diagnostic in result.diagnostics)
-        assert result.final_output["children"] == children
+    assert result.diagnostics == []
+    assert result.final_output["parents"][0]["children"] == [children[0]]
+    assert result.final_output["parents"][1]["children"] == []
+    assert result.final_output["children"] == []
 
 
 def test_indexed_relationship_matching_preserves_structured_keys() -> None:

--- a/tests/extract/test_relationship_parent_selection_red.py
+++ b/tests/extract/test_relationship_parent_selection_red.py
@@ -224,22 +224,20 @@ _MAIN_ADOPTED_NOTE = (
     "0c359e45/d4f8ead/24a490c, which is why the revision is recorded per row"
 )
 
-# The accepted boundary inputs disagree on `multiple_match_strategy`:
+# The accepted boundary inputs vary on `multiple_match_strategy`:
 # arcadia_legacy declares `first_stable` on its persisted relationship while
-# arcadia_v1 and generic_v1 declare no strategy at all.  RULING 7b (2026-08-05)
-# resolves this by DECLARING `multiple_match_strategy: first_stable` in the
-# arcadia_v1 and generic_v1 accepted inputs, routed through the Phase 4
-# promotion lifecycle (tasks 10.1b / 10.2a) -- NOT by editing those inputs now.
-# See `test_pending_accepted_inputs_declare_one_ambiguity_strategy` below, which
-# flips from failing to passing when that promotion lands.
+# arcadia_v1 and generic_v1 declare no strategy at all.  The 2026-08-17 ruling
+# (superseding RULING 7b) makes an undeclared strategy default to
+# `first_stable`, so all three surfaces share one tie behavior with no fixture
+# edit or promotion-time declaration required.  See
+# `test_pending_accepted_inputs_declare_one_ambiguity_strategy` below, which
+# now verifies no accepted input declares a foreign strategy.
 _PARITY_RULING = (
-    "RULING 7b (2026-08-05): the accepted inputs currently disagree on "
-    "multiple_match_strategy (arcadia_legacy declares first_stable; arcadia_v1 "
-    "and generic_v1 declare none). Resolution is to DECLARE first_stable in the "
-    "arcadia_v1 and generic_v1 accepted inputs through the Phase 4 promotion "
-    "lifecycle (10.1b/10.2a), not by editing them now. Until that promotion "
-    "lands the three surfaces cannot demonstrate the parity spec.md:374-375 "
-    "requires. The primitive-level contract in this row is ratified."
+    "2026-08-17 ruling (supersedes RULING 7b): an undeclared "
+    "multiple_match_strategy defaults to first_stable, so arcadia_legacy "
+    "(declares first_stable) and arcadia_v1/generic_v1 (declare none) share "
+    "one tie behavior. No accepted-input declaration is required at promotion. "
+    "The primitive-level contract in this row is ratified."
 )
 
 BEHAVIOR_TABLE: typing.Tuple[Row, ...] = (
@@ -319,20 +317,31 @@ BEHAVIOR_TABLE: typing.Tuple[Row, ...] = (
         strategy="first_stable",
     ),
     _row(
-        "R16_multiple_exact_without_strategy_is_ambiguous",
+        "R16_multiple_exact_without_strategy_first_stable",
+        [{_M: "M-1", _P: "Utility", _S: "water"}, {_M: "m-1", _P: "utility", _S: "WATER"}],
+        {_M: "M-1", _P: "Utility", _S: "water"},
+        0,
+        "exact",
+        "RATIFIED primitive contract per the 2026-08-17 ruling, which supersedes "
+        "RULING 7b (2026-08-05): an undeclared multiple_match_strategy defaults to "
+        "first_stable, restoring legacy assertion "
+        f"{_STMT}:5741, which returns the first candidate with NO declared strategy. "
+        "Only an explicitly declared strategy other than first_stable leaves the "
+        f"tie ambiguous. {_PARITY_RULING}",
+        provenance=RATIFIED,
+    ),
+    _row(
+        "R16b_multiple_exact_foreign_declared_strategy_is_ambiguous",
         [{_M: "M-1", _P: "Utility", _S: "water"}, {_M: "m-1", _P: "utility", _S: "WATER"}],
         {_M: "M-1", _P: "Utility", _S: "water"},
         None,
         "none",
-        "RATIFIED primitive contract per RULING 7b (2026-08-05): an undeclared "
-        "multiple_match_strategy makes multiple exact candidates AMBIGUOUS. This is "
-        "a DELIBERATE DIVERGENCE from legacy assertion "
-        f"{_STMT}:5741, which returns the first candidate with NO declared strategy; "
-        "openspec tasks.md:1365-1366 'Ambiguity follows only the packet's declared "
-        "strategy' and tasks.md:1381-1382 'Delete the unconditional direct_matches[0] "
-        "result' mandate the divergence, so Internal Arcadia must update :5741 in "
-        f"3.2a7c. {_PARITY_RULING}",
+        "2026-08-17 ruling: only an explicitly declared strategy other than "
+        "first_stable leaves multiple exact candidates ambiguous. YAML "
+        "validation rejects such values at authoring time, so this row covers "
+        "the unvalidated runtime-packet path only.",
         ambiguous=True,
+        strategy="round_robin",
         provenance=RATIFIED,
     ),
     # --- reviewed available-identity matrix -------------------------------
@@ -841,28 +850,16 @@ def _accepted_relationship(surface: str) -> typing.Mapping[str, typing.Any]:
     return relationships[0]
 
 
-@pytest.mark.pending_decision
 def test_pending_accepted_inputs_declare_one_ambiguity_strategy() -> None:
-    """PENDING PROMOTION -- fails until the Phase 4 fixture promotion lands.
+    """Accepted inputs must not declare a strategy other than `first_stable`.
 
-    spec.md:374-375 requires Arcadia and renamed-generic parity as proof of the
-    general contract.  Under behavior-table row R16 -- now the RATIFIED primitive
-    contract -- a workflow with no declared `multiple_match_strategy` treats
-    multiple exact candidates as ambiguous, while `first_stable` selects the
-    first.  The accepted boundary inputs do not agree on that declaration:
-    arcadia_legacy declares `first_stable`, arcadia_v1 and generic_v1 declare
-    none, so the three surfaces land on opposite sides of the R15/R16 boundary.
-
-    RULING 7b (2026-08-05) resolves this by DECLARING
-    `multiple_match_strategy: first_stable` in the arcadia_v1 and generic_v1
-    accepted inputs, routed through the Phase 4 promotion lifecycle (tasks 10.1b
-    and 10.2a).  It is explicitly NOT resolved by editing those accepted inputs
-    now, and this lane changes no fixture bytes.
-
-    This test therefore stays red on purpose and **flips to passing when that
-    promotion lands** -- it is the promotion's acceptance check, not a matcher
-    requirement.  It is marked `pending_decision` so it never reads as a 3.2a7b
-    implementation target.
+    The 2026-08-17 ruling (superseding RULING 7b) makes an undeclared
+    `multiple_match_strategy` default to `first_stable`, so the parity
+    spec.md:374-375 requires holds whether an accepted input declares
+    `first_stable` (arcadia_legacy) or declares nothing (arcadia_v1,
+    generic_v1).  No promotion-time declaration is required.  This test guards
+    the one state that would still split the surfaces: an accepted input
+    declaring some other strategy.
     """
     surfaces = ("arcadia_legacy", "arcadia_v1", "generic_v1")
     accepted_paths = [
@@ -876,9 +873,8 @@ def test_pending_accepted_inputs_declare_one_ambiguity_strategy() -> None:
 
     declared = {surface: _accepted_relationship(surface).get("multiple_match_strategy") for surface in surfaces}
 
-    assert set(declared.values()) == {"first_stable"}, (
-        "RULING 7b: every accepted input must declare "
-        "multiple_match_strategy=first_stable once the Phase 4 promotion "
-        "(10.1b/10.2a) lands; until then the parity spec.md:374-375 requires "
-        f"cannot hold under R16. Current state: {declared}"
+    assert set(declared.values()) <= {None, "first_stable"}, (
+        "2026-08-17 ruling: an undeclared multiple_match_strategy defaults to "
+        "first_stable, so accepted inputs may declare first_stable or nothing; "
+        f"a foreign declared strategy splits the surfaces. Current state: {declared}"
     )

--- a/tests/extract/test_relationship_parent_selection_seam_red.py
+++ b/tests/extract/test_relationship_parent_selection_seam_red.py
@@ -475,17 +475,11 @@ def test_output_names_default_to_the_child_group_name(omitted: str) -> None:
 
 
 def test_reassembly_reports_ambiguity_only_per_declared_strategy() -> None:
-    """Encodes behavior-table row R16, RATIFIED by RULING 7b (2026-08-05):
-    an undeclared `multiple_match_strategy` makes multiple exact candidates
-    ambiguous.  The `pending_decision` tag this test carried in fix round 1 is
-    removed -- only the fixture-level declaration is still pending promotion
-    (see `test_pending_accepted_inputs_declare_one_ambiguity_strategy`).
-    Currently passes, so it is a regression guard rather than a red requirement.
-
-    tasks.md:1365-1366 -- ambiguity follows only the packet's declared
-    strategy.  Two exact candidates with no strategy are ambiguous and
-    unmatched; with `first_stable` the first parent in order wins.
-    (Behavior-table rows R15/R16.)
+    """Encodes behavior-table row R16 under the 2026-08-17 ruling (supersedes
+    RULING 7b): an undeclared `multiple_match_strategy` defaults to
+    `first_stable`, matching the legacy Arcadia matcher.  Two exact candidates
+    with no declared strategy attach the child to the first parent in stable
+    input order with no ambiguity diagnostic.  (Behavior-table rows R15/R16.)
     """
     meters = [
         {"meter_number": "M-1", "provider_name": "Utility", "service_type": "water"},
@@ -493,11 +487,11 @@ def test_reassembly_reports_ambiguity_only_per_declared_strategy() -> None:
     ]
     charge = {"meter_number": "M-1", "provider_name": "Utility", "service_type": "water"}
 
-    ambiguous = _reassemble(meters, [charge])
-    assert ambiguous.final_output["meters"][0]["meter_charges"] == []
-    assert ambiguous.final_output["meters"][1]["meter_charges"] == []
-    assert ambiguous.final_output["account_charges"] == [charge]
-    assert [d.code for d in ambiguous.diagnostics] == ["ambiguous_relationship_match"]
+    undeclared = _reassemble(meters, [charge])
+    assert undeclared.final_output["meters"][0]["meter_charges"] == [charge]
+    assert undeclared.final_output["meters"][1]["meter_charges"] == []
+    assert undeclared.final_output["account_charges"] == []
+    assert undeclared.diagnostics == []
 
     stable = _reassemble(
         meters,


### PR DESCRIPTION
An absent `multiple_match_strategy` on a relationship packet now resolves multiple exact parent candidates to the first parent in stable input order, matching the original Arcadia matcher (`Statement.get_charge_meter` on internal-arcadia-agents main). Refuse-on-tie previously existed only as the absent-field fallback, and `first_stable` is the only legal declared value, so absence silently selected a behavior the original algorithm never had. Live extraction hit this: sibling meters that legitimately share every declared match attribute sent their charges to the account level, while the governed answer keys expect every charge nested.

Changes:
- `select_relationship_parent` treats an absent strategy as `first_stable` on multiple direct matches. An explicitly declared strategy other than `first_stable` still yields no selection with `ambiguous=True`.
- The matcher docstring corrects its baseline citation: the previously cited `2797b5e` is a plan-branch checkpoint, not main.
- Behavior-table row R16 and the reassembly and seam tie tests flip to the default, red before the source change; a new row covers the explicit foreign-strategy edge.
- The promotion acceptance check now rejects only a foreign declared strategy instead of requiring accepted inputs to declare `first_stable`.
- OpenSpec change `default-first-stable-ties` amends the custom-output-readback spec; strict validation passes.

Costs: undeclared ties change output shape from account-level charges to first-parent attachment for every consumer; the extraction-boundary capture rerun and answer keys are the verification. Consumers of the `ambiguous` flag never see it set for undeclared ties anymore.

Full `tests/extract`: only the 14 failures already present on main (verified against a clean baseline in the same venv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)