### PR TITLE
Require explicit authored roles for agent chains

### DIFF
--- a/openspec/changes/require-authored-workflow-group-roles/proposal.md
+++ b/openspec/changes/require-authored-workflow-group-roles/proposal.md
@@ -1,0 +1,19 @@
+# Proposal: require authored workflow group roles
+
+## Why
+
+Agent-chain validation inferred processing roles from task suffixes and group
+names. Identical groups could therefore validate differently after a rename.
+
+## What changes
+
+- Require every canonical v1 final and pseudo group used by an agent chain to
+  declare its processing `role`.
+- Validate each parallel branch against the authored role.
+- Resolve serial task coverage by authored role, never group name.
+- Preserve roles across persisted-workflow reload.
+
+Pure Arcadia legacy role synthesis remains Cashbot-owned. This SDK change is a
+pre-implemented slice of Cashbot's
+`complete-canonical-workflow-compiler-migration` task 11.3 and does not create
+another compiler or fixture path.

--- a/openspec/changes/require-authored-workflow-group-roles/specs/extract-yaml/spec.md
+++ b/openspec/changes/require-authored-workflow-group-roles/specs/extract-yaml/spec.md
@@ -1,0 +1,38 @@
+# Spec delta: extract-yaml
+
+## ADDED Requirements
+
+### Requirement: canonical workflow processing roles are authored
+
+For a canonical v1 workflow with an `agent_chain`, the SDK SHALL require every
+final group and pseudo group to declare an explicit processing `role`. It SHALL
+use that role for branch validation and serial task coverage. It SHALL NOT infer
+role from group name, task suffix, field vocabulary, or shape.
+
+#### Scenario: renaming a group does not change validation
+
+- **GIVEN** two otherwise identical canonical workflows whose group names differ
+- **AND** their authored roles and agent chains are identical
+- **WHEN** the SDK validates them
+- **THEN** both produce the same result.
+
+#### Scenario: a missing role fails independently of name
+
+- **GIVEN** a canonical workflow group used by an agent chain has no role
+- **WHEN** the SDK validates the workflow
+- **THEN** validation fails whether the group name is `charges`, `fees`, or any
+  other value.
+
+#### Scenario: a parallel branch must match its authored role
+
+- **GIVEN** a parallel branch invokes meter tasks for a group authored with the
+  `charges` role
+- **WHEN** the SDK validates the workflow
+- **THEN** validation fails with the role mismatch.
+
+#### Scenario: persisted reload preserves roles
+
+- **GIVEN** a canonical authored workflow with explicit roles is prepared
+- **WHEN** its persisted workflow mapping is loaded again
+- **THEN** every authored role is preserved
+- **AND** agent-chain validation produces the same result.

--- a/openspec/changes/require-authored-workflow-group-roles/tasks.md
+++ b/openspec/changes/require-authored-workflow-group-roles/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: require authored workflow group roles
+
+## 1. Contract
+
+- [x] 1.1 Require explicit authored roles independently of group names.
+- [x] 1.2 Validate parallel task suffixes against authored roles.
+- [x] 1.3 Resolve serial task coverage by authored role.
+- [x] 1.4 Preserve authored roles through persisted-workflow reload.
+
+## 2. Verification
+
+- [x] 2.1 Add renamed-group regressions for parallel and serial chains.
+- [x] 2.2 Pass focused and full repository tests on a supported Python version.
+- [x] 2.3 Pass the promoted four-case owner replay.
+- [ ] 2.4 Merge PR #78 through normal repository gates and archive this change.

--- a/openspec/specs/custom-output-readback/spec.md
+++ b/openspec/specs/custom-output-readback/spec.md
@@ -231,17 +231,17 @@ matches, the tie resolves to the first parent in stable input order: the
   (2026-08-17 ruling: absence defaults to `first_stable`, the original Arcadia
   tie behavior).
 
-#### Scenario: Ambiguous child matches fail clearly
+#### Scenario: Runtime-only strategy metadata does not change selection
 
 - **GIVEN** one child record matches more than one parent record
 - **AND** the relationship explicitly declares a `multiple_match_strategy`
   other than `first_stable` (rejected at YAML authoring time, but possible on
   an unvalidated runtime packet)
 - **WHEN** the SDK applies relationship metadata
