### PR TITLE
Fix extraction final answer tool prompt

### DIFF
--- a/src/groundx/extract/agents/agent.py
+++ b/src/groundx/extract/agents/agent.py
@@ -117,8 +117,9 @@ def build_openai_server_model(settings: AgentSettings) -> OpenAIServerModel:
 
 prompt_suffix = (
     "\nReturn exactly one `final_answer` tool call with exactly one argument named `answer`. "
-    "The `answer` value must be a JSON string containing the requested JSON object. Do not include "
-    'any other arguments. Example: {"answer":"{\\"field\\":null}"}\n'
+    "The `answer` value must be a JSON string containing the requested JSON value, which may be an "
+    'object or array. Do not include any other arguments. Object example: {"answer":"{\\"field\\":null}"}. '
+    'Array example: {"answer":"[{\\"field\\":\\"value\\"}]"}.\n'
 )
 
 SUPPORTED_IMAGE_TRANSPORTS = {"pil", "data_url", "remote_url"}

--- a/src/groundx/extract/agents/agent.py
+++ b/src/groundx/extract/agents/agent.py
@@ -115,13 +115,11 @@ def build_openai_server_model(settings: AgentSettings) -> OpenAIServerModel:
     return model
 
 
-prompt_suffix = """
-Return only your response using the `final_answer` tool format:
-
-```json
-{{"answer": {{"type": RESPONSE_HERE, "description": "The final answer to the problem"}}}}
-```
-"""
+prompt_suffix = (
+    "\nReturn exactly one `final_answer` tool call with exactly one argument named `answer`. "
+    "The `answer` value must be a JSON string containing the requested JSON object. Do not include "
+    'any other arguments. Example: {"answer":"{\\"field\\":null}"}\n'
+)
 
 SUPPORTED_IMAGE_TRANSPORTS = {"pil", "data_url", "remote_url"}
 AgentTraceCallback = typing.Callable[[typing.Dict[str, typing.Any]], None]

--- a/tests/extract/agents/test_agent_response_reliability.py
+++ b/tests/extract/agents/test_agent_response_reliability.py
@@ -41,8 +41,9 @@ def test_prompt_suffix_matches_final_answer_tool_schema() -> None:
     }
     assert agent_module.prompt_suffix == (
         "\nReturn exactly one `final_answer` tool call with exactly one argument named `answer`. "
-        "The `answer` value must be a JSON string containing the requested JSON object. Do not include "
-        'any other arguments. Example: {"answer":"{\\"field\\":null}"}\n'
+        "The `answer` value must be a JSON string containing the requested JSON value, which may be an "
+        'object or array. Do not include any other arguments. Object example: {"answer":"{\\"field\\":null}"}. '
+        'Array example: {"answer":"[{\\"field\\":\\"value\\"}]"}.\n'
     )
 
 

--- a/tests/extract/agents/test_agent_response_reliability.py
+++ b/tests/extract/agents/test_agent_response_reliability.py
@@ -5,6 +5,8 @@ import pytest
 try:
     from smolagents import CodeAgent, ToolCallingAgent
     from smolagents.agent_types import AgentText
+    from smolagents.default_tools import FinalAnswerTool
+    from smolagents.models import get_tool_json_schema
 except ModuleNotFoundError:
     pytest.skip("smolagents extra is not installed", allow_module_level=True)
 
@@ -21,6 +23,26 @@ def settings(retries: int) -> AgentSettings:
         max_steps=1,
         response_parse_max_retries=retries,
         imports=[],
+    )
+
+
+def test_prompt_suffix_matches_final_answer_tool_schema() -> None:
+    schema = get_tool_json_schema(FinalAnswerTool())
+
+    assert schema["function"]["parameters"] == {
+        "type": "object",
+        "properties": {
+            "answer": {
+                "type": "string",
+                "description": "The final answer to the problem",
+            }
+        },
+        "required": ["answer"],
+    }
+    assert agent_module.prompt_suffix == (
+        "\nReturn exactly one `final_answer` tool call with exactly one argument named `answer`. "
+        "The `answer` value must be a JSON string containing the requested JSON object. Do not include "
+        'any other arguments. Example: {"answer":"{\\"field\\":null}"}\n'
     )
 
 


### PR DESCRIPTION
## Summary

- Align the extraction prompt with the actual `final_answer` tool schema.
- Require one `answer` string containing the requested JSON object or array.
- Show valid object and array tool-call examples.
- Add a regression test against the installed smolagents schema.

## Why

The current production prompt tells models to send nested `type` and `description` arguments, but the tool accepts one string argument named `answer`. Models can respond with malformed calls and retry until timeout.

The replacement prompt was tested against the current provider endpoints. Bedrock Gemma, DeepInfra Gemma, and OpenAI GPT-5.5 each returned valid object and array results in one `final_answer` call.

## Validation

- Focused contract tests, 8 passed
- Full suite excluding governed intentional-red fixtures, 703 passed, 2 skipped
- `poetry run mypy .`, passed
- Ruff on changed files, passed
- Package build, passed

The protected intentional-red fixture checks remain separate because those fixture packs are not in the repository.

## Release

Publish the next SDK version after merge. Internal Arcadia currently pins 3.9.15 and should update only after the new version is available.
