### PR TITLE
Strip unsupported stop for Bedrock GPT-5 models

### DIFF
--- a/src/groundx/extract/agents/agent.py
+++ b/src/groundx/extract/agents/agent.py
@@ -20,9 +20,11 @@ from smolagents.memory import (  # pyright: ignore[reportMissingTypeStubs]
     TaskStep,
 )
 from smolagents.models import (  # pyright: ignore[reportMissingTypeStubs]
+    REMOVE_PARAMETER,
     ChatMessage,
     MessageRole,
     OpenAIServerModel,
+    supports_stop_parameter,
 )
 
 if typing.TYPE_CHECKING:
@@ -39,6 +41,7 @@ def _enforce_bedrock_request_limit(request: typing.Any) -> None:
 
 
 def _bedrock_model_options(
+    model_id: str,
     model_options: typing.Dict[str, typing.Any],
 ) -> typing.Dict[str, typing.Any]:
     import httpx
@@ -61,6 +64,12 @@ def _bedrock_model_options(
         ]
     client_kwargs["http_client"] = http_client
     options["client_kwargs"] = client_kwargs
+
+    model_id_parts = model_id.split(".")
+    model_id_candidates = [".".join(model_id_parts[index:]) for index in range(len(model_id_parts))]
+    if any(not supports_stop_parameter(candidate) for candidate in model_id_candidates):
+        options["stop"] = REMOVE_PARAMETER
+
     return options
 
 
@@ -106,7 +115,7 @@ def build_openai_server_model(settings: AgentSettings) -> OpenAIServerModel:
 
     model_options = dict(settings.model_kwargs or {})
     if settings.service == "bedrock":
-        model_options = _bedrock_model_options(model_options)
+        model_options = _bedrock_model_options(settings.model_id, model_options)
     model = OpenAIServerModel(**model_kwargs, **model_options)
 
     client = getattr(model, "client", None)

--- a/tests/extract/agents/test_agent_model_settings.py
+++ b/tests/extract/agents/test_agent_model_settings.py
@@ -115,6 +115,30 @@ def test_agent_model_client_uses_remaining_shared_deadline(
     assert calls[1] == {"model": "test"}
 
 
+def test_bedrock_gpt5_provider_prefix_removes_unsupported_stop() -> None:
+    from smolagents.models import ChatMessage, MessageRole
+
+    from groundx.extract.agents.agent import build_openai_server_model
+
+    model = build_openai_server_model(
+        AgentSettings(
+            api_base="https://bedrock.example/v1",
+            api_key="test-key",
+            model_id="openai.gpt-5.6-luna",
+            service="bedrock",
+        )
+    )
+
+    completion_kwargs = model._prepare_completion_kwargs(
+        messages=[ChatMessage(role=MessageRole.USER, content="test")],
+        stop_sequences=["STOP"],
+    )
+
+    assert model.model_id == "openai.gpt-5.6-luna"
+    assert "stop" not in completion_kwargs
+    model.client._client.close()
+
+
 def test_bedrock_model_checks_the_final_http_request_body(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Bedrock model IDs include a provider prefix such as `openai.gpt-5.6-luna`. smolagents does not recognize that dotted prefix, so it sends `stop` and Bedrock rejects the request.

This keeps the provider model ID unchanged, checks each Bedrock model suffix with smolagents' existing capability function, and uses `REMOVE_PARAMETER` to omit `stop`.

Validation:
- Regression test failed before the fix and passes after it
- 7 focused model-setting tests pass
- Ruff check and format pass
- Wheel and source package build
- Line-ending check passes