### PR TITLE
Preserve persisted workflow readback

### DIFF
--- a/openspec/changes/fix-persisted-workflow-derivation/proposal.md
+++ b/openspec/changes/fix-persisted-workflow-derivation/proposal.md
@@ -1,67 +1,43 @@
-# Proposal — fix-persisted-workflow-derivation
+# Proposal: preserve persisted workflow readback
 
 ## Execution route
 
-This active SDK input is governed by
+This SDK change is governed by
 `internal-arcadia-agents/openspec/changes/complete-extraction-boundary-regression-coverage/tasks.md`.
-Tasks 0.5, 2.2d, 2.2f, 3.2c0, and 9.1a own the remaining diagnosis, stored-route
-migration, SDK placement, cross-repo proof, release, pinning, and deployment
-work. This proposal is not a separate completion or certification path.
+It is an input to that closeout, not a separate certification path.
 
 ## Why
 
-Live prod testing (2026-07-08, cashbot-go `accept-workflow-yaml-source` E2E) proved that **any
-workflow with repeating groups (meters/charges-style list output) fails extraction** when the
-runtime derives its reassembly metadata from the persisted workflow. Five deployed workflows
-(four Go-compiled + the platform's own `studio-demo` from May) all fail; a local reproduction
-against the persisted forms isolated two defects in `src/groundx/extract/prompt/utility.py`
-(identical in 3.7.7 and 3.7.8):
+`load_extraction_definition_from_workflow_response()` recompiles an existing
+workflow by passing its persisted extract back through the authored-YAML
+compiler. That crosses two different boundaries:
 
-1. **Wildcard poisoning** — `_apply_custom_workflow_field_paths` copies each persisted route's
-   `final_path` verbatim into `workflow_field_paths`. Harness-dialect workflows store
-   `/charges/*/amount` (3 segments, not a valid RFC 6901 pointer); the reassembly parser
-   (`extraction_reassembly._parse_final_path`) requires exactly 2 segments and rejects them →
-   `route ... must have exactly two non-empty path segments` / `missing routed group` 500s.
-   The authored-YAML path derives correct 2-segment paths; only persisted-readback breaks.
+- authored YAML is validated and compiled when a workflow is created or updated;
+- persisted workflow readback is execution input and must be preserved.
 
-2. **Hash false-positive** — `_normalize_persisted_custom_workflow_metadata` recomputes the
-   schema hash over its *re-normalized* structures and compares it to the stored hash that was
-   computed over the *original* (harness-dialect) structures. Different canonicalization →
-   guaranteed mismatch → `ValueError: caller schema_hash does not match route metadata`. The
-   runtime's metadata loader swallows the exception and proceeds with no metadata (observed as
-   the v1/utility extraction hang).
-
-Root context: two long-standing compiled dialects exist (harness `compile_workflow.py`:
-3-segment + `is_repeated: true`; SDK `prepare_extraction_yaml`: 2-segment + flags), documented
-in cashbot-go `pkg/testdata/workflowyaml/goldens/FINDINGS.md`. Production deploys the harness
-dialect; the extraction runtime reads the SDK dialect. This change makes the SDK reader
-**dialect-tolerant** so every already-stored workflow works; consolidated task 2.2d owns the
-Cashbot API's canonical stored-route behavior going forward.
+The error blocked two protected workflows before ingest. Arcadia legacy was
+rejected because its historical authored snapshot contains
+`final_value_aliases`. Generic v1 was rejected because current authoring-chain
+coverage rules were applied to its already compiled routes.
 
 ## What changes
 
