### PR TITLE
Add Bedrock extract request support

### DIFF
--- a/src/groundx/extract/agents/agent.py
+++ b/src/groundx/extract/agents/agent.py
@@ -29,6 +29,41 @@ if typing.TYPE_CHECKING:
     from PIL.Image import Image
 
 
+BEDROCK_REQUEST_LIMIT_BYTES = 3_500_000
+
+
+def _enforce_bedrock_request_limit(request: typing.Any) -> None:
+    body = request.content
+    if len(body) > BEDROCK_REQUEST_LIMIT_BYTES:
+        raise ValueError(f"bedrock request is {len(body)} bytes; limit is {BEDROCK_REQUEST_LIMIT_BYTES} bytes")
+
+
+def _bedrock_model_options(
+    model_options: typing.Dict[str, typing.Any],
+) -> typing.Dict[str, typing.Any]:
+    import httpx
+
+    options = dict(model_options)
+    if "client" in options:
+        raise ValueError("bedrock service does not support a custom model client")
+
+    client_kwargs = dict(options.get("client_kwargs") or {})
+    http_client = client_kwargs.get("http_client")
+    if http_client is None:
+        http_client = httpx.Client(event_hooks={"request": [_enforce_bedrock_request_limit]})
+    else:
+        hooks = getattr(http_client, "event_hooks", None)
+        if not isinstance(hooks, dict):
+            raise ValueError("bedrock service requires an HTTP client with request event hooks")
+        hooks["request"] = [
+            *hooks.get("request", []),
+            _enforce_bedrock_request_limit,
+        ]
+    client_kwargs["http_client"] = http_client
+    options["client_kwargs"] = client_kwargs
+    return options
+
+
 class _DeadlineOpenAICompletions:
     def __init__(self, client: typing.Any) -> None:
         self._client = client
@@ -69,10 +104,10 @@ def build_openai_server_model(settings: AgentSettings) -> OpenAIServerModel:
     if settings.reasoning_effort:
         model_kwargs["reasoning_effort"] = settings.reasoning_effort
 
-    if settings.model_kwargs:
-        model = OpenAIServerModel(**model_kwargs, **settings.model_kwargs)
-    else:
-        model = OpenAIServerModel(**model_kwargs)
+    model_options = dict(settings.model_kwargs or {})
+    if settings.service == "bedrock":
+        model_options = _bedrock_model_options(model_options)
+    model = OpenAIServerModel(**model_kwargs, **model_options)
 
     client = getattr(model, "client", None)
     if client is not None and not isinstance(client, _DeadlineOpenAIClient):

--- a/src/groundx/extract/settings/settings.py
+++ b/src/groundx/extract/settings/settings.py
@@ -1,7 +1,8 @@
-import json, typing, os
+import json
+import os
+import typing
 
 from pydantic import BaseModel
-
 
 AWS_REGION: str = "AWS_REGION"
 AWS_DEFAULT_REGION: str = "AWS_DEFAULT_REGION"
@@ -46,6 +47,7 @@ class AgentSettings(BaseModel):
     response_parse_max_retries: int = 3
     image_transport: str = "pil"
     model_kwargs: typing.Optional[typing.Dict[str, typing.Any]] = None
+    service: typing.Optional[str] = None
 
     def get_api_key(self) -> str:
         if self.api_key:
@@ -55,7 +57,7 @@ class AgentSettings(BaseModel):
         if key:
             return key
 
-        raise Exception(f"you must set a valid agent api_key")
+        raise Exception("you must set a valid agent api_key")
 
 
 class ContainerSettings(BaseModel):
@@ -96,7 +98,7 @@ class ContainerSettings(BaseModel):
         if key:
             return key
 
-        raise Exception(f"you must set a callback_api_key")
+        raise Exception("you must set a callback_api_key")
 
     def get_valid_api_keys(self) -> typing.List[str]:
         keys: typing.List[str] = []
@@ -129,7 +131,7 @@ class ContainerSettings(BaseModel):
             keys.append(key)
 
         if len(keys) < 1:
-            raise Exception(f"you must set an array of valid_api_keys")
+            raise Exception("you must set an array of valid_api_keys")
 
         return keys
 
@@ -214,4 +216,4 @@ class GroundXSettings(BaseModel):
         if key:
             return key
 
-        raise Exception(f"you must set a valid GroundX api_key")
+        raise Exception("you must set a valid GroundX api_key")

--- a/tests/extract/agents/test_agent_model_settings.py
+++ b/tests/extract/agents/test_agent_model_settings.py
@@ -1,6 +1,7 @@
 import types
 import typing
 
+import httpx
 import pytest
 
 try:
@@ -112,3 +113,51 @@ def test_agent_model_client_uses_remaining_shared_deadline(
     assert calls[0]["max_retries"] == 0
     assert 0 < calls[0]["timeout"] <= 9
     assert calls[1] == {"model": "test"}
+
+
+def test_bedrock_model_checks_the_final_http_request_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_agent_constructors(monkeypatch)
+
+    AgentTool(
+        AgentSettings(
+            api_base="https://bedrock.example/v1",
+            api_key="test-key",
+            model_id="google.gemma-4-31b",
+            service="bedrock",
+        ),
+        Logger("agent-tool-model-settings", "error"),
+    )
+
+    client_kwargs = CapturingOpenAIModel.calls[-1]["client_kwargs"]
+    http_client = client_kwargs["http_client"]
+    exact = httpx.Request(
+        "POST",
+        "https://bedrock.example/v1/chat/completions",
+        content=b"x" * agent_module.BEDROCK_REQUEST_LIMIT_BYTES,
+    )
+    over = httpx.Request(
+        "POST",
+        "https://bedrock.example/v1/chat/completions",
+        content=b"x" * (agent_module.BEDROCK_REQUEST_LIMIT_BYTES + 1),
+    )
+
+    hook = http_client.event_hooks["request"][-1]
+    hook(exact)
+    with pytest.raises(ValueError, match="bedrock request.*3500000"):
+        hook(over)
+    http_client.close()
+
+
+def test_non_bedrock_model_does_not_install_bedrock_body_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_agent_constructors(monkeypatch)
+
+    AgentTool(
+        AgentSettings(api_key="test-key", service="openai"),
+        Logger("agent-tool-model-settings", "error"),
+    )
+
+    assert "client_kwargs" not in CapturingOpenAIModel.calls[-1]

--- a/tests/extract/agents/test_agent_tool_image_transport.py
+++ b/tests/extract/agents/test_agent_tool_image_transport.py
@@ -108,6 +108,24 @@ def test_agent_tool_remote_url_transport_uses_image_url_blocks_without_fetching(
     assert "sig=secret" not in json.dumps(agent.memory.get_full_steps())
 
 
+def test_agent_tool_remote_url_transport_passes_s3_image_uris() -> None:
+    agent, model = build_agent()
+    image_uri = "s3://configured-bucket/workflows/pages/page-1.png"
+
+    result = agent.process(
+        "read this",
+        images=[],
+        image_urls=[image_uri],
+        image_transport="remote_url",
+    )
+
+    assert result == {"ok": True}
+    assert {
+        "type": "image_url",
+        "image_url": {"url": image_uri},
+    } in last_user_content(model)
+
+
 def test_agent_tool_uses_agent_settings_image_transport_default() -> None:
     agent = AgentTool(
         AgentSettings(

--- a/tests/extract/settings/test_settings.py
+++ b/tests/extract/settings/test_settings.py
@@ -1,10 +1,8 @@
-import typing, os, unittest
+import os
+import typing
+import unittest
 
 from groundx.extract.settings.settings import (
-    AgentSettings,
-    ContainerSettings,
-    ContainerUploadSettings,
-    GroundXSettings,
     AWS_REGION,
     CALLBACK_KEY,
     GX_AGENT_KEY,
@@ -13,8 +11,11 @@ from groundx.extract.settings.settings import (
     GX_REGION,
     GX_SECRET,
     VALID_KEYS,
+    AgentSettings,
+    ContainerSettings,
+    ContainerUploadSettings,
+    GroundXSettings,
 )
-
 
 AWS_KEY: str = "AWS_ACCESS_KEY_ID"
 AWS_SECRET: str = "AWS_SECRET_ACCESS_KEY"
@@ -36,6 +37,7 @@ class TestAgentSettings(unittest.TestCase):
                     "max_steps": 7,
                     "model_id": "gpt-5.4-mini",
                     "reasoning_effort": None,
+                    "service": None,
                 },
             },
             {
@@ -45,12 +47,14 @@ class TestAgentSettings(unittest.TestCase):
                 "image_transport": "remote_url",
                 "max_steps": 4,
                 "model_id": "gpt-5",
+                "service": "bedrock",
                 "expect": {
                     "api_base": "http://test.com",
                     "api_key": "mykey",
                     "image_transport": "remote_url",
                     "max_steps": 4,
                     "model_id": "gpt-5",
+                    "service": "bedrock",
                 },
             },
             {
@@ -62,6 +66,7 @@ class TestAgentSettings(unittest.TestCase):
                     "max_steps": 7,
                     "model_id": "gpt-5.4-mini",
                     "reasoning_effort": None,
+                    "service": None,
                 },
             },
         ]
@@ -82,6 +87,8 @@ class TestAgentSettings(unittest.TestCase):
                 input["max_steps"] = tst["max_steps"]
             if "model_id" in tst:
                 input["model_id"] = tst["model_id"]
+            if "service" in tst:
+                input["service"] = tst["service"]
 
             settings = AgentSettings(**input)
 
@@ -96,16 +103,14 @@ class TestAgentSettings(unittest.TestCase):
 
             self.assertEqual(settings.max_steps, tst["expect"]["max_steps"])
 
-            self.assertEqual(
-                settings.image_transport, tst["expect"]["image_transport"]
-            )
+            self.assertEqual(settings.image_transport, tst["expect"]["image_transport"])
 
             self.assertEqual(settings.model_id, tst["expect"]["model_id"])
 
             if "reasoning_effort" in tst["expect"]:
-                self.assertEqual(
-                    settings.reasoning_effort, tst["expect"]["reasoning_effort"]
-                )
+                self.assertEqual(settings.reasoning_effort, tst["expect"]["reasoning_effort"])
+
+            self.assertEqual(settings.service, tst["expect"]["service"])
 
 
 class TestContainerUploadSettings(unittest.TestCase):
@@ -424,9 +429,7 @@ class TestContainerSettings(unittest.TestCase):
 
             self.assertEqual(settings.cache_to, tst["expect"]["cache_to"])
 
-            self.assertEqual(
-                settings.google_sheets_drive_id, tst["expect"]["google_sheets_drive_id"]
-            )
+            self.assertEqual(settings.google_sheets_drive_id, tst["expect"]["google_sheets_drive_id"])
 
             self.assertEqual(
                 settings.google_sheets_template_id,


### PR DESCRIPTION
## Summary

- adds optional `AgentSettings.service`
- applies the Bedrock request-size check to the final serialized HTTP request
- leaves all non-Bedrock model requests unchanged

The public workflow enum is added separately in eyelevelai/eyelevel-fern-config#53. This hand-written extract change must merge before the generated SDK release.

## Validation

- 18 focused tests passed
- 553 non-protected extract tests passed, 8 skipped
- Ruff check and format passed
- targeted mypy passed
- package build passed

The protected fixture suite still requires its private fixtures.