### PR TITLE
Disable reasoning for Bedrock Luna tool calls

### DIFF
--- a/src/groundx/extract/agents/agent.py
+++ b/src/groundx/extract/agents/agent.py
@@ -69,6 +69,8 @@ def _bedrock_model_options(
     model_id_candidates = [".".join(model_id_parts[index:]) for index in range(len(model_id_parts))]
     if any(not supports_stop_parameter(candidate) for candidate in model_id_candidates):
         options["stop"] = REMOVE_PARAMETER
+    if "gpt-5.6-luna" in model_id_candidates:
+        options["reasoning_effort"] = "none"
 
     return options
 
@@ -116,6 +118,8 @@ def build_openai_server_model(settings: AgentSettings) -> OpenAIServerModel:
     model_options = dict(settings.model_kwargs or {})
     if settings.service == "bedrock":
         model_options = _bedrock_model_options(settings.model_id, model_options)
+        if "reasoning_effort" in model_options:
+            model_kwargs.pop("reasoning_effort", None)
     model = OpenAIServerModel(**model_kwargs, **model_options)
 
     client = getattr(model, "client", None)

--- a/tests/extract/agents/test_agent_model_settings.py
+++ b/tests/extract/agents/test_agent_model_settings.py
@@ -115,7 +115,7 @@ def test_agent_model_client_uses_remaining_shared_deadline(
     assert calls[1] == {"model": "test"}
 
 
-def test_bedrock_gpt5_provider_prefix_removes_unsupported_stop() -> None:
+def test_bedrock_luna_removes_unsupported_stop_and_disables_reasoning() -> None:
     from smolagents.models import ChatMessage, MessageRole
 
     from groundx.extract.agents.agent import build_openai_server_model
@@ -136,6 +136,30 @@ def test_bedrock_gpt5_provider_prefix_removes_unsupported_stop() -> None:
 
     assert model.model_id == "openai.gpt-5.6-luna"
     assert "stop" not in completion_kwargs
+    assert completion_kwargs["reasoning_effort"] == "none"
+    model.client._client.close()
+
+
+def test_bedrock_luna_overrides_incompatible_reasoning_effort() -> None:
+    from smolagents.models import ChatMessage, MessageRole
+
+    from groundx.extract.agents.agent import build_openai_server_model
+
+    model = build_openai_server_model(
+        AgentSettings(
+            api_base="https://bedrock.example/v1",
+            api_key="test-key",
+            model_id="openai.gpt-5.6-luna",
+            reasoning_effort="medium",
+            service="bedrock",
+        )
+    )
+
+    completion_kwargs = model._prepare_completion_kwargs(
+        messages=[ChatMessage(role=MessageRole.USER, content="test")],
+    )
+
+    assert completion_kwargs["reasoning_effort"] == "none"
     model.client._client.close()
 
 


### PR DESCRIPTION
Bedrock enables reasoning by default for GPT-5.6 Luna. Its Chat Completions endpoint rejects function-tool requests unless the wire request explicitly sets `reasoning_effort` to `none`.

This keeps the workflow setting null and performs the required provider-specific translation only in GroundX Python's existing Bedrock model-option normalization.

The ADP canary boundary replay confirmed:
- Cashbot persisted and selected the Bedrock Luna workflow engine.
- Internal Arcadia Agents selected that engine and kept reasoning null.
- GroundX Python omitted `reasoning_effort`.
- Bedrock rejected the function-tool request and required the explicit provider disable value.
- S3 image hydration reached the provider boundary successfully.

Validation:
- 584 passed, 5 skipped, 58 subtests passed
- focused model-setting tests pass
- changed-file Ruff and mypy pass
- diff check passes