-- **THEN** the helper returns a diagnostic that names the relationship and child
-  record
-- **AND** the child stays in the unmatched child group
-- **AND** it does not silently attach the child to an arbitrary parent.
+- **THEN** the child still attaches to the first matching parent in input order
+- **AND** no ambiguity diagnostic is emitted
+- **AND** authoring validation remains responsible for rejecting the foreign
+  strategy before persistence.
 
 #### Scenario: A declared strategy resolves an exact tie
 
@@ -251,20 +251,15 @@ matches, the tie resolves to the first parent in stable input order: the
 - **THEN** the child attaches to the first matching parent in input order
 - **AND** no ambiguity diagnostic is emitted.
 
-#### Scenario: Ignored passthrough fields are the only fallback
+#### Scenario: Passthrough metadata does not weaken matching
 
 - **GIVEN** relationship metadata declares `parent_passthrough_attrs` that
   overlap `match_attrs`
 - **AND** no parent matches the child on the full populated match-key shape
 - **WHEN** the SDK applies relationship metadata
-- **THEN** the SDK retries comparison with exactly those passthrough attrs
-  removed
-- **AND** the child attaches only when exactly one parent survives that retry
-- **AND** more than one surviving parent leaves the child unmatched without an
-  ambiguity diagnostic
-- **AND** `parent_passthrough_attrs` never changes the outcome of the full
-  match-key pass
-- **AND** removing every match attr, or removing none, performs no retry.
+- **THEN** the SDK performs no fallback comparison
+- **AND** the child remains unmatched
+- **AND** `parent_passthrough_attrs` never changes parent selection.
 
 #### Scenario: Chained relationships create arrays inside arrays
 
@@ -312,18 +307,14 @@ selection = select_relationship_parent(parents, child, relationship)
 - `parents` is an ordered sequence of parent records (mappings), `child` is one
   child record, and `relationship` is the relationship packet.
 - The packet is accepted in persisted snake_case or dispatched camelCase
-  spelling. `match_attrs`/`matchAttrs`,
-  `parent_passthrough_attrs`/`parentPassthroughAttrs`, and
-  `multiple_match_strategy`/`multipleMatchStrategy` are the selection-relevant
-  fields; snake_case wins when both spellings are present.
+  spelling. Only `match_attrs`/`matchAttrs` affects parent selection;
+  snake_case wins when both spellings are present. Other relationship metadata
+  is ignored by the matcher.
 - The return value is the frozen dataclass
   `RelationshipParentSelection(parent, ambiguous)`. `parent` is the selected
-  parent record object itself — identity-preserving, so a caller can map it back
-  to its own domain object — or `None`. `ambiguous` is `True` only for multiple
-  exact candidates under an explicitly declared `multiple_match_strategy`
-  other than `first_stable`; an absent strategy defaults to `first_stable`
-  (2026-08-17 ruling), so undeclared ties select the first parent and are
-  never ambiguous.
+  parent record object itself, identity-preserving so a caller can map it back
+  to its own domain object, or `None`. `ambiguous` is always `False` because
+  exact ties select the first parent in stable input order.
 - The primitive is total: it never raises for unsupported value types.
 - Both names are exported from `groundx.extract`.
 
@@ -334,8 +325,7 @@ selection = select_relationship_parent(parents, child, relationship)
 - **WHEN** it calls `select_relationship_parent(parents, child, relationship)`
 - **THEN** it receives a `RelationshipParentSelection`
 - **AND** `parent` is the selected parent record object or `None`
-- **AND** `ambiguous` distinguishes an unresolved declared-strategy tie from an
-  ordinary no-match
+- **AND** `ambiguous` is `False`
 - **AND** the consumer needs no reassembly, X-Ray, or `Document` state to select.
 
 #### Scenario: One primitive serves every workflow
@@ -346,8 +336,8 @@ selection = select_relationship_parent(parents, child, relationship)
 - **THEN** every case is served by the one exported primitive
 - **AND** reassembly's `_apply_relationships` delegates to it rather than
   matching inline
-- **AND** the selection outcome depends only on the packet's selection-relevant
-  fields and the record values, never on group names, final field names,
+- **AND** the selection outcome depends only on `match_attrs` and the record
+  values, never on other relationship metadata, group names, final field names,
   workflow identity, or compiler provenance.
 
 #### Scenario: Renamed generic workflows select identically