-- `_apply_custom_workflow_field_paths` is pinned VERBATIM (re-scoped by fresh-scan P1/P2: `*`
-  tokens are the SDK's own row-routing vocabulary — field-level lists — so stripping them here
-  broke 7 SDK tests). The wildcard normalization for the reassembly parser's 2-segment
-  contract moves to its only consumer's export boundary: internal-arcadia-agents
-  `workflow_reassembly_metadata` (task 3.2).
-- Readers STOP verifying writer hashes entirely (adversarial finding F1: even an as-received
-  recompute diverges across hash implementations — proven SDK `896b…` vs stored Go `f1a2…`
-  over identical structures). The stored `schema_hash` is writer-owned and opaque; read-time
-  integrity is structural validation; the server becomes the only hash authority
-  (consolidated task 2.2d).
-- Regression tests pinned to **both dialect goldens** (harness-dialect and SDK-dialect
-  persisted extracts) must derive byte-identical `workflow_field_paths` and pass reassembly
-  preflight; plus an end-to-end repeated-group reassembly test — the exact case production
-  missed.
+- Authored paths, YAML text, and authored mappings continue through
+  `prepare_extraction_yaml()`.
+- Existing workflow responses and mappings explicitly marked
+  `mapping_kind="workflow_extract"` receive structural execution-metadata
+  validation only.
+- Persisted extract bytes are preserved, and readback returns `prepared=None`.
+- The reader does not reapply current authoring rules or compare writer-owned
+  hashes.
+
+Internal Arcadia already reconstructs its runtime prompt cache and reassembly
+metadata from the deployed workflow. It does not need an SDK-authored prepared
+object at this boundary.
 
 ## Impact
 
-- Affected: only the persisted-workflow read path (`prepare_extraction_yaml` "persisted"
-  classification). Today that path always fails for repeated groups, so the change strictly
-  enables; SDK-dialect inputs are byte-identical before/after.
-- Consumers: internal-arcadia-agents (extract pods) via `prepare_arcadia_extraction_yaml`.
-  Rollout = SDK release → internal-arcadia-agents pin bump → extract pod redeploy → rerun the
-  cashbot-go live proof matrix (repeated-group population).
-- Out of scope here: what the API stores (consolidated task 2.2d), the
-  internal-arcadia-agents exception-swallowing (follow-up noted in tasks).
+The change affects only existing-workflow readback. Creating or updating a
+workflow from authored YAML remains fully compiled and validated. Rollout
+requires an SDK release, an Internal Arcadia pin update, and extraction-service
+deployment before the protected file replays and closeout capture resume.

--- a/openspec/changes/fix-persisted-workflow-derivation/specs/extract-yaml/spec.md
+++ b/openspec/changes/fix-persisted-workflow-derivation/specs/extract-yaml/spec.md
@@ -1,39 +1,41 @@
-# Spec delta — extract-yaml (fix-persisted-workflow-derivation)
+# Spec delta: extract-yaml
 
-## MODIFIED Requirements
+## ADDED Requirements
 
-### Requirement: Field paths preserve final_path verbatim
+### Requirement: persisted workflow readback is not authored compilation
 
