### PR TITLE
Deprecate the local authoring surface for the compiler migration

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,5 +1,6 @@
 # Specify files that shouldn't be modified by Fern
 README.md
+CHANGELOG.md
 CONTRIBUTING.md
 AGENTS.md
 src/groundx/ingest.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+Hand-written SDK surface changes. Generated releases are produced from
+[`eyelevel-fern-config`](https://github.com/eyelevelai/eyelevel-fern-config).
+
+## Unreleased
+
+### Deprecated
+
+- `groundx.extract.prepare_extraction_yaml` (and its re-export from
+  `groundx.extract.prompt`). Calling it emits a `DeprecationWarning`. Cashbot
+  owns workflow validation and compilation: submit authored YAML unchanged
+  with `create_extraction_workflow`/`update_extraction_workflow` and read
+  workflows back with `load_extraction_definition_from_workflow`.
+- Loading authored YAML sources (`path`, `yaml_text`, or an authored mapping)
+  through `load_extraction_definition` / `load_extraction_definition_from_yaml`
+  runs the deprecated local compiler and emits the same `DeprecationWarning`.
+  Workflow readback and `mapping_kind="workflow_extract"` loading do not warn
+  and remain supported.
+- The relationship-packet spellings `parent_passthrough_attrs` /
+  `parentPassthroughAttrs` and `multiple_match_strategy` /
+  `multipleMatchStrategy` are compatibility-only transport aliases on
+  historical packets. `select_relationship_parent` and custom-output
+  reassembly accept and ignore them; they never change parent selection
+  (see `openspec/specs/custom-output-readback/spec.md`). Canonical packets
+  omit both fields.
+
+## Planned breaking release (not shipped)
+
+The next breaking GroundX Python release removes the deprecated local
+authoring surface. Nothing below is removed yet; this section is the removal
+plan for `openspec/changes/retire-local-workflow-compiler` (Cashbot
+`complete-canonical-workflow-compiler-migration` tasks 11.3/11.6), gated on
+supported consumers migrating to raw-YAML authoring or server metadata.
+
+### To be removed
+
+- `prepare_extraction_yaml` and the compiler-only `PreparedExtractionYaml`
+  type.
+- Authored-YAML extraction definition loading: the `path`, `yaml_text`,
+  `mapping` (authored), and `prepared` sources of `load_extraction_definition`
+  and `load_extraction_definition_from_yaml`, plus the unused compiled
+  authoring helpers in `groundx.extract.workflows`
+  (`workflow_kwargs_from_extraction_definition`,
+  `ensure_workflow_method_supports_kwargs`, `disabled_fixed_default_steps`).
+
+### To be preserved
+
+- Raw-YAML `create_extraction_workflow` / `update_extraction_workflow`.
+- Server workflow readback (`load_extraction_definition_from_workflow`) and
+  `mapping_kind="workflow_extract"` loading without recompilation.
+- Custom-output reassembly and `select_relationship_parent` consuming
+  server-supplied canonical metadata, including the accepted-and-ignored
+  handling of the historical relationship-packet spellings above.

--- a/openspec/specs/extraction-placement/spec.md
+++ b/openspec/specs/extraction-placement/spec.md
@@ -12,8 +12,8 @@ and authored final JSON placement.
 
 GroundX Python SHALL own its hand-written extraction YAML parser/compiler
 behavior and keep the resulting route metadata in parity with the canonical
-production compiler and the supported Harness fallback. GroundX Python SHALL
-also own production X-Ray/custom-output reassembly from compiled route metadata.
+production compiler. GroundX Python SHALL also own production
+X-Ray/custom-output reassembly from compiled route metadata.
 
 This ownership does not make the SDK the product YAML upload compiler. It makes
 the SDK responsible for accepting the supported authored contract, producing

--- a/src/groundx/extract/custom_outputs.py
+++ b/src/groundx/extract/custom_outputs.py
@@ -116,9 +116,7 @@ _EXTRACTED_FIELD_VALUE_KEYS = {"value", "_raw_text", "confidence", "conflicts", 
 _CONFLICTS_SIBLING_SUFFIX = "__conflicts"
 _RELATIONSHIP_PACKET_CAMEL_KEYS = {
     "match_attrs": "matchAttrs",
-    # Deprecated transport spellings kept for historical packets only: both
-    # fields are accepted and ignored, never honored, and are removed from
-    # canonical selector behavior by the compiler migration.
+    # Historical packet aliases are accepted but ignored.
     "parent_passthrough_attrs": "parentPassthroughAttrs",
     "multiple_match_strategy": "multipleMatchStrategy",
 }

--- a/src/groundx/extract/custom_outputs.py
+++ b/src/groundx/extract/custom_outputs.py
@@ -116,6 +116,9 @@ _EXTRACTED_FIELD_VALUE_KEYS = {"value", "_raw_text", "confidence", "conflicts", 
 _CONFLICTS_SIBLING_SUFFIX = "__conflicts"
 _RELATIONSHIP_PACKET_CAMEL_KEYS = {
     "match_attrs": "matchAttrs",
+    # Deprecated transport spellings kept for historical packets only: both
+    # fields are accepted and ignored, never honored, and are removed from
+    # canonical selector behavior by the compiler migration.
     "parent_passthrough_attrs": "parentPassthroughAttrs",
     "multiple_match_strategy": "multipleMatchStrategy",
 }

--- a/src/groundx/extract/prompt/manager.py
+++ b/src/groundx/extract/prompt/manager.py
@@ -13,9 +13,9 @@ from ..services.logger import Logger
 from .source import Source
 from .utility import (
     PreparedExtractionYaml,
+    _prepare_extraction_yaml,
     do_not_remove_fields,
     load_from_mapping,
-    prepare_extraction_yaml,
 )
 from .utility import (
     load_from_yaml as _load_from_yaml,
@@ -337,7 +337,7 @@ class PromptManager:
     def _prepare_extraction_yaml(
         self, raw: RawExtractionConfig
     ) -> PreparedExtractionYaml:
-        return prepare_extraction_yaml(
+        return _prepare_extraction_yaml(
             raw,
             top_level_metadata_keys=self._top_level_metadata_keys,
             final_group_metadata_keys=self._final_group_metadata_keys,

--- a/src/groundx/extract/prompt/utility.py
+++ b/src/groundx/extract/prompt/utility.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import re
 import typing
+import warnings
 
 import yaml
 from ..classes.element import Element
@@ -2317,7 +2318,7 @@ def _resolve_pseudo_workflow_metadata(
     return resolved
 
 
-def prepare_extraction_yaml(
+def _prepare_extraction_yaml(
     raw_yaml: typing.Union[str, typing.Mapping[str, typing.Any]],
     top_level_metadata_keys: typing.Optional[typing.Iterable[str]] = None,
     final_group_metadata_keys: typing.Optional[typing.Iterable[str]] = None,
@@ -2648,6 +2649,36 @@ def prepare_extraction_yaml(
     )
 
 
+_PREPARE_EXTRACTION_YAML_DEPRECATION = (
+    "prepare_extraction_yaml is deprecated and will be removed in the next "
+    "breaking GroundX SDK release; Cashbot owns workflow validation and "
+    "compilation. Submit authored YAML unchanged with "
+    "create_extraction_workflow/update_extraction_workflow and read workflows "
+    "back with load_extraction_definition_from_workflow."
+)
+
+
+def prepare_extraction_yaml(
+    raw_yaml: typing.Union[str, typing.Mapping[str, typing.Any]],
+    top_level_metadata_keys: typing.Optional[typing.Iterable[str]] = None,
+    final_group_metadata_keys: typing.Optional[typing.Iterable[str]] = None,
+    workflow_group_metadata_keys: typing.Optional[typing.Iterable[str]] = None,
+    pseudo_group_metadata_keys: typing.Optional[typing.Iterable[str]] = None,
+) -> PreparedExtractionYaml:
+    warnings.warn(
+        _PREPARE_EXTRACTION_YAML_DEPRECATION,
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _prepare_extraction_yaml(
+        raw_yaml,
+        top_level_metadata_keys=top_level_metadata_keys,
+        final_group_metadata_keys=final_group_metadata_keys,
+        workflow_group_metadata_keys=workflow_group_metadata_keys,
+        pseudo_group_metadata_keys=pseudo_group_metadata_keys,
+    )
+
+
 def element_from_mapping(data: typing.Dict[str, typing.Any]) -> Element:
     if "fields" in data:
         return group_from_mapping(data)
@@ -2720,7 +2751,7 @@ def load_from_mapping(data: typing.Dict[str, typing.Any]) -> typing.Dict[str, Gr
 
 
 def load_from_yaml(raw_yaml: str) -> typing.Dict[str, Group]:
-    prepared = prepare_extraction_yaml(raw_yaml)
+    prepared = _prepare_extraction_yaml(raw_yaml)
 
     return load_from_mapping(prepared.groups)
 

--- a/src/groundx/ingest.py
+++ b/src/groundx/ingest.py
@@ -411,6 +411,11 @@ class GroundX(GroundXBase):
         sources are compiled into a prepared definition. Mixed payloads that
         leak authoring-only workflow metadata into execution extracts are
         rejected.
+        Loading authored YAML sources runs the deprecated local compiler and
+        emits a `DeprecationWarning`; it will be removed in the next breaking
+        SDK release. Submit authored YAML unchanged with
+        `create_extraction_workflow`/`update_extraction_workflow` and read
+        workflows back with `load_extraction_definition_from_workflow`.
         """
         extraction_workflows = _import_extraction_workflows()
         return extraction_workflows.load_extraction_definition_from_yaml(
@@ -1145,6 +1150,11 @@ class AsyncGroundX(AsyncGroundXBase):
         sources are compiled into a prepared definition. Mixed payloads that
         leak authoring-only workflow metadata into execution extracts are
         rejected.
+        Loading authored YAML sources runs the deprecated local compiler and
+        emits a `DeprecationWarning`; it will be removed in the next breaking
+        SDK release. Submit authored YAML unchanged with
+        `create_extraction_workflow`/`update_extraction_workflow` and read
+        workflows back with `load_extraction_definition_from_workflow`.
         """
         extraction_workflows = _import_extraction_workflows()
         return extraction_workflows.load_extraction_definition_from_yaml(

--- a/tests/extract/test_extraction_workflow_definitions.py
+++ b/tests/extract/test_extraction_workflow_definitions.py
@@ -1,6 +1,7 @@
 import copy
 import inspect
 import typing
+import warnings
 from pathlib import Path
 
 import pytest
@@ -9,6 +10,7 @@ import yaml
 from groundx import AsyncGroundX, GroundX
 from groundx.core.request_options import RequestOptions
 from groundx.extract import prepare_extraction_yaml
+from groundx.extract.prompt.utility import _prepare_extraction_yaml
 from groundx.types import (
     WorkflowDetail,
     WorkflowResponse,
@@ -720,3 +722,35 @@ async def test_async_workflow_readback_preserves_server_metadata() -> None:
         "{{LANGUAGE_UNKNOWN}}": "",
     }
     assert definition.prepared is None
+
+
+def test_prepare_extraction_yaml_is_deprecated() -> None:
+    with pytest.warns(
+        DeprecationWarning,
+        match="removed in the next breaking GroundX SDK release",
+    ):
+        prepared = prepare_extraction_yaml(CUSTOM_WORKFLOW_YAML)
+
+    assert (
+        prepared.persisted_workflow_extract == _prepare_extraction_yaml(CUSTOM_WORKFLOW_YAML).persisted_workflow_extract
+    )
+
+
+def test_authored_yaml_definition_loading_warns_deprecation() -> None:
+    with pytest.warns(DeprecationWarning, match="prepare_extraction_yaml is deprecated"):
+        definition = _client(RecordingWorkflows()).load_extraction_definition_from_yaml(
+            yaml_text=CUSTOM_WORKFLOW_YAML,
+        )
+
+    assert definition.prepared is not None
+
+
+def test_workflow_extract_definition_loading_does_not_warn() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        definition = _client(RecordingWorkflows()).load_extraction_definition_from_yaml(
+            mapping=copy.deepcopy(EXECUTION_ONLY_EXTRACT),
+            mapping_kind="workflow_extract",
+        )
+
+    assert definition.extract == EXECUTION_ONLY_EXTRACT

--- a/tests/extract/test_relationship_parent_selection.py
+++ b/tests/extract/test_relationship_parent_selection.py
@@ -91,7 +91,11 @@ def test_requires_equal_populated_key_shape_and_values(parent, child) -> None:
     assert _select([parent], child).parent is None
 
 
-def test_ignores_passthrough_fallback_metadata() -> None:
+@pytest.mark.parametrize(
+    "passthrough_key",
+    ["parent_passthrough_attrs", "parentPassthroughAttrs"],
+)
+def test_ignores_passthrough_fallback_metadata(passthrough_key) -> None:
     parent = {
         "meter_number": "12",
         "provider_name": "Utility",
@@ -106,13 +110,17 @@ def test_ignores_passthrough_fallback_metadata() -> None:
     selection = _select(
         [parent],
         child,
-        parent_passthrough_attrs=["provider_name"],
+        **{passthrough_key: ["provider_name"]},
     )
 
     assert selection == RelationshipParentSelection(None, False)
 
 
-def test_ignores_tie_strategy_metadata() -> None:
+@pytest.mark.parametrize(
+    "strategy_key",
+    ["multiple_match_strategy", "multipleMatchStrategy"],
+)
+def test_ignores_tie_strategy_metadata(strategy_key) -> None:
     parents = [
         {"meter_number": "M-1"},
         {"meter_number": "m-1"},
@@ -121,7 +129,7 @@ def test_ignores_tie_strategy_metadata() -> None:
     selection = _select(
         parents,
         {"meter_number": "M-1"},
-        multiple_match_strategy="unsupported",
+        **{strategy_key: "unsupported"},
     )
 
     assert selection == RelationshipParentSelection(parents[0], False)


### PR DESCRIPTION
Implements the GroundX Python deprecation slice of Cashbot `complete-canonical-workflow-compiler-migration` tasks 11.3 and 11.6 (repo change: `openspec/changes/retire-local-workflow-compiler`). Cashbot owns workflow validation and compilation; the SDK's `create_extraction_workflow`/`update_extraction_workflow` already submit authored YAML unchanged. This PR deprecates the remaining local authoring surface ahead of its removal in the planned breaking release. No behavior changes.

## Changes

- `prepare_extraction_yaml` emits a `DeprecationWarning` naming the raw-YAML replacement and the planned breaking removal. The implementation moves to a private `_prepare_extraction_yaml`; `PromptManager` server-config loading, `load_from_yaml`, and workflow readback keep working without warnings until their owners migrate.
- Loading authored YAML sources through `load_extraction_definition` / `load_extraction_definition_from_yaml` warns the same way (it runs the local compiler). `mapping_kind="workflow_extract"` loading and `load_extraction_definition_from_workflow` readback stay warning-free; a test pins that.
- The relationship-packet spellings `parent_passthrough_attrs`/`parentPassthroughAttrs` and `multiple_match_strategy`/`multipleMatchStrategy` are marked as deprecated compatibility aliases in `custom_outputs.py`. Verified behavior: nothing in selection or reassembly reads either field; tests now pin both spellings as accepted-and-ignored by `select_relationship_parent`, matching the `custom-output-readback` contract.
- New `CHANGELOG.md` records the deprecations and the planned, not shipped, breaking release that removes `prepare_extraction_yaml`, `PreparedExtractionYaml`, and authored-YAML definition loading while preserving raw-YAML authoring, server readback, reassembly, and stable-first relationship selection.
- **Note for review:** `CHANGELOG.md` is added to `.fernignore` so regeneration preserves it. Repo guidance treats `.fernignore` additions as needing owner sign-off; this PR is that ask.
- Live-spec correction: `extraction-placement` no longer names the retired Studio Harness fallback as a parity target (see the commit message for the requirement-level record).

## Verification

- `poetry run pytest tests/extract tests/custom -q`: 516 passed, 2 skipped, 58 subtests passed.
- `poetry run mypy .`: clean (259 files).
- `ruff check` clean on changed files; `ruff format` clean on changed hunks (`prompt/utility.py` and `prompt/manager.py` carry pre-existing format drift untouched here).
- `scripts/check-line-endings.sh`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
