### PR TITLE
Document extraction archive corrections

### DIFF
--- a/openspec/changes/archive/2026-07-07-generalize-v1-custom-output-reassembly/corrections.md
+++ b/openspec/changes/archive/2026-07-07-generalize-v1-custom-output-reassembly/corrections.md
@@ -1,0 +1,5 @@
+# Correction
+
+This change was superseded, not abandoned. Later GroundX Python reassembly,
+relationship, and protected fixture replay work delivered and verified the
+applicable behavior through the canonical four-case fixture pack.

--- a/openspec/changes/archive/2026-08-23-normalize-extracted-value-types/corrections.md
+++ b/openspec/changes/archive/2026-08-23-normalize-extracted-value-types/corrections.md
@@ -1,0 +1,10 @@
+# Correction
+
+The 2026-08-24 convergence capture covered the released coercion behavior and
+recorded end-to-end reassembly drift on all four protected surfaces. The prior
+candidate `2fc4aee5879dc76c0e28f9f1aef66d2fe02782b0034795ca073164f53594e026`
+was replaced by human-approved candidate
+`02093d4141d5abf22519f88fb3f482b5dcf9f2f217fc858465db0c1ee1a00709`.
+This records the required drift outcome; it does not attribute every changed
+byte to coercion because the convergence capture also included other approved
+runtime changes.


### PR DESCRIPTION
Records that the earlier reassembly plan was superseded, not abandoned, and records the four-case convergence drift outcome omitted from the value-normalization archive. No code or fixture bytes change.\n\nValidation: OPENSPEC_TELEMETRY=0 npx --yes @fission-ai/openspec@1.3.1 validate --all --strict --json (11/11 passed); git diff --check.