@@ -357,17 +347,14 @@ selection = select_relationship_parent(parents, child, relationship)
 - **WHEN** the same records are selected through both under that rename
 - **THEN** the selected parent and the ambiguity result are the same.
 
-#### Scenario: Retained parent conflicts ride as record siblings
+#### Scenario: Retained parent conflicts do not change selection
 
-- **GIVEN** a parent record carries retained conflict state for a field the
-  passthrough fallback would ignore
+- **GIVEN** a parent record carries retained conflict state for a match field
 - **AND** that state is supplied as the record sibling key `<field>__conflicts`
   holding a list of conflicting values
-- **WHEN** the fallback pass would otherwise accept that parent
-- **THEN** the SDK rejects that parent and leaves the child unmatched
-- **AND** an empty `<field>__conflicts` list does not reject the parent
-- **AND** the convention is read-side only: the SDK consumes
-  `<field>__conflicts` for selection and defines no policy for writing it.
+- **WHEN** the SDK selects a parent
+- **THEN** the conflict sibling does not affect the comparison
+- **AND** selection uses only the populated `match_attrs` values.
 
 #### Scenario: Empty routed values retain non-empty conflict siblings
 
@@ -376,8 +363,7 @@ selection = select_relationship_parent(parents, child, relationship)
 - **WHEN** the SDK reassembles custom output
 - **THEN** it omits the empty field value
 - **AND** it retains the conflict sibling on the same final record
-- **AND** fallback parent selection consumes that sibling exactly as it would
-  when supplied directly.
+- **AND** parent selection ignores that sibling.
 
 ### Requirement: Relationship metadata is prepared and persisted with workflow metadata
 

--- a/src/groundx/extract/prompt/utility.py
+++ b/src/groundx/extract/prompt/utility.py
@@ -1020,7 +1020,7 @@ def _normalize_workflow_template(value: typing.Any) -> typing.Dict[str, str]:
 
 def _normalize_agent_chain(
     value: typing.Any,
-    workflow_groups: typing.Optional[typing.Set[str]] = None,
+    workflow_group_roles: typing.Optional[typing.Mapping[str, str]] = None,
 ) -> typing.Optional[typing.Any]:
     if value is None:
         return None