-`workflow_field_paths` SHALL carry each route's `final_path` verbatim, including `*` tokens —
-they are load-bearing vocabulary for the SDK's own row routing (field-level lists such as
-`/group/list_field/*/sub`). Consumers with narrower path contracts (the Arcadia reassembly
-parser's 2-segment group/field pointers) SHALL normalize at THEIR export boundary
-(internal-arcadia-agents `workflow_reassembly_metadata`), never in the shared derivation.
-(Fresh-scan P1/P2: the earlier "SDK dialect is 2-segment" model was falsified by the SDK's own
-row-routing tests — both dialects legitimately contain `*`.)
+The SDK SHALL compile and validate authored YAML when creating a new extraction
+definition. It SHALL NOT recompile the persisted extract returned by an
+existing workflow. Existing-workflow readback SHALL preserve the extract,
+structurally validate its execution metadata, and return `prepared=None`.
 
-#### Scenario: starred routes survive derivation untouched
+#### Scenario: historical authored snapshot remains readable
 
-- **GIVEN** a persisted workflow whose `output_routes[].final_path` values include `*` tokens
-- **WHEN** `prepare_extraction_yaml` derives `workflow_field_paths`
-- **THEN** every derived path equals its route's `final_path` byte-for-byte
+- **GIVEN** an existing workflow contains a historical authored snapshot that
+  current authoring validation would reject
+- **WHEN** the SDK loads that workflow for execution
+- **THEN** it preserves the workflow extract without compiling the snapshot
+- **AND** it returns `prepared=None`.
 
-### Requirement: Readers do not verify writer hashes
+#### Scenario: current authoring rules do not rewrite deployed execution
 
-The persisted-workflow reader SHALL NOT compare the stored `schema_hash` against any recompute
-(cross-implementation hash comparison is the proven false-positive: distinct canonicalizations
-disagree over identical structures). The stored hash is writer-owned and opaque to readers.
-Read-time integrity SHALL be structural validation of the stored metadata; a canonical hash MAY
-be recomputed for runtime use but SHALL never gate loading.
+- **GIVEN** an existing workflow has valid compiled execution routes
+- **AND** its authored agent chain does not satisfy current authoring coverage
+  rules
+- **WHEN** the SDK loads the workflow
+- **THEN** the deployed extract is accepted unchanged
+- **AND** current authoring coverage rules are not applied.
 
-#### Scenario: either dialect loads without hash errors
+#### Scenario: authored input still compiles
 
-- **GIVEN** a workflow persisted in the harness or SDK dialect with its writer's hash
-- **WHEN** the persisted metadata is loaded for runtime use
-- **THEN** no schema-hash comparison occurs and loading succeeds
+- **GIVEN** a path, YAML string, or authored mapping
+- **WHEN** the SDK creates an extraction definition from it
+- **THEN** the SDK applies current authored-YAML validation and compilation
+- **AND** returns its prepared definition.
 
-#### Scenario: structural corruption still fails
+#### Scenario: malformed execution metadata fails
 
-- **GIVEN** a persisted workflow whose routes reference undefined steps or malformed targets
-- **WHEN** the persisted metadata is loaded
-- **THEN** structural validation raises a descriptive error
+- **GIVEN** an existing workflow whose execution routes reference missing
+  workflow fields
+- **WHEN** the SDK loads the workflow
+- **THEN** structural validation fails with a descriptive error.

--- a/openspec/changes/fix-persisted-workflow-derivation/tasks.md
+++ b/openspec/changes/fix-persisted-workflow-derivation/tasks.md
@@ -1,74 +1,31 @@
-# Tasks — fix-persisted-workflow-derivation
+# Tasks: preserve persisted workflow readback
 
-Execution note: this is the SDK implementation input for the consolidated
-extraction reliability plan in
-`internal-arcadia-agents/openspec/changes/complete-extraction-boundary-regression-coverage/tasks.md`.
-The prior derivation release does not close the new placement work. Active tasks
-0.5, 2.2d, 2.2f, 3.2c0, and 9.1a own the remaining diagnosis, stored-route
-migration, `output_scope` parsing, complete-path reassembly, cross-repo proof,
-release, pinning, and deployed-version verification. Do not use this file as a
-separate certification finish path.
+## 1. Boundary contract
 
-## 1. Failing tests first (TDD; both are red today)
-
-- [x] 1.1 (re-scoped, fresh-scan P1/P2) Tests in THIS repo: (a) harness-dialect stored hash
-      never gates loading; (b) `workflow_field_paths` preserves starred `final_path` values
-      VERBATIM (the `*` is SDK row-routing vocabulary); (c) recomputed hash attached, never
-      compared. Fixture = the real prod readback. The 2-segment derivation tests MOVED to
-      internal-arcadia-agents (3.2) — the reassembly export is the only 2-segment consumer.
-- [x] 1.2 (lives in internal-arcadia-agents PR #81 with the export fix) Test: end-to-end repeated-group reassembly — workflow output with list groups
-      (`meters`/`charges` rows) + harness-dialect persisted metadata reassembles into final
-      arrays with zero diagnostics (the exact prod failure).
-- [x] 1.3 Test: structural integrity still enforced — corrupt stored structures (drop a
-      route's target, malform a leaf) → still raises via structural validation, WITHOUT any
-      stored-hash comparison.
+- [x] 1.1 Add a regression using a historical persisted authored snapshot with
+      `final_value_aliases`; prove readback does not compile it.
+- [x] 1.2 Add a regression using the real v1 contract shape with a persisted
+      agent chain that current authoring validation would reject; prove
+      readback preserves it.
+- [x] 1.3 Keep structural validation for persisted execution metadata and
+      authoring-only key leakage.
 
 ## 2. Implementation
 
-- [x] 2.1 (re-scoped) `_apply_custom_workflow_field_paths` stays VERBATIM by design, with a
-      comment pinning why (`*` = row-routing vocabulary; normalization is the Arcadia export's
-      job). The wildcard normalization implementation moves to internal-arcadia-agents (3.2).
-- [x] 2.2 (PR #38) `_normalize_persisted_custom_workflow_metadata`: STOP comparing stored `schema_hash`
-      at read time entirely — repro #4 proved even an as-received recompute diverges across
-      hash implementations (SDK `896b…` vs stored Go `f1a2…` over the same structures). The
-      stored hash is writer-owned/opaque to readers; read-time integrity = structural
-      validation (routes/leaves/steps well-formed); the recomputed canonical hash is attached
-      for runtime use only, never compared against the stored one. (Consolidated task 2.2d
-      owns canonical Cashbot storage and route migration.)
-- [x] 2.3 Confirm `agent_chain` handling unchanged (hash never covered it; keep it that way,
-      pinned by a test).
+- [x] 2.1 Remove `prepare_extraction_yaml()` from workflow-response and explicit
+      `workflow_extract` loading.
+- [x] 2.2 Preserve the persisted extract and workflow-level settings exactly.
+- [x] 2.3 Return `prepared=None` for every existing-workflow readback.
+- [x] 2.4 Document the authored-input and persisted-readback boundary on sync
+      and async clients.
 
-## 3. Release + rollout
+## 3. Verification and rollout
 
-- [ ] 3.1 SDK publication was complete for the original persisted-workflow
-      derivation work via the released 3.8.4 line, but new SDK code changes
-      were added after that release for relationship child-row dedupe in
-      `src/groundx/extract/custom_outputs.py`. A new SDK PR merge and release
-      are required before deployed extract pods can prove the corrected
-      Arcadia-family 24-30 nested meter-charge shape. Runtime verification
-      remains owned by the consolidated deployment gate in
-      `internal-arcadia-agents`.
-- [x] 3.2 (PR #81 — ALSO fixes the hardcoded {meters,charges} array vocabulary: array-ness now derives from workflow metadata per the archived generalize-v1 spec, UNION legacy names per owner ruling; runtime pin/deploy verification tracked in the consolidated plan) internal-arcadia-agents — NOW OWNS THE WILDCARD NORMALIZATION (fresh-scan P2):
-      `workflow_reassembly_metadata` normalizes group-repetition paths (`/g/*/f` → `/g/f`)
-      when exporting `workflow_field_paths` for the reassembly parser; field-level list paths
-      (still >2 tokens after the strip) get an EXPLICIT unsupported-in-reassembly error, not
-      silence (fresh-scan P3). Tests: harness-dialect persisted workflow through
-      `prepare_arcadia_extraction_yaml` + `reassemble_from_metadata` end-to-end (the moved
-      2-segment tests live here); bump `groundx[extract]` pin.
-- [x] 3.3 (folded into PR #81, NOT separate — adversarial finding: the export fix raises errors the swallow would eat) stop silently swallowing metadata
-      loader exceptions (`classes/statement.py:1400`) — surface as a visible diagnostic; the
-      prod hang was undebuggable because the ValueError vanished.
-- [ ] 3.4 Diagnostics for the three un-root-caused live failures BEFORE declaring the retest
-      gate: (a) confirm the v1/utility hang mechanism in pod logs (the swallowed
-      `caller schema_hash` ValueError at the observed timestamps); (b) root-cause scaffold's
-      empty workflow output (custom steps produced no groups at all — readback keys? steps
-      never ran?); (c) root-cause legacy's all-empty values (legacy shape has no customSteps —
-      is the standard pipeline expected to populate it at all, and if not, what should the API
-      return?). Each becomes a test or a documented expected-behavior note.
-- [ ] 3.5 Tolerance lifetime: this dialect tolerance is deleted ONLY when the
-      stored-route inventory and migration in consolidated task 2.2d show zero
-      non-canonical rows, not on a schedule.
-- [ ] 3.6 Redeploy extract pods; rerun the cashbot-go live proof matrix (legacy, v1, utility,
-      scaffold + studio-demo control) with the rich utility PDF; require populated
-      `meters`/`charges` rows, not just completion. Then delete test workflows/buckets
-      (30065-30068, 30096).
+- [ ] 3.1 Pass focused, extract, static, and package tests on Python 3.9.
+- [ ] 3.2 Replay the exact protected workflow readbacks and record compact
+      inputs, outputs, identities, and failures.
+- [ ] 3.3 Open and merge the SDK PR through normal repository gates.
+- [ ] 3.4 Human release owner publishes the next SDK version.
+- [ ] 3.5 Update Internal Arcadia's SDK pin, deploy the approved production
+      branch, and verify extract, reconcile, QA, and save handoffs on the exact
+      saved files before capture resumes.

--- a/src/groundx/extract/workflows.py
+++ b/src/groundx/extract/workflows.py
@@ -118,9 +118,7 @@ def load_extraction_definition_from_yaml(
     if source_name == "mapping":
         effective_kind = mapping_kind or _AUTHORED_YAML_MAPPING_KIND
         if effective_kind not in {_AUTHORED_YAML_MAPPING_KIND, _WORKFLOW_EXTRACT_MAPPING_KIND}:
-            raise ValueError(
-                "mapping_kind must be 'authored_yaml' or 'workflow_extract'"
-            )
+            raise ValueError("mapping_kind must be 'authored_yaml' or 'workflow_extract'")
 
         mapping_value = _ensure_mapping(source_value, "mapping")
         if effective_kind == _WORKFLOW_EXTRACT_MAPPING_KIND:
@@ -155,9 +153,8 @@ def load_extraction_definition_from_workflow_response(
     if not isinstance(extract, Mapping):
         raise ValueError(f"workflow [{workflow_id}] does not include extraction config")
 
-    extract_mapping = _deepcopy_mapping(
-        typing.cast(typing.Mapping[str, typing.Any], extract)
-    )
+    extract_mapping = _deepcopy_mapping(typing.cast(typing.Mapping[str, typing.Any], extract))
+    _validate_workflow_extract_mapping(extract_mapping)
     fallback_metadata = _workflow_metadata(extract_mapping)
 
     template = _first_present(
@@ -179,7 +176,7 @@ def load_extraction_definition_from_workflow_response(
 
     return ExtractionDefinition(
         extract=extract_mapping,
-        prepared=_prepared_from_workflow_extract(extract_mapping),
+        prepared=None,
         template=_normalize_template(template),
         custom_steps=_plain_metadata_sequence(custom_steps, _CUSTOM_STEP_ALIASES),
         output_routes=_plain_metadata_sequence(output_routes, _OUTPUT_ROUTE_ALIASES),
@@ -291,8 +288,7 @@ def ensure_workflow_method_supports_kwargs(
     kwargs: typing.Mapping[str, typing.Any],
 ) -> None:
     unsupported = [
-        key for key in _UNRELEASED_WORKFLOW_KWARGS
-        if key in kwargs and not _method_accepts_keyword(method, key)
+        key for key in _UNRELEASED_WORKFLOW_KWARGS if key in kwargs and not _method_accepts_keyword(method, key)
     ]
     if unsupported:
         unsupported_list = ", ".join(unsupported)
@@ -335,11 +331,11 @@ def _definition_from_workflow_extract(
     extract: typing.Mapping[str, typing.Any],
 ) -> ExtractionDefinition:
     extract_mapping = _deepcopy_mapping(extract)
-    prepared = _validate_workflow_extract_mapping(extract_mapping)
+    _validate_workflow_extract_mapping(extract_mapping)
     metadata = _workflow_metadata(extract_mapping)
     return ExtractionDefinition(
         extract=extract_mapping,
-        prepared=prepared,
+        prepared=None,
         template=_normalize_template(metadata.get("template")),
         custom_steps=_plain_metadata_sequence(
             metadata.get("custom_steps"),
@@ -357,17 +353,9 @@ def _definition_from_workflow_extract(
     )
 
 
-def _prepared_from_workflow_extract(
-    extract: typing.Mapping[str, typing.Any],
-) -> typing.Optional[PreparedExtractionYaml]:
-    if _PERSISTED_WORKFLOW_EXTRACT_KEY not in extract:
-        return None
-    return prepare_extraction_yaml(extract)
-
-
 def _validate_workflow_extract_mapping(
     extract: typing.Mapping[str, typing.Any],
-) -> typing.Optional[PreparedExtractionYaml]:
+) -> None:
     authoring_paths = _find_authoring_only_workflow_keys(extract)
     if authoring_paths:
         preview = ", ".join(authoring_paths[:3])
@@ -377,19 +365,22 @@ def _validate_workflow_extract_mapping(
             "workflow extract with workflow.metadata_version"
         )
 
+    persisted_source = extract.get(_PERSISTED_WORKFLOW_EXTRACT_KEY)
+    if persisted_source is not None and not isinstance(persisted_source, Mapping):
+        raise ValueError("workflow_extract._groundx_persisted_extract must be a mapping")
+
+    raw_metadata = extract.get(_WORKFLOW_METADATA_KEY)
+    if raw_metadata is not None and not isinstance(raw_metadata, Mapping):
+        raise ValueError("workflow_extract.workflow must be a mapping")
     metadata = _workflow_metadata(extract)
     has_workflow_metadata = bool(set(metadata.keys()) & _PERSISTED_WORKFLOW_METADATA_KEYS)
     if not has_workflow_metadata:
-        return _prepared_from_workflow_extract(extract)
+        return
 
     if metadata.get("metadata_version") != _WORKFLOW_METADATA_VERSION:
         raise ValueError("unsupported custom workflow metadata_version")
 
-    prepared = prepare_extraction_yaml(extract)
     _validate_workflow_metadata_references(extract, metadata)
-    if _PERSISTED_WORKFLOW_EXTRACT_KEY in extract:
-        return prepared
-    return None
 
 
 def _find_authoring_only_workflow_keys(
@@ -412,11 +403,7 @@ def _find_authoring_only_workflow_keys(
 
         child_path = f"{path}.{key}"
         is_name_position = parent_key == "fields"
-        if (
-            isinstance(key, str)
-            and key in _AUTHORING_ONLY_WORKFLOW_KEYS
-            and not is_name_position
-        ):
+        if isinstance(key, str) and key in _AUTHORING_ONLY_WORKFLOW_KEYS and not is_name_position:
             paths.append(child_path)
 
         paths.extend(
@@ -452,8 +439,7 @@ def _validate_workflow_metadata_references(
                 raise ValueError(f"workflow.{metadata_key}[{idx}] is missing workflow_field")
             if not _workflow_field_exists(extract, group_name, field_name):
                 raise ValueError(
-                    f"workflow.{metadata_key}[{idx}] references missing "
-                    f"workflow field [{group_name}.{field_name}]"
+                    f"workflow.{metadata_key}[{idx}] references missing workflow field [{group_name}.{field_name}]"
                 )
 
 
@@ -510,9 +496,7 @@ def _select_source(**sources: typing.Any) -> typing.Tuple[str, typing.Any]:
         if not selected:
             raise ValueError(f"expected exactly one source: {source_names}")
         conflicts = ", ".join(name for name, _value in selected)
-        raise ValueError(
-            f"expected exactly one source from {source_names}; received {conflicts}"
-        )
+        raise ValueError(f"expected exactly one source from {source_names}; received {conflicts}")
     return selected[0]
 
 
@@ -557,9 +541,7 @@ def _normalize_template(value: typing.Any) -> typing.Optional[typing.Dict[str, s
         if not isinstance(key, str):
             raise ValueError("workflow template keys must be strings")
         if not isinstance(template_value, str):
-            raise ValueError(
-                f"workflow template value for [{key}] must be a string"
-            )
+            raise ValueError(f"workflow template value for [{key}] must be a string")
         template[key] = template_value
     return template or None
 
@@ -630,10 +612,7 @@ def _normalize_mapping_aliases(
 ) -> typing.Any:
     if isinstance(value, Mapping):
         mapping = typing.cast(typing.Mapping[typing.Any, typing.Any], value)
-        return {
-            aliases.get(key, key): _normalize_mapping_aliases(item, aliases)
-            for key, item in mapping.items()
-        }
+        return {aliases.get(key, key): _normalize_mapping_aliases(item, aliases) for key, item in mapping.items()}
     if isinstance(value, (list, tuple)):
         sequence = typing.cast(typing.Sequence[typing.Any], value)
         return [_normalize_mapping_aliases(item, aliases) for item in sequence]
@@ -675,9 +654,13 @@ def _method_accepts_keyword(method: typing.Any, key: str) -> bool:
     for parameter in signature.parameters.values():
         if parameter.kind == inspect.Parameter.VAR_KEYWORD:
             return True
-        if parameter.kind in {
-            inspect.Parameter.KEYWORD_ONLY,
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-        } and parameter.name == key:
+        if (
+            parameter.kind
+            in {
+                inspect.Parameter.KEYWORD_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            }
+            and parameter.name == key
+        ):
             return True
     return False

--- a/src/groundx/ingest.py
+++ b/src/groundx/ingest.py
@@ -295,7 +295,9 @@ class GroundX(GroundXBase):
             A `PreparedExtractionYaml` returned by `prepare_extraction_yaml`.
         mapping_kind : typing.Optional[str]
             Use `"workflow_extract"` only when `mapping` is an existing workflow
-            extract payload. Omit it for authored YAML-shaped mappings.
+            extract payload. Existing workflow extracts are structurally
+            validated and preserved without recompiling their authored source.
+            Omit it for authored YAML-shaped mappings.
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration forwarded to the generated workflow
             client. Valid only with `workflow_id`.
@@ -384,8 +386,10 @@ class GroundX(GroundXBase):
         may be either YAML or an existing workflow ID.
         Authored YAML may be pure legacy or explicitly marked v1 YAML. Existing
         workflow extract mappings must use `mapping_kind="workflow_extract"`;
-        mixed payloads that leak authoring-only workflow metadata into
-        execution extracts are rejected.
+        Existing workflow extracts return `prepared=None`; only authored YAML
+        sources are compiled into a prepared definition. Mixed payloads that
+        leak authoring-only workflow metadata into execution extracts are
+        rejected.
         """
         extraction_workflows = _import_extraction_workflows()
         return extraction_workflows.load_extraction_definition_from_yaml(
@@ -420,8 +424,8 @@ class GroundX(GroundXBase):
         -------
         typing.Any
             An `ExtractionDefinition` loaded from the workflow response.
-            Workflows that only contain execution-ready extract JSON return a
-            definition with `prepared=None`.
+            Existing workflow extracts are preserved and return a definition
+            with `prepared=None`.
 
         Examples
         --------
@@ -432,9 +436,9 @@ class GroundX(GroundXBase):
 
         Notes
         -----
-        Workflows that only contain execution-ready extract JSON return a
-        definition with `prepared=None`; the create/update payload remains
-        reusable, but authored YAML metadata is unavailable.
+        Existing workflow extracts return `prepared=None`; the create/update
+        payload remains reusable, but the persisted authored snapshot is not
+        recompiled or treated as current authoring input.
         """
         extraction_workflows = _import_extraction_workflows()
         response = self.workflows.get(workflow_id, request_options=request_options)
@@ -480,7 +484,8 @@ class GroundX(GroundXBase):
             A `PreparedExtractionYaml` returned by `prepare_extraction_yaml`.
         mapping_kind : typing.Optional[str]
             Use `"workflow_extract"` only when `mapping` is an existing workflow
-            extract payload.
+            extract payload. Existing workflow extracts are structurally
+            validated and preserved without recompiling their authored source.
         name : typing.Optional[str]
             Workflow name. Required for create.
         chunk_strategy : typing.Any
@@ -1211,8 +1216,10 @@ class AsyncGroundX(AsyncGroundXBase):
         may be either YAML or an existing workflow ID.
         Authored YAML may be pure legacy or explicitly marked v1 YAML. Existing
         workflow extract mappings must use `mapping_kind="workflow_extract"`;
-        mixed payloads that leak authoring-only workflow metadata into
-        execution extracts are rejected.
+        Existing workflow extracts return `prepared=None`; only authored YAML
+        sources are compiled into a prepared definition. Mixed payloads that
+        leak authoring-only workflow metadata into execution extracts are
+        rejected.
         """
         extraction_workflows = _import_extraction_workflows()
         return extraction_workflows.load_extraction_definition_from_yaml(
@@ -1243,7 +1250,8 @@ class AsyncGroundX(AsyncGroundXBase):
         Returns
         -------
         typing.Any
-            An `ExtractionDefinition` loaded from the workflow response.
+            An `ExtractionDefinition` that preserves the existing workflow
+            extract and has `prepared=None`.
 
         Examples
         --------
@@ -1251,6 +1259,8 @@ class AsyncGroundX(AsyncGroundXBase):
 
         Prefer `load_extraction_definition(workflow_id=...)` for new code when
         the source may be either YAML or an existing workflow ID.
+
+        Existing workflow extracts are not recompiled as authored YAML.
         """
         extraction_workflows = _import_extraction_workflows()
         response = await self.workflows.get(

--- a/tests/extract/test_extraction_workflow_definitions.py
+++ b/tests/extract/test_extraction_workflow_definitions.py
@@ -104,6 +104,8 @@ ADP_WORKFLOW_SOURCE: dict[str, typing.Any] = {
     },
 }
 
+V1_CONTRACT_YAML = Path(__file__).parent / "prompt" / "fixtures" / "extraction_yaml_contract_v1.yaml"
+
 
 EXECUTION_ONLY_EXTRACT = {
     "line_items": {
@@ -332,6 +334,47 @@ def test_load_extraction_definition_uses_workflow_id() -> None:
     assert definition.template["{{LANGUAGE_UNKNOWN}}"] == ""
 
 
+def test_workflow_readback_does_not_recompile_historical_authored_snapshot() -> None:
+    extract = copy.deepcopy(prepare_extraction_yaml(CUSTOM_WORKFLOW_YAML).persisted_workflow_extract)
+    extract["_groundx_persisted_extract"]["line_items"]["final_value_aliases"] = {"description": "label"}
+    response = WorkflowResponse(
+        workflow=WorkflowDetail(
+            workflow_id="historical-workflow",
+            extract=typing.cast(typing.Any, extract),
+        )
+    )
+
+    definition = _client(RecordingWorkflows(response)).load_extraction_definition(workflow_id="historical-workflow")
+
+    assert definition.extract == extract
+    assert definition.prepared is None
+
+
+def test_workflow_extract_mapping_does_not_revalidate_authored_agent_chain() -> None:
+    extract = copy.deepcopy(prepare_extraction_yaml(V1_CONTRACT_YAML.read_text()).persisted_workflow_extract)
+    partial_chain = [
+        {
+            "parallel": [
+                {
+                    "group": "statement_identity",
+                    "chain": ["reconcile_statement", "qa_statement"],
+                }
+            ]
+        },
+        "save_statement",
+    ]
+    extract["workflow"]["agent_chain"] = copy.deepcopy(partial_chain)
+    extract["_groundx_persisted_extract"]["workflow"]["agent_chain"] = copy.deepcopy(partial_chain)
+
+    definition = _client(RecordingWorkflows()).load_extraction_definition_from_yaml(
+        mapping=extract,
+        mapping_kind="workflow_extract",
+    )
+
+    assert definition.extract == extract
+    assert definition.prepared is None
+
+
 def test_load_extraction_definition_uses_workflow_id_before_yaml_sources(tmp_path: Path) -> None:
     path = tmp_path / "statement.yaml"
     path.write_text("not: [valid")
@@ -414,7 +457,7 @@ def test_workflow_extract_mapping_requires_explicit_kind() -> None:
     )
 
     assert definition.extract == persisted
-    assert definition.prepared is not None
+    assert definition.prepared is None
     assert definition.template == {
         "{{LANGUAGE}}": "English",
         "{{LANGUAGE_UNKNOWN}}": "",
@@ -601,7 +644,8 @@ def test_load_adp_workflow_readback_preserves_section_strategy() -> None:
         mapping_kind="workflow_extract",
     )
 
-    assert definition.prepared is not None
+    assert definition.prepared is None
+    assert mapping_definition.prepared is None
     assert definition.section_strategy == "page"
     assert mapping_definition.section_strategy == "page"
 


### PR DESCRIPTION
## Summary

Existing workflow readback now preserves the deployed extract and performs structural execution-metadata validation without recompiling the persisted authored snapshot. Authored paths, YAML text, and authored mappings continue through the normal compiler.

This fixes protected Arcadia legacy and generic v1 workflows that were rejected before ingest when current authoring rules were incorrectly applied to already compiled workflows.

## Verification

- 702 passed, 6 skipped, 11 intentional fixture-red tests deselected, 58 subtests passed
- focused workflow-definition tests: 34 passed
- ruff passes on changed Python files
- mypy passes across 269 source files
- package build passes
- strict OpenSpec validation passes
- live Arcadia legacy, Arcadia v1, and generic v1 workflow readbacks retain byte-identical canonical JSON

## Release

A human release owner must publish the next SDK version after merge.