### PR TITLE
Submit extraction workflow YAML without local compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@ client.ingest(
 
 ## Extraction Workflows
 
-Extraction workflow helpers require the extract extra:
-
-```sh
-pip install "groundx[extract]"
-```
-
 Create or update an extraction workflow directly from a YAML file:
 
 ```python
@@ -69,17 +63,22 @@ client.update_extraction_workflow(
 )
 ```
 
-Load an extraction definition when you need to inspect or reuse settings:
+The SDK sends the YAML unchanged. GroundX validates and compiles it.
 
-```python
-definition = client.load_extraction_definition(path="statement.yaml")
-existing = client.load_extraction_definition(workflow_id="workflow-id")
+Server workflow metadata readback requires the extract extra:
+
+```sh
+pip install "groundx[extract]"
 ```
 
-If `workflow_id` is provided, the SDK loads from that workflow before considering
-YAML inputs. For create/update, pass `path=...` directly for the common case or
-pass `definition=...` when you already loaded one; `definition` takes precedence
-over YAML inputs.
+Load an existing workflow when you need its compiled extraction metadata:
+
+```python
+existing = client.load_extraction_definition_from_workflow("workflow-id")
+```
+
+For create and update, pass exactly one of `path=...` or `yaml_text=...`.
+Compiled definitions, mappings, and prepared objects are not authoring inputs.
 
 Workflow assignment is still explicit. After creating a workflow, assign it to a
 bucket, group, or account with the normal workflow API.

--- a/openspec/changes/retire-local-workflow-compiler/compiler-retirement-inventory.md
+++ b/openspec/changes/retire-local-workflow-compiler/compiler-retirement-inventory.md
@@ -1,0 +1,31 @@
+# Compiler Retirement Inventory
+
+## Authoring boundary
+
+| Former SDK responsibility | Canonical owner and protection |
+| --- | --- |
+| YAML validation and supported shapes | Cashbot `pkg/workflowyaml/compile_rules_test.go` and `canonical_v1_contract_test.go` |
+| Legacy Arcadia synthesis | Cashbot `legacy_synthesis_test.go` |
+| Custom steps, routes, leaf fields, and agent chain | Cashbot `TestCompileWorkflowYAMLRequestBody`, `Test_WorkflowYAML_EndToEndJourney`, and `TestWorkflowYAML_ProductCreateUpdateUsesExplicitOutputScope` |
+| Create, update, readback, idempotence, and source preservation | Cashbot `workflow_test.go` and `workflow_persistence_test.go` YAML journey tests |
+| V1 downgrade and malformed-source rejection | Cashbot workflow handler and compiler rule tests |
+| SDK transport | `test_raw_yaml_workflow_authoring.py` and `test_create_extraction_workflow_sends_only_authored_yaml` |
+
+SDK tests that asserted locally compiled `extract`, `customSteps`,
+`outputRoutes`, `leafFields`, or fixed-step overlays were removed because those
+outputs now belong to Cashbot. Their behavior tests remain in the owning service.
+
+## Remaining compiler consumers
+
+- Internal Arcadia still uses `prepare_extraction_yaml` for local prompt-source
+  loading. Deployed workflow loading already consumes persisted prompts and
+  task metadata without running the authoring compiler.
+- Studio Harness still uses its own compiler for deploy, run, prompt manager,
+  certification diagnostics, fanout, and field coverage.
+- GroundX Python prompt-manager and compiler tests still consume
+  `prepare_extraction_yaml`.
+
+The public compiler and compiler-only types cannot be removed until these
+supported consumers migrate. Raw-YAML create and update are safe now because
+Internal Arcadia PR 125 already calls `workflows.create` and
+`workflows.update` with authored YAML directly.

--- a/openspec/changes/retire-local-workflow-compiler/design.md
+++ b/openspec/changes/retire-local-workflow-compiler/design.md
@@ -1,0 +1,26 @@
+# Design: retire the local workflow compiler
+
+## Boundary
+
+Cashbot is the only authoring compiler. The SDK may read a YAML file or accept
+YAML text, but it sends those bytes to `workflows.create` or
+`workflows.update` without parsing, normalizing, validating, hashing, or
+building execution metadata.
+
+Server workflow readback remains supported. Reassembly and relationship
+selection consume the canonical metadata returned by the server and do not
+derive missing metadata from YAML, names, prompts, or output shape.
+
+## Compatibility
+
+This is an intentional breaking release. Remove definition, mapping, and
+prepared-object authoring inputs instead of retaining a hidden compiled-JSON
+fallback. Remove the public compiler and compiler-only types only after source
+scans show that supported consumers have moved to raw YAML or server metadata.
+
+## Verification
+
+Tests prove byte-preserving sync and async create/update calls, source
+selection errors before API mutation, exact server-metadata readback, and
+unchanged reassembly and stable-first relationship selection. The final
+four-case proof is owned by PR 125 and uses the single governed Harness path.

--- a/openspec/changes/retire-local-workflow-compiler/proposal.md
+++ b/openspec/changes/retire-local-workflow-compiler/proposal.md
@@ -1,0 +1,20 @@
+# Proposal: retire the local workflow compiler
+
+## Why
+
+GroundX Python still compiles authored extraction YAML into execution JSON.
+Cashbot now owns workflow validation, compilation, canonical metadata, and
+schema identity. Keeping both compilers lets identical YAML produce different
+behavior.
+
+## What changes
+
+- Send authored YAML unchanged through workflow create and update helpers.
+- Remove SDK APIs and types that create or reconstruct compiler-owned metadata.
+- Preserve workflow readback, custom-output reassembly, and relationship
+  selection from server-supplied metadata.
+- Release the removal as an explicit breaking SDK change after consumers move
+  to raw-YAML authoring.
+
+This implements the GroundX Python portion of Cashbot's
+`complete-canonical-workflow-compiler-migration` tasks 11.3, 11.6, and 11.9.

--- a/openspec/changes/retire-local-workflow-compiler/specs/extraction-placement/spec.md
+++ b/openspec/changes/retire-local-workflow-compiler/specs/extraction-placement/spec.md
@@ -1,0 +1,24 @@
+# Spec delta: extraction-placement
+
+## MODIFIED Requirements
+
+### Requirement: GroundX Python owns reassembly from canonical metadata
+
+GroundX Python SHALL reassemble X-Ray and custom output from canonical route
+and relationship metadata supplied by the server. It SHALL NOT compile authored
+workflow YAML or reconstruct missing compiler-owned metadata.
+
+#### Scenario: reassembly consumes supplied placement
+
+- **GIVEN** X-Ray custom output and valid server-compiled route metadata
+- **WHEN** GroundX Python reassembles the custom output
+- **THEN** it writes values to the supplied destinations
+- **AND** it does not recalculate placement from group names, roles, prompts,
+  aliases, field policy, values, or path depth.
+
+#### Scenario: relationship selection consumes supplied metadata
+
+- **GIVEN** canonical relationship metadata and ordered parent candidates
+- **WHEN** GroundX Python selects a relationship parent
+- **THEN** it applies the stable-first populated-key algorithm
+- **AND** it does not derive relationship metadata from authored YAML.

--- a/openspec/changes/retire-local-workflow-compiler/specs/extraction-workflow-convenience/spec.md
+++ b/openspec/changes/retire-local-workflow-compiler/specs/extraction-workflow-convenience/spec.md
@@ -1,0 +1,49 @@
+# Spec delta: extraction-workflow-convenience
+
+## ADDED Requirements
+
+### Requirement: extraction workflow authoring submits raw YAML
+
+The Python SDK SHALL send authored YAML unchanged to the workflow API for
+create and update. It SHALL NOT compile, validate, normalize, hash, or derive
+execution metadata from that YAML.
+
+#### Scenario: create preserves YAML bytes
+
+- **GIVEN** authored YAML text or a UTF-8 YAML file
+- **WHEN** a caller creates an extraction workflow
+- **THEN** the generated workflow client receives the exact YAML text
+- **AND** no SDK workflow compiler runs.
+
+#### Scenario: update preserves YAML bytes
+
+- **GIVEN** authored YAML text or a UTF-8 YAML file
+- **WHEN** a caller updates an extraction workflow
+- **THEN** the generated workflow client receives the exact YAML text
+- **AND** no SDK workflow compiler runs.
+
+#### Scenario: authoring accepts one raw source
+
+- **GIVEN** an extraction workflow create or update call
+- **WHEN** neither or both of `path` and `yaml_text` are supplied
+- **THEN** the SDK fails before calling the workflow API.
+
+### Requirement: server workflow metadata remains readable
+
+The Python SDK SHALL preserve server-supplied extraction metadata for readback
+and reassembly without reconstructing authored or compiler-owned metadata.
+
+#### Scenario: workflow readback preserves server metadata
+
+- **GIVEN** a workflow response containing canonical extraction metadata
+- **WHEN** the SDK loads that workflow for readback
+- **THEN** it preserves the response metadata exactly
+- **AND** it does not run an authoring compiler.
+
+## REMOVED Requirements
+
+### Requirement: Python SDK exposes first-class extraction definition loaders
+
+### Requirement: Python SDK exposes extraction workflow create/update helpers
+
+### Requirement: Extraction workflow create/update validates supported shapes

--- a/openspec/changes/retire-local-workflow-compiler/tasks.md
+++ b/openspec/changes/retire-local-workflow-compiler/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: retire the local workflow compiler
+
+## 1. Inventory
+
+- [x] 1.1 Inventory every production and test caller of the compiler,
+      compiler-only types, YAML definition loaders, and authoring helpers.
+- [ ] 1.2 Confirm supported consumers use raw-YAML authoring or server metadata
+      before removing each public surface.
+
+## 2. Raw-YAML authoring
+
+- [x] 2.1 Add failing sync and async tests proving create and update preserve
+      YAML bytes and do not invoke local compilation.
+- [x] 2.2 Make path and YAML-text helpers call the generated workflow client
+      directly, with clear exclusive-source errors.
+- [x] 2.3 Remove compiled definition, mapping, prepared, and workflow-setting
+      overlay authoring inputs.
+
+## 3. Compiler retirement
+
+- [ ] 3.1 Remove persisted-workflow derivation and authored-YAML definition
+      loaders while preserving exact server workflow readback.
+- [ ] 3.2 Remove `prepare_extraction_yaml` and compiler-only public types after
+      all supported callers are migrated.
+- [ ] 3.3 Preserve server-metadata reassembly and stable-first relationship
+      selection without derivation fallbacks.
+
+## 4. Verification and release handoff
+
+- [ ] 4.1 Pass focused tests, full tests, lint, type checks, build, and line
+      endings on the supported Python version.
+- [ ] 4.2 Pass the existing four-case owner replay without changing fixtures,
+      expected outputs, scores, or gates.
+- [ ] 4.3 Open the breaking SDK PR and provide the human release owner with the
+      requested version, merged commit, evidence, and downstream pin changes.
+- [ ] 4.4 After the approved release and final canonical-only certification,
+      archive this change.

--- a/src/groundx/ingest.py
+++ b/src/groundx/ingest.py
@@ -114,6 +114,27 @@ def _select_extraction_definition_loader_source(
     return selected[0]
 
 
+def _read_authored_extraction_yaml(
+    *,
+    path: typing.Any = OMIT,
+    yaml_text: typing.Any = OMIT,
+) -> str:
+    selected = [name for name, value in (("path", path), ("yaml_text", yaml_text)) if value is not OMIT]
+    if len(selected) != 1:
+        if not selected:
+            raise ValueError("expected exactly one source: path, yaml_text")
+        raise ValueError("expected exactly one source from path, yaml_text; received path, yaml_text")
+
+    if path is not OMIT:
+        if not isinstance(path, (str, os.PathLike)):
+            raise TypeError("path must be a string or path-like object")
+        return Path(os.path.expanduser(os.fspath(path))).read_bytes().decode("utf-8")
+
+    if not isinstance(yaml_text, str):
+        raise TypeError("yaml_text must be a string")
+    return yaml_text
+
+
 def get_presigned_url(
     endpoint: str,
     file_name: str,
@@ -450,52 +471,22 @@ class GroundX(GroundXBase):
     def create_extraction_workflow(
         self,
         *,
-        definition: typing.Any = OMIT,
         path: typing.Any = OMIT,
         yaml_text: typing.Any = OMIT,
-        mapping: typing.Any = OMIT,
-        prepared: typing.Any = OMIT,
-        mapping_kind: typing.Optional[str] = None,
         name: typing.Optional[str] = None,
-        chunk_strategy: typing.Any = OMIT,
-        section_strategy: typing.Any = OMIT,
-        steps: typing.Any = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> typing.Any:
         """
-        Create an extraction workflow from a definition or YAML/prepared source.
-
-        Extraction workflow helpers require the extract extra:
-        `pip install groundx[extract]`.
+        Create an extraction workflow from authored YAML.
 
         Parameters
         ----------
-        definition : typing.Any
-            An `ExtractionDefinition` returned by an extraction definition
-            loader.
         path : typing.Any
             Path to an authored extraction YAML file.
         yaml_text : typing.Any
             Authored extraction YAML as a string.
-        mapping : typing.Any
-            Authored YAML-shaped mapping, or a workflow extract mapping when
-            `mapping_kind="workflow_extract"` is set.
-        prepared : typing.Any
-            A `PreparedExtractionYaml` returned by `prepare_extraction_yaml`.
-        mapping_kind : typing.Optional[str]
-            Use `"workflow_extract"` only when `mapping` is an existing workflow
-            extract payload. Existing workflow extracts are structurally
-            validated and preserved without recompiling their authored source.
         name : typing.Optional[str]
             Workflow name. Required for create.
-        chunk_strategy : typing.Any
-            Optional workflow chunk strategy override.
-        section_strategy : typing.Any
-            Optional workflow section strategy override.
-        steps : typing.Any
-            Optional fixed workflow step overlay. When omitted and the
-            definition has custom steps, fixed default extraction steps are
-            disabled.
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration forwarded to the generated workflow
             client.
@@ -515,88 +506,42 @@ class GroundX(GroundXBase):
 
         Notes
         -----
-        This delegates to `client.workflows.create(...)` after loading the
-        extraction definition and copying workflow template/custom-step settings.
-        If `definition` is provided, it takes precedence over YAML/prepared
-        inputs. Otherwise pass exactly one of `path`, `yaml_text`, `mapping`, or
-        `prepared`.
+        Pass exactly one of `path` or `yaml_text`. The SDK sends that authored
+        YAML unchanged to the workflow API. Cashbot owns validation and
+        compilation.
         Assign the returned workflow to a bucket, group, or account explicitly.
         """
-        extraction_workflows = _import_extraction_workflows()
-        resolved = extraction_workflows.resolve_extraction_definition_source(
-            definition=definition,
-            path=path,
-            yaml_text=yaml_text,
-            mapping=mapping,
-            prepared=prepared,
-            mapping_kind=mapping_kind,
-        )
-        kwargs = extraction_workflows.workflow_kwargs_from_extraction_definition(
-            resolved,
+        if not isinstance(name, str) or not name:
+            raise ValueError("workflow name is required")
+        yaml_source = _read_authored_extraction_yaml(path=path, yaml_text=yaml_text)
+        return self.workflows.create(
             name=name,
-            require_name=True,
-            chunk_strategy=chunk_strategy,
-            section_strategy=section_strategy,
-            steps=steps,
+            yaml=yaml_source,
             request_options=request_options,
         )
-        extraction_workflows.ensure_workflow_method_supports_kwargs(
-            self.workflows.create,
-            kwargs,
-        )
-        return self.workflows.create(**kwargs)
 
     def update_extraction_workflow(
         self,
         workflow_id: str,
         *,
-        definition: typing.Any = OMIT,
         path: typing.Any = OMIT,
         yaml_text: typing.Any = OMIT,
-        mapping: typing.Any = OMIT,
-        prepared: typing.Any = OMIT,
-        mapping_kind: typing.Optional[str] = None,
         name: typing.Any = OMIT,
-        chunk_strategy: typing.Any = OMIT,
-        section_strategy: typing.Any = OMIT,
-        steps: typing.Any = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> typing.Any:
         """
-        Update an extraction workflow from a definition or YAML/prepared source.
-
-        Extraction workflow helpers require the extract extra:
-        `pip install groundx[extract]`.
+        Update an extraction workflow from authored YAML.
 
         Parameters
         ----------
         workflow_id : str
             Existing workflow ID to update.
-        definition : typing.Any
-            An `ExtractionDefinition` returned by an extraction definition
-            loader.
         path : typing.Any
             Path to an authored extraction YAML file.
         yaml_text : typing.Any
             Authored extraction YAML as a string.
-        mapping : typing.Any
-            Authored YAML-shaped mapping, or a workflow extract mapping when
-            `mapping_kind="workflow_extract"` is set.
-        prepared : typing.Any
-            A `PreparedExtractionYaml` returned by `prepare_extraction_yaml`.
-        mapping_kind : typing.Optional[str]
-            Use `"workflow_extract"` only when `mapping` is an existing workflow
-            extract payload.
         name : typing.Any
-            Optional workflow name to send with the full update payload.
-        chunk_strategy : typing.Any
-            Optional workflow chunk strategy override.
-        section_strategy : typing.Any
-            Optional workflow section strategy override.
-        steps : typing.Any
-            Optional fixed workflow step overlay. When omitted and the
-            definition has custom steps, fixed default extraction steps are
-            disabled.
+            Optional workflow name.
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration forwarded to the generated workflow
             client.
@@ -616,36 +561,16 @@ class GroundX(GroundXBase):
 
         Notes
         -----
-        Update sends the full extraction workflow settings, not a patch. Pass
-        the YAML or definition again so custom workflow settings are preserved.
-        If `definition` is provided, it takes precedence over YAML/prepared
-        inputs. Otherwise pass exactly one of `path`, `yaml_text`, `mapping`, or
-        `prepared`.
-        The SDK validates only the supplied definition shape here. Stored-state
-        downgrade protection is enforced server-side by the workflow API; this
-        helper does not perform a hidden `workflows.get(...)` preflight read.
+        Pass exactly one of `path` or `yaml_text`. The SDK sends that authored
+        YAML unchanged to the workflow API. Cashbot owns validation and
+        compilation.
         """
-        extraction_workflows = _import_extraction_workflows()
-        resolved = extraction_workflows.resolve_extraction_definition_source(
-            definition=definition,
-            path=path,
-            yaml_text=yaml_text,
-            mapping=mapping,
-            prepared=prepared,
-            mapping_kind=mapping_kind,
-        )
-        kwargs = extraction_workflows.workflow_kwargs_from_extraction_definition(
-            resolved,
-            name=name,
-            chunk_strategy=chunk_strategy,
-            section_strategy=section_strategy,
-            steps=steps,
-            request_options=request_options,
-        )
-        extraction_workflows.ensure_workflow_method_supports_kwargs(
-            self.workflows.update,
-            kwargs,
-        )
+        kwargs: typing.Dict[str, typing.Any] = {
+            "yaml": _read_authored_extraction_yaml(path=path, yaml_text=yaml_text),
+            "request_options": request_options,
+        }
+        if name is not OMIT:
+            kwargs["name"] = name
         return self.workflows.update(workflow_id, **kwargs)
 
     def ingest(
@@ -1275,46 +1200,22 @@ class AsyncGroundX(AsyncGroundXBase):
     async def create_extraction_workflow(
         self,
         *,
-        definition: typing.Any = OMIT,
         path: typing.Any = OMIT,
         yaml_text: typing.Any = OMIT,
-        mapping: typing.Any = OMIT,
-        prepared: typing.Any = OMIT,
-        mapping_kind: typing.Optional[str] = None,
         name: typing.Optional[str] = None,
-        chunk_strategy: typing.Any = OMIT,
-        section_strategy: typing.Any = OMIT,
-        steps: typing.Any = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> typing.Any:
         """
-        Create an extraction workflow from a definition or YAML/prepared source.
+        Create an extraction workflow from authored YAML.
 
         Parameters
         ----------
-        definition : typing.Any
-            An `ExtractionDefinition` returned by an extraction definition
-            loader.
         path : typing.Any
             Path to an authored extraction YAML file.
         yaml_text : typing.Any
             Authored extraction YAML as a string.
-        mapping : typing.Any
-            Authored YAML-shaped mapping, or a workflow extract mapping when
-            `mapping_kind="workflow_extract"` is set.
-        prepared : typing.Any
-            A `PreparedExtractionYaml` returned by `prepare_extraction_yaml`.
-        mapping_kind : typing.Optional[str]
-            Use `"workflow_extract"` only when `mapping` is an existing workflow
-            extract payload.
         name : typing.Optional[str]
             Workflow name. Required for create.
-        chunk_strategy : typing.Any
-            Optional workflow chunk strategy override.
-        section_strategy : typing.Any
-            Optional workflow section strategy override.
-        steps : typing.Any
-            Optional fixed workflow step overlay.
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration forwarded to the generated workflow
             client.
@@ -1331,80 +1232,40 @@ class AsyncGroundX(AsyncGroundXBase):
         ...     name="statement extraction",
         ... )
 
-        If `definition` is provided, it takes precedence over YAML/prepared
-        inputs. Otherwise pass exactly one of `path`, `yaml_text`, `mapping`, or
-        `prepared`.
+        Pass exactly one of `path` or `yaml_text`. Cashbot validates and
+        compiles the unchanged YAML.
         """
-        extraction_workflows = _import_extraction_workflows()
-        resolved = extraction_workflows.resolve_extraction_definition_source(
-            definition=definition,
-            path=path,
-            yaml_text=yaml_text,
-            mapping=mapping,
-            prepared=prepared,
-            mapping_kind=mapping_kind,
-        )
-        kwargs = extraction_workflows.workflow_kwargs_from_extraction_definition(
-            resolved,
+        if not isinstance(name, str) or not name:
+            raise ValueError("workflow name is required")
+        yaml_source = _read_authored_extraction_yaml(path=path, yaml_text=yaml_text)
+        return await self.workflows.create(
             name=name,
-            require_name=True,
-            chunk_strategy=chunk_strategy,
-            section_strategy=section_strategy,
-            steps=steps,
+            yaml=yaml_source,
             request_options=request_options,
         )
-        extraction_workflows.ensure_workflow_method_supports_kwargs(
-            self.workflows.create,
-            kwargs,
-        )
-        return await self.workflows.create(**kwargs)
 
     async def update_extraction_workflow(
         self,
         workflow_id: str,
         *,
-        definition: typing.Any = OMIT,
         path: typing.Any = OMIT,
         yaml_text: typing.Any = OMIT,
-        mapping: typing.Any = OMIT,
-        prepared: typing.Any = OMIT,
-        mapping_kind: typing.Optional[str] = None,
         name: typing.Any = OMIT,
-        chunk_strategy: typing.Any = OMIT,
-        section_strategy: typing.Any = OMIT,
-        steps: typing.Any = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> typing.Any:
         """
-        Update an extraction workflow from a definition or YAML/prepared source.
+        Update an extraction workflow from authored YAML.
 
         Parameters
         ----------
         workflow_id : str
             Existing workflow ID to update.
-        definition : typing.Any
-            An `ExtractionDefinition` returned by an extraction definition
-            loader.
         path : typing.Any
             Path to an authored extraction YAML file.
         yaml_text : typing.Any
             Authored extraction YAML as a string.
-        mapping : typing.Any
-            Authored YAML-shaped mapping, or a workflow extract mapping when
-            `mapping_kind="workflow_extract"` is set.
-        prepared : typing.Any
-            A `PreparedExtractionYaml` returned by `prepare_extraction_yaml`.
-        mapping_kind : typing.Optional[str]
-            Use `"workflow_extract"` only when `mapping` is an existing workflow
-            extract payload.
         name : typing.Any
-            Optional workflow name to send with the full update payload.
-        chunk_strategy : typing.Any
-            Optional workflow chunk strategy override.
-        section_strategy : typing.Any
-            Optional workflow section strategy override.
-        steps : typing.Any
-            Optional fixed workflow step overlay.
+            Optional workflow name.
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration forwarded to the generated workflow
             client.
@@ -1424,35 +1285,15 @@ class AsyncGroundX(AsyncGroundXBase):
 
         Notes
         -----
-        Update sends the full extraction workflow settings, not a patch. If
-        `definition` is provided, it takes precedence over YAML/prepared inputs.
-        Otherwise pass exactly one of `path`, `yaml_text`, `mapping`, or
-        `prepared`.
-        The SDK validates only the supplied definition shape here. Stored-state
-        downgrade protection is enforced server-side by the workflow API; this
-        helper does not perform a hidden `workflows.get(...)` preflight read.
+        Pass exactly one of `path` or `yaml_text`. Cashbot validates and
+        compiles the unchanged YAML.
         """
-        extraction_workflows = _import_extraction_workflows()
-        resolved = extraction_workflows.resolve_extraction_definition_source(
-            definition=definition,
-            path=path,
-            yaml_text=yaml_text,
-            mapping=mapping,
-            prepared=prepared,
-            mapping_kind=mapping_kind,
-        )
-        kwargs = extraction_workflows.workflow_kwargs_from_extraction_definition(
-            resolved,
-            name=name,
-            chunk_strategy=chunk_strategy,
-            section_strategy=section_strategy,
-            steps=steps,
-            request_options=request_options,
-        )
-        extraction_workflows.ensure_workflow_method_supports_kwargs(
-            self.workflows.update,
-            kwargs,
-        )
+        kwargs: typing.Dict[str, typing.Any] = {
+            "yaml": _read_authored_extraction_yaml(path=path, yaml_text=yaml_text),
+            "request_options": request_options,
+        }
+        if name is not OMIT:
+            kwargs["name"] = name
         return await self.workflows.update(workflow_id, **kwargs)
 
     async def ingest(

--- a/tests/custom/test_extraction_workflow_client_exports.py
+++ b/tests/custom/test_extraction_workflow_client_exports.py
@@ -63,7 +63,7 @@ def test_extraction_workflow_helpers_have_method_level_docstrings() -> None:
 
     update_doc = inspect.getdoc(GroundX.update_extraction_workflow)
     assert update_doc is not None
-    assert "full extraction workflow settings" in update_doc
+    assert "Cashbot owns validation" in update_doc
 
 
 def test_base_groundx_import_does_not_import_extract_optional_dependencies() -> None:
@@ -139,7 +139,7 @@ def test_extraction_methods_raise_install_hint_when_extract_extra_is_missing(
         client.load_extraction_definition_from_yaml(yaml_text=CUSTOM_WORKFLOW_YAML)
 
 
-def test_create_extraction_workflow_sends_custom_steps_after_generated_client_release() -> None:
+def test_create_extraction_workflow_sends_only_authored_yaml() -> None:
     captured: typing.List[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -167,12 +167,7 @@ def test_create_extraction_workflow_sends_custom_steps_after_generated_client_re
 
     assert len(captured) == 1
     payload = _request_json(captured[0])
-    assert payload["customSteps"][0]["name"] == "line_item_labels"
-    assert payload["customSteps"][0]["requiredTemplateKeys"] == ["{{LANGUAGE}}"]
-    assert payload["template"] == {
-        "{{LANGUAGE}}": "English",
-        "{{LANGUAGE_UNKNOWN}}": "",
+    assert payload == {
+        "name": "statement extraction",
+        "yaml": CUSTOM_WORKFLOW_YAML,
     }
-    assert payload["steps"]["chunk-keys"] is None
-    assert payload["outputRoutes"][0]["stepName"] == "line_item_labels"
-    assert payload["leafFields"][0]["stepName"] == "line_item_labels"

--- a/tests/extract/prompt/test_yaml_contract_v1.py
+++ b/tests/extract/prompt/test_yaml_contract_v1.py
@@ -1,36 +1,13 @@
 import json
 from pathlib import Path
-import typing
 
 import pytest
 
-from groundx import GroundX
 from groundx.extract import prepare_extraction_yaml
-
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
 CONTRACT_YAML = FIXTURE_DIR / "extraction_yaml_contract_v1.yaml"
 EXPECTED_JSON = FIXTURE_DIR / "extraction_yaml_contract_v1.expected.json"
-
-
-class RecordingWorkflows:
-    def __init__(self, response: typing.Any = None) -> None:
-        self.response = response
-        self.calls: typing.List[typing.Tuple[typing.Any, ...]] = []
-
-    def create(self, **kwargs: typing.Any) -> str:
-        self.calls.append(("create", kwargs))
-        return "created"
-
-    def update(self, id: str, **kwargs: typing.Any) -> str:
-        self.calls.append(("update", id, kwargs))
-        return "updated"
-
-
-def _client(workflows: RecordingWorkflows) -> GroundX:
-    client = GroundX.__new__(GroundX)
-    typing.cast(typing.Any, client)._workflows = workflows
-    return client
 
 
 def test_contract_fixture_compiles_to_expected_payload() -> None:
@@ -69,26 +46,6 @@ def test_pseudo_groups_create_custom_workflow_routes_and_preserve_agent_chain() 
     ]
     assert "workflow_step" not in authored["_pseudo_groups"]["statement_identity"]
     assert "workflow_output_key" not in json.dumps(authored)
-
-
-def test_create_update_persist_agent_chain_only_inside_extract() -> None:
-    workflows = RecordingWorkflows()
-    client = _client(workflows)
-
-    client.create_extraction_workflow(path=CONTRACT_YAML, name="statement extraction")
-    client.update_extraction_workflow(
-        "workflow-1",
-        path=CONTRACT_YAML,
-        name="statement extraction",
-    )
-
-    create_kwargs = workflows.calls[0][1]
-    update_kwargs = workflows.calls[1][2]
-    for kwargs in (create_kwargs, update_kwargs):
-        assert "agent_chain" not in kwargs
-        assert kwargs["extract"]["workflow"]["agent_chain"] == (
-            kwargs["extract"]["_groundx_persisted_extract"]["workflow"]["agent_chain"]
-        )
 
 
 def test_agent_chain_rejects_map_shape() -> None:
@@ -181,9 +138,7 @@ statement:
     with pytest.raises(ValueError, match="missing.*is not a workflow group"):
         prepare_extraction_yaml(unknown_group)
 
-    unknown_task = unknown_group.replace(
-        "reconcile_statement", "unknown_task"
-    ).replace("missing", "statement")
+    unknown_task = unknown_group.replace("reconcile_statement", "unknown_task").replace("missing", "statement")
     with pytest.raises(ValueError, match="unsupported task"):
         prepare_extraction_yaml(unknown_task)
 
@@ -351,9 +306,7 @@ generic_group_c:
 
     reloaded = prepare_extraction_yaml(prepared.persisted_workflow_extract)
 
-    reloaded_authored = reloaded.persisted_workflow_extract[
-        "_groundx_persisted_extract"
-    ]
+    reloaded_authored = reloaded.persisted_workflow_extract["_groundx_persisted_extract"]
     assert reloaded_authored["generic_group_a"]["role"] == "statement"
     assert reloaded_authored["generic_group_b"]["role"] == "meters"
     assert reloaded_authored["generic_group_c"]["role"] == "charges"

--- a/tests/extract/test_extraction_workflow_definitions.py
+++ b/tests/extract/test_extraction_workflow_definitions.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 import yaml
-from .prompt._fixtures import SAMPLE_YAML_1
 
 from groundx import AsyncGroundX, GroundX
 from groundx.core.request_options import RequestOptions
@@ -45,28 +44,6 @@ line_items:
         identifiers:
           - Description
         instructions: Return the printed line-item description.
-        type: str
-"""
-
-INVALID_TOP_LEVEL_METADATA_YAML = """
-unsupported_policy_version: v1
-statement:
-  fields:
-    account_number:
-      prompt:
-        instructions: Return the account number.
-        type: str
-"""
-
-POLICY_METADATA_YAML = """
-extraction_policy_version: v1
-statement:
-  explanation_attrs:
-    - account_number
-  fields:
-    account_number:
-      prompt:
-        instructions: Return the account number.
         type: str
 """
 
@@ -228,17 +205,6 @@ def _step_value(value: typing.Any, field: str) -> typing.Any:
     if isinstance(value, dict):
         return typing.cast(typing.Dict[str, typing.Any], value)[field]
     return getattr(value, field)
-
-
-def _model_to_alias_dict(value: typing.Any) -> typing.Dict[str, typing.Any]:
-    if isinstance(value, dict):
-        return typing.cast(typing.Dict[str, typing.Any], value)
-    if hasattr(value, "dict"):
-        return typing.cast(typing.Dict[str, typing.Any], value.dict())
-    return typing.cast(
-        typing.Dict[str, typing.Any],
-        value.model_dump(by_alias=True, exclude_none=False),
-    )
 
 
 def _find_mapping_keys(
@@ -669,72 +635,7 @@ def test_prepare_adp_persisted_source_preserves_runtime_metadata() -> None:
     assert prepared.workflow_group_metadata["adp_f1_employer_and_plan_information"]["role"] == "statement"
 
 
-def test_create_and_update_use_definition_before_yaml_sources() -> None:
-    client = _client(RecordingWorkflows())
-    definition = client.load_extraction_definition_from_yaml(yaml_text=CUSTOM_WORKFLOW_YAML)
-
-    assert (
-        client.create_extraction_workflow(
-            definition=definition,
-            yaml_text="not: [valid",
-            name="statement extraction",
-        )
-        == "created"
-    )
-    assert (
-        client.update_extraction_workflow(
-            "workflow-1",
-            definition=definition,
-            yaml_text="not: [valid",
-            name="statement extraction",
-        )
-        == "updated"
-    )
-
-    assert client.workflows.calls[0][1]["extract"] == definition.extract
-    assert client.workflows.calls[1][2]["extract"] == definition.extract
-
-
-def test_create_and_update_reject_mapping_kind_with_definition() -> None:
-    client = _client(RecordingWorkflows())
-    definition = client.load_extraction_definition_from_yaml(yaml_text=CUSTOM_WORKFLOW_YAML)
-
-    with pytest.raises(ValueError, match="mapping_kind"):
-        client.create_extraction_workflow(
-            definition=definition,
-            mapping_kind="workflow_extract",
-            name="statement extraction",
-        )
-
-    with pytest.raises(ValueError, match="mapping_kind"):
-        client.update_extraction_workflow(
-            "workflow-1",
-            definition=definition,
-            mapping_kind="workflow_extract",
-            name="statement extraction",
-        )
-
-
-def test_create_and_update_reject_missing_or_ambiguous_yaml_sources() -> None:
-    client = _client(RecordingWorkflows())
-
-    with pytest.raises(ValueError, match="exactly one"):
-        client.create_extraction_workflow(name="statement extraction")
-    with pytest.raises(ValueError, match="path.*yaml_text|yaml_text.*path"):
-        client.create_extraction_workflow(
-            path="statement.yaml",
-            yaml_text=CUSTOM_WORKFLOW_YAML,
-            name="statement extraction",
-        )
-    with pytest.raises(ValueError, match="mapping_kind"):
-        client.create_extraction_workflow(
-            yaml_text=CUSTOM_WORKFLOW_YAML,
-            mapping_kind="workflow_extract",
-            name="statement extraction",
-        )
-
-
-def test_create_and_update_forward_workflow_settings_and_request_options() -> None:
+def test_create_and_update_forward_raw_yaml_and_request_options() -> None:
     workflows = RecordingWorkflows()
     client = _client(workflows)
     request_options: RequestOptions = {"timeout_in_seconds": 1}
@@ -764,168 +665,10 @@ def test_create_and_update_forward_workflow_settings_and_request_options() -> No
     assert create_kwargs["request_options"] is request_options
     assert update_kwargs["name"] == "statement extraction"
     assert update_kwargs["request_options"] is request_options
-    assert create_kwargs["template"] == {
-        "{{LANGUAGE}}": "English",
-        "{{LANGUAGE_UNKNOWN}}": "",
-    }
-    assert create_kwargs["extract"]["workflow"]["template"] == {
-        "{{LANGUAGE}}": "English",
-        "{{LANGUAGE_UNKNOWN}}": "",
-    }
-    assert create_kwargs["custom_steps"][0]["name"] == "line_item_labels"
-    assert create_kwargs["output_routes"][0]["output_key"] == "label"
-    assert create_kwargs["leaf_fields"][0]["field_type"] == "str"
-    assert update_kwargs["extract"] == create_kwargs["extract"]
-
-
-def test_create_and_update_accept_yaml_path_shortcut(tmp_path: Path) -> None:
-    path = tmp_path / "statement.yaml"
-    path.write_text(CUSTOM_WORKFLOW_YAML)
-    workflows = RecordingWorkflows()
-    client = _client(workflows)
-
-    assert (
-        client.create_extraction_workflow(
-            path=path,
-            name="statement extraction",
-        )
-        == "created"
-    )
-    assert (
-        client.update_extraction_workflow(
-            "workflow-1",
-            path=path,
-            name="statement extraction",
-        )
-        == "updated"
-    )
-
-    create_kwargs = workflows.calls[0][1]
-    update_kwargs = workflows.calls[1][2]
-    assert create_kwargs["extract"] == update_kwargs["extract"]
-    assert create_kwargs["template"] == {
-        "{{LANGUAGE}}": "English",
-        "{{LANGUAGE_UNKNOWN}}": "",
-    }
-
-
-def test_create_and_update_yaml_path_errors_include_source_context(
-    tmp_path: Path,
-) -> None:
-    path = tmp_path / "statement.yaml"
-    path.write_text(INVALID_TOP_LEVEL_METADATA_YAML)
-    workflows = RecordingWorkflows()
-    client = _client(workflows)
-
-    with pytest.raises(ValueError) as create_exc:
-        client.create_extraction_workflow(
-            path=path,
-            name="statement extraction",
-        )
-
-    create_message = str(create_exc.value)
-    assert str(path) in create_message
-    assert "unsupported top-level metadata [unsupported_policy_version]" in create_message
-
-    with pytest.raises(ValueError) as update_exc:
-        client.update_extraction_workflow(
-            "workflow-1",
-            path=path,
-            name="statement extraction",
-        )
-
-    update_message = str(update_exc.value)
-    assert str(path) in update_message
-    assert "unsupported top-level metadata [unsupported_policy_version]" in update_message
-    assert workflows.calls == []
-
-
-@pytest.mark.asyncio
-async def test_async_create_and_update_yaml_path_accept_supported_policy_metadata(
-    tmp_path: Path,
-) -> None:
-    path = tmp_path / "statement.yaml"
-    path.write_text(POLICY_METADATA_YAML)
-    workflows = AsyncRecordingWorkflows()
-    client = _async_client(workflows)
-
-    assert (
-        await client.create_extraction_workflow(
-            path=path,
-            name="statement extraction",
-        )
-        == "created"
-    )
-    assert (
-        await client.update_extraction_workflow(
-            "workflow-1",
-            path=path,
-            name="statement extraction",
-        )
-        == "updated"
-    )
-
-    create_extract = workflows.calls[0][1]["extract"]
-    update_extract = workflows.calls[1][2]["extract"]
-    assert create_extract == update_extract
-    assert create_extract["_groundx_persisted_extract"]["extraction_policy_version"] == "v1"
-
-
-def test_create_and_update_yaml_path_accept_supported_policy_metadata(
-    tmp_path: Path,
-) -> None:
-    path = tmp_path / "statement.yaml"
-    path.write_text(POLICY_METADATA_YAML)
-    workflows = RecordingWorkflows()
-    client = _client(workflows)
-
-    assert (
-        client.create_extraction_workflow(
-            path=path,
-            name="statement extraction",
-        )
-        == "created"
-    )
-    assert (
-        client.update_extraction_workflow(
-            "workflow-1",
-            path=path,
-            name="statement extraction",
-        )
-        == "updated"
-    )
-
-    create_extract = workflows.calls[0][1]["extract"]
-    update_extract = workflows.calls[1][2]["extract"]
-    assert create_extract == update_extract
-    assert create_extract["_groundx_persisted_extract"]["extraction_policy_version"] == "v1"
-
-
-def test_create_and_update_accept_legacy_yaml_without_preflight() -> None:
-    workflows = RecordingWorkflows()
-    client = _client(workflows)
-
-    assert (
-        client.create_extraction_workflow(
-            yaml_text=SAMPLE_YAML_1,
-            name="legacy extraction",
-        )
-        == "created"
-    )
-    assert (
-        client.update_extraction_workflow(
-            "workflow-1",
-            yaml_text=SAMPLE_YAML_1,
-        )
-        == "updated"
-    )
-
-    assert [call[0] for call in workflows.calls] == ["create", "update"]
-    create_extract = workflows.calls[0][1]["extract"]
-    update_extract = workflows.calls[1][2]["extract"]
-    assert "workflow" not in create_extract
-    assert "_groundx_persisted_extract" not in create_extract
-    assert update_extract == create_extract
+    assert create_kwargs["yaml"] == CUSTOM_WORKFLOW_YAML
+    assert update_kwargs["yaml"] == CUSTOM_WORKFLOW_YAML
+    assert set(create_kwargs) == {"name", "yaml", "request_options"}
+    assert set(update_kwargs) == {"name", "yaml", "request_options"}
 
 
 def test_update_helper_exposes_no_client_side_downgrade_option() -> None:
@@ -952,29 +695,8 @@ def test_create_requires_name_but_update_can_omit_name() -> None:
     assert "name" not in workflows.calls[0][2]
 
 
-def test_custom_steps_disable_exact_fixed_default_overlay() -> None:
-    workflows = RecordingWorkflows()
-    client = _client(workflows)
-
-    client.create_extraction_workflow(
-        yaml_text=CUSTOM_WORKFLOW_YAML,
-        name="statement extraction",
-    )
-
-    steps = workflows.calls[0][1]["steps"]
-    assert _model_to_alias_dict(steps) == {
-        "chunk-instruct": None,
-        "chunk-keys": None,
-        "chunk-summary": None,
-        "doc-keys": None,
-        "doc-summary": None,
-        "sect-instruct": None,
-        "sect-summary": None,
-    }
-
-
 @pytest.mark.asyncio
-async def test_async_methods_match_sync_source_loading_and_forwarding() -> None:
+async def test_async_workflow_readback_preserves_server_metadata() -> None:
     response = WorkflowResponse(
         workflow=WorkflowDetail(
             workflow_id="workflow-1",
@@ -986,68 +708,15 @@ async def test_async_methods_match_sync_source_loading_and_forwarding() -> None:
     client = _async_client(workflows)
     request_options: RequestOptions = {"timeout_in_seconds": 1}
 
-    definition = await client.load_extraction_definition_from_yaml(yaml_text=CUSTOM_WORKFLOW_YAML)
-    direct_definition = await client.load_extraction_definition(yaml_text=CUSTOM_WORKFLOW_YAML)
-    workflow_definition = await client.load_extraction_definition(
-        workflow_id="workflow-1",
-        yaml_text="not: [valid",
-        request_options=request_options,
-    )
-    from_workflow = await client.load_extraction_definition_from_workflow(
+    definition = await client.load_extraction_definition_from_workflow(
         "workflow-1",
         request_options=request_options,
     )
-    created = await client.create_extraction_workflow(
-        definition=definition,
-        yaml_text="not: [valid",
-        name="statement extraction",
-        request_options=request_options,
-    )
-    updated = await client.update_extraction_workflow(
-        "workflow-1",
-        definition=from_workflow,
-        yaml_text="not: [valid",
-        request_options=request_options,
-    )
 
-    assert created == "created"
-    assert updated == "updated"
-    assert workflows.calls[0] == ("get", "workflow-1", request_options)
-    assert workflows.calls[1] == ("get", "workflow-1", request_options)
-    assert workflows.calls[2][1]["request_options"] is request_options
-    assert workflows.calls[3][2]["request_options"] is request_options
-    assert workflows.calls[2][1]["template"]["{{LANGUAGE_UNKNOWN}}"] == ""
-    assert direct_definition.extract == definition.extract
-    assert workflow_definition.extract == from_workflow.extract
-
-
-@pytest.mark.asyncio
-async def test_async_create_and_update_yaml_path_errors_include_source_context(
-    tmp_path: Path,
-) -> None:
-    path = tmp_path / "statement.yaml"
-    path.write_text(INVALID_TOP_LEVEL_METADATA_YAML)
-    workflows = AsyncRecordingWorkflows()
-    client = _async_client(workflows)
-
-    with pytest.raises(ValueError) as create_exc:
-        await client.create_extraction_workflow(
-            path=path,
-            name="statement extraction",
-        )
-
-    create_message = str(create_exc.value)
-    assert str(path) in create_message
-    assert "unsupported top-level metadata [unsupported_policy_version]" in create_message
-
-    with pytest.raises(ValueError) as update_exc:
-        await client.update_extraction_workflow(
-            "workflow-1",
-            path=path,
-            name="statement extraction",
-        )
-
-    update_message = str(update_exc.value)
-    assert str(path) in update_message
-    assert "unsupported top-level metadata [unsupported_policy_version]" in update_message
-    assert workflows.calls == []
+    assert workflows.calls == [("get", "workflow-1", request_options)]
+    assert definition.extract == EXECUTION_ONLY_EXTRACT
+    assert definition.template == {
+        "{{LANGUAGE}}": "English",
+        "{{LANGUAGE_UNKNOWN}}": "",
+    }
+    assert definition.prepared is None

--- a/tests/extract/test_raw_yaml_workflow_authoring.py
+++ b/tests/extract/test_raw_yaml_workflow_authoring.py
@@ -1,0 +1,123 @@
+import asyncio
+import typing
+from pathlib import Path
+
+import pytest
+
+from groundx import AsyncGroundX, GroundX
+
+
+class RecordingWorkflows:
+    def __init__(self) -> None:
+        self.calls: list[tuple[typing.Any, ...]] = []
+
+    def create(self, **kwargs: typing.Any) -> str:
+        self.calls.append(("create", kwargs))
+        return "created"
+
+    def update(self, workflow_id: str, **kwargs: typing.Any) -> str:
+        self.calls.append(("update", workflow_id, kwargs))
+        return "updated"
+
+
+class AsyncRecordingWorkflows:
+    def __init__(self) -> None:
+        self.calls: list[tuple[typing.Any, ...]] = []
+
+    async def create(self, **kwargs: typing.Any) -> str:
+        self.calls.append(("create", kwargs))
+        return "created"
+
+    async def update(self, workflow_id: str, **kwargs: typing.Any) -> str:
+        self.calls.append(("update", workflow_id, kwargs))
+        return "updated"
+
+
+def _client(workflows: RecordingWorkflows) -> GroundX:
+    client = GroundX.__new__(GroundX)
+    typing.cast(typing.Any, client)._workflows = workflows
+    return client
+
+
+def _async_client(workflows: AsyncRecordingWorkflows) -> AsyncGroundX:
+    client = AsyncGroundX.__new__(AsyncGroundX)
+    typing.cast(typing.Any, client)._workflows = workflows
+    return client
+
+
+def test_create_extraction_workflow_passes_yaml_text_unchanged() -> None:
+    workflows = RecordingWorkflows()
+    raw_yaml = "not: [locally valid\n"
+
+    result = _client(workflows).create_extraction_workflow(
+        name="raw workflow",
+        yaml_text=raw_yaml,
+    )
+
+    assert result == "created"
+    assert workflows.calls == [("create", {"name": "raw workflow", "yaml": raw_yaml, "request_options": None})]
+
+
+def test_update_extraction_workflow_reads_path_without_rewriting(tmp_path: Path) -> None:
+    workflows = RecordingWorkflows()
+    raw_yaml = "statement:\n  fields: {}\n# preserve trailing comment\n"
+    source = tmp_path / "workflow.yaml"
+    source.write_text(raw_yaml, encoding="utf-8")
+
+    result = _client(workflows).update_extraction_workflow(
+        "workflow-1",
+        path=source,
+    )
+
+    assert result == "updated"
+    assert workflows.calls == [("update", "workflow-1", {"yaml": raw_yaml, "request_options": None})]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"path": "workflow.yaml", "yaml_text": "statement: {}\n"},
+    ],
+)
+def test_extraction_workflow_authoring_requires_one_raw_source(
+    kwargs: dict[str, typing.Any],
+) -> None:
+    workflows = RecordingWorkflows()
+
+    with pytest.raises(ValueError, match="exactly one.*path, yaml_text"):
+        _client(workflows).create_extraction_workflow(name="raw workflow", **kwargs)
+
+    assert workflows.calls == []
+
+
+def test_async_extraction_workflow_authoring_passes_yaml_unchanged() -> None:
+    async def run() -> None:
+        workflows = AsyncRecordingWorkflows()
+        raw_yaml = "not: [locally valid\n"
+        client = _async_client(workflows)
+
+        created = await client.create_extraction_workflow(
+            name="raw workflow",
+            yaml_text=raw_yaml,
+        )
+        updated = await client.update_extraction_workflow(
+            "workflow-1",
+            yaml_text=raw_yaml,
+        )
+
+        assert created == "created"
+        assert updated == "updated"
+        assert workflows.calls == [
+            (
+                "create",
+                {"name": "raw workflow", "yaml": raw_yaml, "request_options": None},
+            ),
+            (
+                "update",
+                "workflow-1",
+                {"yaml": raw_yaml, "request_options": None},
+            ),
+        ]
+
+    asyncio.run(run())


### PR DESCRIPTION
## Why

Cashbot owns workflow validation, compilation, canonical metadata, and schema identity. The SDK authoring helpers still built compiled execution JSON locally, creating a second behavior path.

## What changed

- create and update accept one YAML path or YAML string and submit it unchanged
- compiled definitions, mappings, prepared objects, and workflow-setting overlays are no longer authoring inputs
- server-metadata readback, reassembly, and relationship selection remain unchanged
- SDK compiler-owned assertions were removed only where equivalent behavior is protected in Cashbot; transport and async readback regressions remain

This is an intentional breaking SDK change and is stacked on PR #78. Do not merge or release it until supported compiler consumers migrate and the canonical-only four-case gate passes.

## Evidence

- `579 passed, 2 skipped, 58 subtests passed`
- changed-file Ruff and format checks passed
- mypy passed for 260 source files
- wheel and sdist built
- OpenSpec validation and line-ending checks passed