@@ -1029,13 +1029,27 @@ def _normalize_agent_chain(
     if not value:
         raise ValueError(f"{_CUSTOM_WORKFLOW_KEY}.agent_chain must be a non-empty list")
 
-    _validate_agent_chain(value, workflow_groups or set())
+    _validate_agent_chain(value, workflow_group_roles or {})
     return copy.deepcopy(value)
+
+
+def _workflow_group_roles(
+    workflow_groups: typing.Iterable[str],
+    workflow_group_metadata: typing.Mapping[str, typing.Mapping[str, typing.Any]],
+    authored_group_roles: typing.Mapping[str, str],
+) -> typing.Dict[str, str]:
+    roles: typing.Dict[str, str] = {}
+    for group in workflow_groups:
+        role = authored_group_roles.get(group)
+        if role is None:
+            role = workflow_group_metadata.get(group, {}).get("role")
+        roles[group] = role if isinstance(role, str) else group
+    return roles
 
 
 def _validate_agent_chain(
     raw_chain: typing.List[typing.Any],
-    workflow_groups: typing.Set[str],
+    workflow_group_roles: typing.Mapping[str, str],
 ) -> None:
     first_stage = raw_chain[0]
     if not isinstance(first_stage, dict) or set(first_stage.keys()) != {"parallel"}:
@@ -1076,7 +1090,7 @@ def _validate_agent_chain(
             group = raw_branch["group"]
             if not isinstance(group, str) or not group:
                 raise ValueError(f"{path}.group must be a non-empty string")
-            if group not in workflow_groups:
+            if group not in workflow_group_roles:
                 raise ValueError(f"{path}.group [{group}] is not a workflow group")
             covered_groups.add(group)
 
@@ -1125,7 +1139,7 @@ def _validate_agent_chain(
     _validate_agent_chain_serial_tasks(raw_chain, serial_start_index)
     _validate_agent_chain_group_coverage(
         raw_chain,
-        workflow_groups,
+        workflow_group_roles,
         covered_groups,
         serial_start_index,
     )
@@ -1160,7 +1174,7 @@ def _validate_agent_chain_serial_tasks(
 
 def _validate_agent_chain_group_coverage(
     raw_chain: typing.List[typing.Any],
-    workflow_groups: typing.Set[str],
+    workflow_group_roles: typing.Mapping[str, str],
     branch_covered_groups: typing.Set[str],
     serial_start_index: int,
 ) -> None:
@@ -1170,13 +1184,16 @@ def _validate_agent_chain_group_coverage(
         raw_stage = raw_chain[stage_index]
         if isinstance(raw_stage, str) and raw_stage in _CUSTOM_WORKFLOW_AGENT_CHAIN_AGENT_TASKS:
             suffix = _agent_chain_task_suffix(raw_stage)
-            if suffix in workflow_groups:
-                covered_groups.add(suffix)
+            covered_groups.update(
+                group
+                for group, role in workflow_group_roles.items()
+                if role == suffix
+            )
             stage_index += 2
             continue
         stage_index += 1
 
-    missing_groups = sorted(workflow_groups - covered_groups)
+    missing_groups = sorted(set(workflow_group_roles) - covered_groups)
     if missing_groups:
         raise ValueError(
             f"{_CUSTOM_WORKFLOW_KEY}.agent_chain does not cover workflow groups [{', '.join(missing_groups)}]"
@@ -1830,6 +1847,8 @@ def _custom_workflow_input(
 def _normalize_persisted_custom_workflow_metadata(
     workflow: typing.Dict[str, typing.Any],
     final_group_metadata: typing.Mapping[str, typing.Mapping[str, typing.Any]],
+    workflow_group_metadata: typing.Mapping[str, typing.Mapping[str, typing.Any]],
+    authored_group_roles: typing.Mapping[str, str],
 ) -> typing.Dict[str, typing.Any]:
     version = workflow.get("metadata_version")
     if version != _CUSTOM_WORKFLOW_METADATA_VERSION:
@@ -1872,7 +1891,11 @@ def _normalize_persisted_custom_workflow_metadata(
         metadata["field_counts"] = field_counts
     agent_chain = _normalize_agent_chain(
         workflow.get(_CUSTOM_WORKFLOW_AGENT_CHAIN_KEY),
-        {route["workflow_group"] for route in routes},
+        _workflow_group_roles(
+            {route["workflow_group"] for route in routes},
+            workflow_group_metadata,
+            authored_group_roles,
+        ),
     )
     if agent_chain is not None:
         metadata[_CUSTOM_WORKFLOW_AGENT_CHAIN_KEY] = agent_chain
@@ -2090,6 +2113,7 @@ def _build_authored_custom_workflow_metadata(
     workflow_field_paths: typing.Dict[str, typing.Dict[str, str]],
     pseudo_group_names: typing.Set[str],
     final_group_metadata: typing.Mapping[str, typing.Mapping[str, typing.Any]],
+    authored_group_roles: typing.Mapping[str, str],
 ) -> typing.Dict[str, typing.Any]:
     template = _normalize_workflow_template(workflow.get("template"))
     custom_steps, steps_by_name = _normalize_custom_workflow_steps(workflow.get("custom_steps"), template)
@@ -2157,7 +2181,11 @@ def _build_authored_custom_workflow_metadata(
         metadata["field_counts"] = field_counts
     agent_chain = _normalize_agent_chain(
         workflow.get(_CUSTOM_WORKFLOW_AGENT_CHAIN_KEY),
-        {route["workflow_group"] for route in routes},
+        _workflow_group_roles(
+            {route["workflow_group"] for route in routes},
+            workflow_group_metadata,
+            authored_group_roles,
+        ),
     )
     if agent_chain is not None:
         metadata[_CUSTOM_WORKFLOW_AGENT_CHAIN_KEY] = agent_chain
@@ -2351,6 +2379,12 @@ def prepare_extraction_yaml(
             continue
         raw_groups[group_name] = group_data
 
+    authored_group_roles = {
+        group_name: raw_group["role"]
+        for group_name, raw_group in raw_groups.items()
+        if isinstance(raw_group, dict) and isinstance(raw_group.get("role"), str)
+    }
+
     groups: typing.Dict[str, typing.Dict[str, typing.Any]] = {}
     final_group_metadata: typing.Dict[str, typing.Dict[str, typing.Any]] = {}
     final_workflow_metadata: typing.Dict[str, typing.Dict[str, typing.Any]] = {}
@@ -2384,6 +2418,8 @@ def prepare_extraction_yaml(
             custom_workflow_metadata = _normalize_persisted_custom_workflow_metadata(
                 custom_workflow_input,
                 final_group_metadata,
+                final_workflow_metadata,
+                authored_group_roles,
             )
         else:
             custom_workflow_authoring_input = custom_workflow_input
@@ -2391,6 +2427,14 @@ def prepare_extraction_yaml(
     raw_pseudo_groups: typing.Dict[str, typing.Any] = {}
     if "_pseudo_groups" in data:
         raw_pseudo_groups = _ensure_mapping(data["_pseudo_groups"], "_pseudo_groups")
+        authored_group_roles.update(
+            {
+                group_name: raw_group["role"]
+                for group_name, raw_group in raw_pseudo_groups.items()
+                if isinstance(raw_group, dict)
+                and isinstance(raw_group.get("role"), str)
+            }
+        )
 
     pseudo_groups: typing.Dict[str, typing.Dict[str, typing.Any]] = {}
     workflow_group_metadata: typing.Dict[str, typing.Dict[str, typing.Any]] = {}
@@ -2512,6 +2556,7 @@ def prepare_extraction_yaml(
                 workflow_field_paths,
                 set(),
                 final_group_metadata,
+                authored_group_roles,
             )
             _strip_custom_workflow_authoring_keys(groups)
             _strip_custom_workflow_authoring_keys(workflow_groups)
@@ -2563,6 +2608,7 @@ def prepare_extraction_yaml(
             workflow_field_paths,
             set(pseudo_groups.keys()),
             final_group_metadata,
+            authored_group_roles,
         )
         _strip_custom_workflow_authoring_keys(groups)
         _strip_custom_workflow_authoring_keys(workflow_groups)

--- a/src/groundx/extract/prompt/utility.py
+++ b/src/groundx/extract/prompt/utility.py
@@ -1092,6 +1092,9 @@ def _validate_agent_chain(
                 raise ValueError(f"{path}.group must be a non-empty string")
             if group not in workflow_group_roles:
                 raise ValueError(f"{path}.group [{group}] is not a workflow group")
+            group_role = workflow_group_roles[group]
+            if not group_role:
+                raise ValueError(f"workflow group [{group}] must declare role")
             covered_groups.add(group)
 
             chain = raw_branch["chain"]
@@ -1103,7 +1106,13 @@ def _validate_agent_chain(
             suffixes = {_agent_chain_task_suffix(task) for task in parsed_chain}
             if len(suffixes) != 1:
                 raise ValueError(f"{path}.chain must use one processing suffix")
-            branch_suffixes.append(suffixes.pop())
+            branch_suffix = suffixes.pop()
+            if group_role != branch_suffix:
+                raise ValueError(
+                    f"workflow group [{group}] declares role {group_role} "
+                    f"but its agent chain uses {branch_suffix}"
+                )
+            branch_suffixes.append(branch_suffix)
             branch_terminal_saves.append(parsed_chain[-1] in _CUSTOM_WORKFLOW_AGENT_CHAIN_SAVE_TASKS)
 
         terminal_save = _agent_chain_following_save_task(raw_chain, stage_index)

--- a/src/groundx/extract/prompt/utility.py
+++ b/src/groundx/extract/prompt/utility.py
@@ -1043,7 +1043,7 @@ def _workflow_group_roles(
         role = authored_group_roles.get(group)
         if role is None:
             role = workflow_group_metadata.get(group, {}).get("role")
-        roles[group] = role if isinstance(role, str) else group
+        roles[group] = role if isinstance(role, str) else ""
     return roles
 
 
@@ -1179,6 +1179,9 @@ def _validate_agent_chain_group_coverage(
     serial_start_index: int,
 ) -> None:
     covered_groups = set(branch_covered_groups)
+    for group, role in workflow_group_roles.items():
+        if group not in covered_groups and not role:
+            raise ValueError(f"workflow group [{group}] must declare role")
     stage_index = serial_start_index
     while stage_index < len(raw_chain):
         raw_stage = raw_chain[stage_index]

--- a/tests/extract/prompt/fixtures/extraction_yaml_contract_v1.expected.json
+++ b/tests/extract/prompt/fixtures/extraction_yaml_contract_v1.expected.json
@@ -69,7 +69,8 @@
             "account_number": {
               "path": "/statement/account_number"
             }
-          }
+          },
+          "role": "statement"
         },
         "statement_totals": {
           "fields": {
@@ -79,7 +80,8 @@
           },
           "prompt": {
             "instructions": "Extract only statement total fields."
-          }
+          },
+          "role": "statement"
         }
       },
       "extraction_policy_version": "v1",
@@ -415,9 +417,11 @@
   },
   "workflow_group_metadata": {
     "statement_identity": {
+      "role": "statement",
       "workflow_step": "statement_identity_fields"
     },
     "statement_totals": {
+      "role": "statement",
       "workflow_step": "statement_total_fields"
     }
   },

--- a/tests/extract/prompt/fixtures/extraction_yaml_contract_v1.yaml
+++ b/tests/extract/prompt/fixtures/extraction_yaml_contract_v1.yaml
@@ -61,12 +61,14 @@ statement:
 
 _pseudo_groups:
   statement_identity:
+    role: statement
     workflow_step: statement_identity_fields
     fields:
       account_number:
         path: /statement/account_number
 
   statement_totals:
+    role: statement
     workflow_step: statement_total_fields
     prompt:
       instructions: Extract only statement total fields.

--- a/tests/extract/prompt/fixtures/harness_dialect_persisted_extract.json
+++ b/tests/extract/prompt/fixtures/harness_dialect_persisted_extract.json
@@ -1,5 +1,6 @@
 {
  "widget_summary": {
+  "role": "statement",
   "fields": {
    "widget_code": {
     "prompt": {
@@ -16,6 +17,7 @@
   }
  },
  "gadget_rows": {
+  "role": "meters",
   "fields": {
    "gadget_id": {
     "prompt": {
@@ -270,6 +272,7 @@
    "schema_hash": "b887988dbf6d84d4cf3a106e1e24af1bd4735e6ccaf9008a78b63b5590c23ee1"
   },
   "widget_summary": {
+   "role": "statement",
    "fields": {
     "widget_code": {
      "prompt": {
@@ -286,6 +289,7 @@
    }
   },
   "gadget_rows": {
+   "role": "meters",
    "fields": {
     "gadget_id": {
      "prompt": {

--- a/tests/extract/prompt/test_manager.py
+++ b/tests/extract/prompt/test_manager.py
@@ -1793,6 +1793,7 @@ workflow:
           chain: [reconcile_meters, qa_meters, save_meters]
 
 generic_group_a:
+  role: statement
   workflow_step: generic_step_a
   fields:
     generic_attr_01:
@@ -1802,6 +1803,7 @@ generic_group_a:
         type: str
 
 generic_group_b:
+  role: meters
   workflow_step: generic_step_b
   fields:
     generic_attr_15:

--- a/tests/extract/prompt/test_output_scope.py
+++ b/tests/extract/prompt/test_output_scope.py
@@ -35,6 +35,7 @@ def test_prepare_extraction_yaml_uses_only_output_scope_for_root_placement() -> 
         _workflow_yaml(
             """
 statement_fields:
+  role: statement
   workflow_step: scalar_step
   output_scope: document_root
   fill_rules:
@@ -50,6 +51,7 @@ statement_fields:
             type: str
 
 grouped_statement_fields:
+  role: statement
   workflow_step: scalar_step
   fill_rules:
     - source: total

--- a/tests/extract/prompt/test_yaml_contract_v1.py
+++ b/tests/extract/prompt/test_yaml_contract_v1.py
@@ -108,6 +108,7 @@ workflow:
       - save_statement
 
 statement:
+  role: statement
   workflow_step: statement_fields
   fields:
     account_number:
@@ -134,6 +135,7 @@ workflow:
     - save_statement
 
 statement:
+  role: statement
   workflow_step: statement_fields
   fields:
     account_number:
@@ -166,6 +168,7 @@ workflow:
     - save_statement
 
 statement:
+  role: statement
   workflow_step: statement_fields
   fields:
     account_number:
@@ -201,6 +204,7 @@ workflow:
     - save_statement
 
 statement:
+  role: statement
   workflow_step: statement_fields
   fields:
     account_number:
@@ -230,6 +234,7 @@ workflow:
 {agent_chain}
 
 statement:
+  role: statement
   workflow_step: statement_fields
   fields:
     account_number:
@@ -403,6 +408,68 @@ statement:
         prepare_extraction_yaml(raw)
 
 
+@pytest.mark.parametrize("group_name", ["charges", "fees"])
+def test_parallel_agent_chain_requires_explicit_role_independent_of_group_name(
+    group_name: str,
+) -> None:
+    raw = f"""
+extraction_policy_version: v1
+
+workflow:
+  custom_steps:
+    - name: charge_step
+      level: chunk
+      kind: keys
+  agent_chain:
+    - parallel:
+        - group: {group_name}
+          chain: [reconcile_charges, save_charges]
+
+{group_name}:
+  workflow_step: charge_step
+  fields:
+    amount:
+      workflow_output_key: amount
+      prompt: {{instructions: Return the amount., type: float}}
+"""
+
+    with pytest.raises(
+        ValueError,
+        match=rf"workflow group \[{group_name}\] must declare role",
+    ):
+        prepare_extraction_yaml(raw)
+
+
+def test_parallel_agent_chain_validates_authored_role_not_group_name() -> None:
+    raw = """
+extraction_policy_version: v1
+
+workflow:
+  custom_steps:
+    - name: charge_step
+      level: chunk
+      kind: keys
+  agent_chain:
+    - parallel:
+        - group: fees
+          chain: [reconcile_charges, save_charges]
+
+fees:
+  role: meters
+  workflow_step: charge_step
+  fields:
+    amount:
+      workflow_output_key: amount
+      prompt: {instructions: Return the amount., type: float}
+"""
+
+    with pytest.raises(
+        ValueError,
+        match=r"workflow group \[fees\] declares role meters but its agent chain uses charges",
+    ):
+        prepare_extraction_yaml(raw)
+
+
 def test_agent_chain_rejects_unscheduled_workflow_groups() -> None:
     raw = """
 extraction_policy_version: v1
@@ -425,6 +492,7 @@ workflow:
     - save_statement
 
 statement:
+  role: statement
   workflow_step: statement_fields
   fields:
     account_number:

--- a/tests/extract/prompt/test_yaml_contract_v1.py
+++ b/tests/extract/prompt/test_yaml_contract_v1.py
@@ -358,6 +358,51 @@ generic_group_c:
     )
 
 
+@pytest.mark.parametrize("group_name", ["charges", "fees"])
+def test_agent_chain_requires_explicit_role_independent_of_group_name(
+    group_name: str,
+) -> None:
+    raw = f"""
+extraction_policy_version: v1
+
+workflow:
+  custom_steps:
+    - name: statement_step
+      level: chunk
+      kind: instruct
+    - name: charges_step
+      level: chunk
+      kind: keys
+  agent_chain:
+    - parallel:
+        - group: statement
+          chain: [reconcile_statement, save_statement]
+    - reconcile_charges
+    - save_charges
+
+statement:
+  role: statement
+  workflow_step: statement_step
+  fields:
+    statement_id:
+      workflow_output_key: statement_id
+      prompt: {{instructions: Return the statement ID., type: str}}
+
+{group_name}:
+  workflow_step: charges_step
+  fields:
+    amount:
+      workflow_output_key: amount
+      prompt: {{instructions: Return the amount., type: float}}
+"""
+
+    with pytest.raises(
+        ValueError,
+        match=rf"workflow group \[{group_name}\] must declare role",
+    ):
+        prepare_extraction_yaml(raw)
+
+
 def test_agent_chain_rejects_unscheduled_workflow_groups() -> None:
     raw = """
 extraction_policy_version: v1
@@ -388,6 +433,7 @@ statement:
         instructions: Return the account number.
         type: str
 meters:
+  role: meters
   workflow_step: meter_fields
   fields:
     meter_number:
@@ -396,6 +442,7 @@ meters:
         instructions: Return the meter number.
         type: str
 charges:
+  role: charges
   workflow_step: charge_fields
   fields:
     charge_amount:

--- a/tests/extract/prompt/test_yaml_contract_v1.py
+++ b/tests/extract/prompt/test_yaml_contract_v1.py
@@ -266,6 +266,98 @@ statement:
             prepare_extraction_yaml(base.format(agent_chain=agent_chain))
 
 
+def test_agent_chain_serial_role_covers_renamed_workflow_group() -> None:
+    raw = """
+extraction_policy_version: v1
+
+workflow:
+  custom_steps:
+    - name: generic_step_a
+      level: chunk
+      kind: instruct
+    - name: generic_step_b
+      level: chunk
+      kind: summary
+    - name: generic_step_c
+      level: chunk
+      kind: keys
+  agent_chain:
+    - parallel:
+        - group: generic_group_b
+          chain: [reconcile_meters, qa_meters, save_meters]
+        - group: generic_group_a
+          chain: [reconcile_statement, qa_statement, save_statement]
+    - reconcile_charges
+    - save_charges
+
+generic_group_a:
+  role: statement
+  workflow_step: generic_step_a
+  fields:
+    account_number:
+      workflow_output_key: account_number
+      prompt:
+        instructions: Return the account number.
+        type: str
+
+generic_group_b:
+  role: meters
+  workflow_step: generic_step_b
+  fields:
+    meter_number:
+      workflow_output_key: meter_number
+      prompt:
+        instructions: Return the meter number.
+        type: str
+
+generic_group_c:
+  role: charges
+  workflow_step: generic_step_c
+  fields:
+    charge_amount:
+      workflow_output_key: charge_amount
+      prompt:
+        instructions: Return the charge amount.
+        type: float
+"""
+
+    prepared = prepare_extraction_yaml(raw)
+
+    authored = prepared.persisted_workflow_extract["_groundx_persisted_extract"]
+    assert authored["generic_group_a"]["role"] == "statement"
+    assert authored["generic_group_b"]["role"] == "meters"
+    assert authored["generic_group_c"]["role"] == "charges"
+    assert prepared.persisted_workflow_extract["workflow"]["agent_chain"] == [
+        {
+            "parallel": [
+                {
+                    "group": "generic_group_b",
+                    "chain": ["reconcile_meters", "qa_meters", "save_meters"],
+                },
+                {
+                    "group": "generic_group_a",
+                    "chain": ["reconcile_statement", "qa_statement", "save_statement"],
+                },
+            ]
+        },
+        "reconcile_charges",
+        "save_charges",
+    ]
+
+    reloaded = prepare_extraction_yaml(prepared.persisted_workflow_extract)
+
+    reloaded_authored = reloaded.persisted_workflow_extract[
+        "_groundx_persisted_extract"
+    ]
+    assert reloaded_authored["generic_group_a"]["role"] == "statement"
+    assert reloaded_authored["generic_group_b"]["role"] == "meters"
+    assert reloaded_authored["generic_group_c"]["role"] == "charges"
+    assert (
+        reloaded.persisted_workflow_extract["workflow"]["agent_chain"]
+        == prepared.persisted_workflow_extract["workflow"]["agent_chain"]
+    )
+
+
 def test_agent_chain_rejects_unscheduled_workflow_groups() -> None:
     raw = """
 extraction_policy_version: v1


### PR DESCRIPTION
Canonical v1 workflow groups must declare their authored processing role. Group names are labels and never determine behavior.

## Changes

- Require explicit roles for parallel and serial agent-chain groups.
- Validate authored roles against task suffixes without inventing or rewriting metadata.
- Cover serial groups by authored role instead of literal group name.
- Reject missing roles identically for groups named charges, fees, or anything else.
- Persist explicit roles through authored and stored workflow round trips.
- Update synthetic authored and persisted fixtures to carry their roles.

## Validation

- PYTHONPATH=$PWD/src poetry run pytest -q: 585 passed, 2 skipped, 58 subtests passed.
- PYTHONPATH=$PWD/src poetry run pytest tests/extract/prompt -q: 145 passed, 5 subtests passed.
- Ruff formatting, Ruff checks, and line-ending checks passed.
- All GitHub checks passed on commit 2a6c283.

## Regression protection

- The role tests fail against the previous implementation.
- Parallel and serial groups named charges and fees receive identical missing-role results.
- A renamed serial group is covered through its explicit authored role.
- A role that conflicts with the task suffix is rejected.

## Compatibility

Canonical v1 workflows missing authored roles now fail consistently. Group placement remains controlled only by output_scope. Pure legacy workflows remain unchanged.