### PR TITLE
Support extraction normalization profiles (AGE-298)

### DIFF
--- a/openspec/specs/extract-yaml/spec.md
+++ b/openspec/specs/extract-yaml/spec.md
@@ -79,6 +79,16 @@ surface.
 - **AND** the marker is exposed in `PreparedExtractionYaml.top_level_metadata`
 - **AND** the marker is preserved in the persisted workflow extract
 
+#### Scenario: Normalization profiles are explicit final-group metadata
+
+- **WHEN** v1 YAML maps runtime attributes to supported
+  `normalization_profiles`
+- **THEN** preparation validates the attribute names and profile names
+- **AND** supports `currency_code`, `currency_label`, and
+  `unit_of_measurement`
+- **AND** preserves the mapping in final-group metadata and the persisted
+  workflow extract without exposing it as an extraction field
+
 #### Scenario: Explicit metadata registration still works
 - **WHEN** the same authored YAML is prepared with the scalar key included in
   `top_level_metadata_keys`

--- a/src/groundx/extract/prompt/utility.py
+++ b/src/groundx/extract/prompt/utility.py
@@ -70,6 +70,7 @@ _SUPPORTED_FINAL_GROUP_METADATA_KEYS = {
     "identity_match",
     "match_attrs",
     "not_required_service_types",
+    "normalization_profiles",
     "partial_pair_attrs",
     "passthrough",
     "passthrough_attrs",
@@ -102,6 +103,11 @@ _PASSTHROUGH_KEYS = {
     "multiple_match_strategy",
     "parent_output_field",
     "unmatched_child_group",
+}
+_SUPPORTED_NORMALIZATION_PROFILES = {
+    "currency_code",
+    "currency_label",
+    "unit_of_measurement",
 }
 _UNSUPPORTED_TOP_LEVEL_KEYS = {"domain"}
 _UNSUPPORTED_WORKFLOW_GROUP_KEYS = {"slot"}
@@ -660,6 +666,36 @@ def _validate_object_array_metadata(
 ) -> None:
     fields = _ensure_fields_mapping(group.get("fields"), f"{group_name}.fields")
     field_names = set(fields)
+
+    normalization_profiles_value = metadata.get("normalization_profiles")
+    if normalization_profiles_value is not None:
+        if not isinstance(normalization_profiles_value, dict):
+            raise ValueError(f"[{group_name}.normalization_profiles] must be a mapping")
+        normalization_profiles = typing.cast(
+            typing.Mapping[typing.Any, typing.Any], normalization_profiles_value
+        )
+        invalid_attrs = {
+            attr
+            for attr in normalization_profiles
+            if not isinstance(attr, str) or not attr
+        }
+        if invalid_attrs:
+            raise ValueError(
+                f"normalization_profiles attributes must be non-empty strings in group [{group_name}]: "
+                + ", ".join(sorted(str(attr) for attr in invalid_attrs))
+            )
+        invalid_profiles = {
+            profile
+            for profile in normalization_profiles.values()
+            if not isinstance(profile, str)
+            or not profile
+            or profile not in _SUPPORTED_NORMALIZATION_PROFILES
+        }
+        if invalid_profiles:
+            raise ValueError(
+                f"unsupported normalization profile in group [{group_name}]: "
+                + ", ".join(sorted(str(profile) for profile in invalid_profiles))
+            )
 
     unique_attrs_value = metadata.get("unique_attrs", [])
     unique_attrs = set(

--- a/tests/extract/prompt/test_persisted_workflow_extract.py
+++ b/tests/extract/prompt/test_persisted_workflow_extract.py
@@ -215,6 +215,69 @@ def _prepare(raw: typing.Any):
     )
 
 
+def test_normalization_profiles_are_supported_final_group_metadata() -> None:
+    raw = """
+extraction_policy_version: v1
+
+statement:
+  normalization_profiles:
+    amount_due_currency: currency_label
+    currency: currency_code
+  fields:
+    amount_due_currency:
+      prompt: {instructions: Return the currency., type: str}
+"""
+
+    prepared = prepare_extraction_yaml(raw)
+    persisted = json.loads(json.dumps(prepared.persisted_workflow_extract))
+    reloaded = prepare_extraction_yaml(persisted)
+
+    expected = {
+        "amount_due_currency": "currency_label",
+        "currency": "currency_code",
+    }
+    assert (
+        prepared.final_group_metadata["statement"]["normalization_profiles"]
+        == expected
+    )
+    assert (
+        reloaded.final_group_metadata["statement"]["normalization_profiles"]
+        == expected
+    )
+    assert persisted["_groundx_persisted_extract"]["statement"][
+        "normalization_profiles"
+    ] == expected
+    assert "normalization_profiles" not in prepared.groups["statement"]
+
+
+@pytest.mark.parametrize(
+    ("metadata", "message"),
+    [
+        ("normalization_profiles: [currency_label]", "normalization_profiles] must be a mapping"),
+        (
+            "normalization_profiles: {amount_due_currency: guess_currency}",
+            "unsupported normalization profile in group [statement]: guess_currency",
+        ),
+    ],
+)
+def test_normalization_profiles_reject_invalid_contracts(
+    metadata: str, message: str
+) -> None:
+    raw = f"""
+extraction_policy_version: v1
+
+statement:
+  {metadata}
+  fields:
+    amount_due_currency:
+      prompt: {{instructions: Return the currency., type: str}}
+"""
+
+    with pytest.raises(ValueError) as exc:
+        prepare_extraction_yaml(raw)
+    assert message in str(exc.value)
+
+
 def test_persisted_workflow_extract_round_trips_authored_metadata() -> None:
     prepared = _prepare(POLICY_YAML)
 


### PR DESCRIPTION
## Why

GroundX Python rejected `normalization_profiles` unless each caller registered the key. That made valid Arcadia v1 metadata inconsistent across the SDK, Cashbot, and Harness compilers.

## What changed

- Treat `normalization_profiles` as supported final-group metadata.
- Require a mapping with non-empty runtime attribute names.
- Allow only `currency_code`, `currency_label`, and `unit_of_measurement`.
- Preserve the mapping through prepare, persistence, and reload without exposing it as an extraction field.
- Permit runtime-populated attributes such as `currency` that are not direct extraction fields.

## Validation

- 100 extract prompt and manager tests passed.
- New normalization-profile contract tests passed.
- Ruff, line-ending, diff, and strict `extract-yaml` OpenSpec checks passed.
- Exact Internal Arcadia PR 96 YAML compiled through the local SDK path with 36 routes and 36 leaves.

Targeted mypy still reports three existing errors in `pydantic_utilities.py` and `extract/services/status.py`; none are in this diff.

## Release handoff

No release was created. After merge, a human release owner must publish the next SDK version before downstream images or pins can consume this contract.