### PR TITLE
AGE-319: add universal identifier matching

### DIFF
--- a/openspec/changes/add-confusable-identifier-matcher/.openspec.yaml
+++ b/openspec/changes/add-confusable-identifier-matcher/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-25

--- a/openspec/changes/add-confusable-identifier-matcher/design.md
+++ b/openspec/changes/add-confusable-identifier-matcher/design.md
@@ -52,12 +52,9 @@ For a string, `match_key` performs one linear pass after `casefold()`:
 3. Preserve every other character and the resulting length.
 
 Whitespace-only strings remain absent where the existing caller already treats
-them as absent. Callers unwrap values and select their existing number, boolean,
-mapping, list, extracted-field wrapper, absence, and unsupported-type behavior
-before invoking either function. Callers that need hashable structured keys
-retain their current typed wrappers and call `match_key` only for string
-components. This prevents Python equality such as `True == 1` from becoming
-matcher behavior.
+them as absent. Callers invoke these functions only for strings. Existing
+nonstring comparison, structured-key, absence, and unsupported-type behavior
+remains outside this matcher.
 
 This restricted implementation is safer than an open-source Unicode skeleton
 library. Unicode security libraries create many equivalences that were not
@@ -88,9 +85,9 @@ conflicts, provenance, diagnostics, and final output.
 
 New tests cover case, every whitespace form, each approved class, combined
 differences, punctuation, unmapped characters, unequal lengths, whitespace-only
-values, nonstring helper rejection, existing caller behavior for mixed and
-nonstring values, structured identity values, stable parent order, populated-key
-shape, raw-value retention, and `exact_attrs` no-op behavior.
+values, nonstring helper rejection, structured string identity values, stable
+parent order, populated-key shape, raw-value retention, and `exact_attrs` no-op
+behavior.
 
 Existing tests run unchanged. If an existing assertion fails because the new
 equality is intentional, implementation stops before editing it and records the

--- a/openspec/changes/add-confusable-identifier-matcher/design.md
+++ b/openspec/changes/add-confusable-identifier-matcher/design.md
@@ -40,9 +40,10 @@ Fern regeneration.
 
 ### Two small public functions own string matching
 
-`match_key(value)` transforms strings and returns nonstrings unchanged.
-`values_match(left, right)` compares only `match_key(left)` and
-`match_key(right)`. It contains no second transformation.
+`match_key(value: str) -> str` transforms one string.
+`values_match(left: str, right: str) -> bool` compares only
+`match_key(left)` and `match_key(right)`. Both reject nonstring input and contain
+no nonstring comparison semantics or second transformation.
 
 For a string, `match_key` performs one linear pass after `casefold()`:
 
@@ -51,10 +52,12 @@ For a string, `match_key` performs one linear pass after `casefold()`:
 3. Preserve every other character and the resulting length.
 
 Whitespace-only strings remain absent where the existing caller already treats
-them as absent. Existing number, boolean, mapping, list, extracted-field wrapper,
-and unsupported-type behavior remains at the caller boundary. Callers that need
-hashable structured keys retain their current typed wrappers, but every string
-component passes through `match_key`.
+them as absent. Callers unwrap values and select their existing number, boolean,
+mapping, list, extracted-field wrapper, absence, and unsupported-type behavior
+before invoking either function. Callers that need hashable structured keys
+retain their current typed wrappers and call `match_key` only for string
+components. This prevents Python equality such as `True == 1` from becoming
+matcher behavior.
 
 This restricted implementation is safer than an open-source Unicode skeleton
 library. Unicode security libraries create many equivalences that were not
@@ -85,9 +88,9 @@ conflicts, provenance, diagnostics, and final output.
 
 New tests cover case, every whitespace form, each approved class, combined
 differences, punctuation, unmapped characters, unequal lengths, whitespace-only
-values, mixed and nonstring values, structured identity values, stable parent
-order, populated-key shape, raw-value retention, and `exact_attrs` no-op
-behavior.
+values, nonstring helper rejection, existing caller behavior for mixed and
+nonstring values, structured identity values, stable parent order, populated-key
+shape, raw-value retention, and `exact_attrs` no-op behavior.
 
 Existing tests run unchanged. If an existing assertion fails because the new
 equality is intentional, implementation stops before editing it and records the
@@ -98,6 +101,12 @@ report over protected fixtures and representative private captures. It lists
 each pair of distinct raw strings that produces one key, with caller and field.
 Every unexpected collision requires human approval. The report is not a runtime
 mode and does not mutate or commit private input.
+
+The docs-only `eyelevel-fern-config`
+`document-universal-identifier-matching` change must merge before the SDK
+release. It removes the public promise that `exact_attrs` selects exact runtime
+equality and documents the universal comparison without changing the API schema,
+compiler, or workflow payload.
 
 ## Risks / Trade-offs
 
@@ -114,9 +123,10 @@ mode and does not mutate or commit private input.
 2. Exercise the Internal Arcadia implementation against this branch and run its
    collision report before publishing.
 3. Obtain approval for every unexpected collision and any existing-test change.
-4. Merge GroundX Python and hand the merged commit and requested version to the
+4. Merge the Fern public-documentation change.
+5. Merge GroundX Python and hand the merged commit and requested version to the
    human release owner.
-5. Pin the published version in Internal Arcadia, rebuild its image, and run the
+6. Pin the published version in Internal Arcadia, rebuild its image, and run the
    protected and affected-document verification.
 
 Rollback pins the prior SDK release and restores the prior Internal Arcadia

--- a/openspec/changes/add-confusable-identifier-matcher/design.md
+++ b/openspec/changes/add-confusable-identifier-matcher/design.md
@@ -1,0 +1,127 @@
+## Context
+
+`custom_outputs.py` currently normalizes relationship strings in
+`_relationship_comparison_value()` and repeated-record identity strings in
+`_normalize_match_value()`. Advanced identity paths can bypass normalization
+through `identity_match.exact_attrs`. `select_relationship_parent()` uses the
+relationship branch directly.
+
+The current selector already preserves populated-key shape, nonstring type
+rules, and stable parent order. The new comparison must change only string
+equality. It must not change record admission, threshold counts, missing-value
+rules, conflict evidence, merge behavior, selection order, or output values.
+
+The code lives under `src/groundx/extract/`, tests under `tests/extract/`, and
+OpenSpec under `openspec/`. All three are protected by `.fernignore` and survive
+Fern regeneration.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One reusable key function owns string transformation.
+- One equality wrapper delegates to that key function.
+- Every identity or relationship string key uses the same behavior.
+- Existing nonstring, absence, threshold, and stable-order behavior remains.
+- Raw values never change.
+
+**Non-Goals:**
+
+- No value normalization, repair, display change, or new workflow metadata.
+- No matching profile, exact mode, field switch, customer branch, or caller
+  option.
+- No Unicode spoof-detection library, fuzzy matching, edit distance, or mapping
+  beyond `{0, o}`, `{1, i, l}`, and `{8, b}`.
+- No use in scalar candidate evidence dedupe, route or schema identity, sorting,
+  rendering, serialization, logging, or arbitrary equality.
+- No existing test or fixture change without human approval.
+
+## Decisions
+
+### Two small public functions own string matching
+
+`match_key(value)` transforms strings and returns nonstrings unchanged.
+`values_match(left, right)` compares only `match_key(left)` and
+`match_key(right)`. It contains no second transformation.
+
+For a string, `match_key` performs one linear pass after `casefold()`:
+
+1. Remove every character for which `str.isspace()` is true.
+2. Map `o` to `0`, `i` and `l` to `1`, and `b` to `8`.
+3. Preserve every other character and the resulting length.
+
+Whitespace-only strings remain absent where the existing caller already treats
+them as absent. Existing number, boolean, mapping, list, extracted-field wrapper,
+and unsupported-type behavior remains at the caller boundary. Callers that need
+hashable structured keys retain their current typed wrappers, but every string
+component passes through `match_key`.
+
+This restricted implementation is safer than an open-source Unicode skeleton
+library. Unicode security libraries create many equivalences that were not
+approved for extraction matching.
+
+### Custom-output identity and relationships share the functions
+
+`custom_outputs.py` uses `match_key` for string components created by
+`_identity_index_value()`, `_identity_key()`,
+`_identity_partition_key()`, `_identity_comparison_value()`, and
+`_records_share_identity()`. Direct string equality uses `values_match`.
+
+`select_relationship_parent()` uses the same equality while retaining the
+existing child populated-key filter, exact populated-key shape requirement, and
+first matching parent in stable input order.
+
+`identity_match.exact_attrs` remains accepted by workflow preparation and
+readback for compatibility, but cannot select raw string equality. Removing the
+runtime branch avoids Cashbot or workflow migration work.
+
+### Comparison never becomes output
+
+Comparison values exist only inside lookups and comparisons. The first raw
+record and existing merge rules continue to determine retained fields,
+conflicts, provenance, diagnostics, and final output.
+
+### Regression gates protect behavior and false merges
+
+New tests cover case, every whitespace form, each approved class, combined
+differences, punctuation, unmapped characters, unequal lengths, whitespace-only
+values, mixed and nonstring values, structured identity values, stable parent
+order, populated-key shape, raw-value retention, and `exact_attrs` no-op
+behavior.
+
+Existing tests run unchanged. If an existing assertion fails because the new
+equality is intentional, implementation stops before editing it and records the
+input, old result, new result, and downstream effect for human approval.
+
+Before release, the Internal Arcadia consumer change runs a read-only collision
+report over protected fixtures and representative private captures. It lists
+each pair of distinct raw strings that produces one key, with caller and field.
+Every unexpected collision requires human approval. The report is not a runtime
+mode and does not mutate or commit private input.
+
+## Risks / Trade-offs
+
+- Distinct identifiers such as `IO` and `10` can collapse. The collision report
+  and human gate block release on unexpected cases.
+- Universal equality intentionally supersedes legacy `exact_attrs` behavior.
+  Existing metadata remains readable, avoiding a workflow migration.
+- GroundX Python cannot publish itself. The PR ends with a human release handoff
+  naming the merged commit and requested version.
+
+## Migration Plan
+
+1. Implement and validate the GroundX Python functions and production callers.
+2. Exercise the Internal Arcadia implementation against this branch and run its
+   collision report before publishing.
+3. Obtain approval for every unexpected collision and any existing-test change.
+4. Merge GroundX Python and hand the merged commit and requested version to the
+   human release owner.
+5. Pin the published version in Internal Arcadia, rebuild its image, and run the
+   protected and affected-document verification.
+
+Rollback pins the prior SDK release and restores the prior Internal Arcadia
+image. No stored value changes.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-confusable-identifier-matcher/proposal.md
+++ b/openspec/changes/add-confusable-identifier-matcher/proposal.md
@@ -10,11 +10,13 @@ case, whitespace, and approved OCR-confusable handling for both.
 
 ## What Changes
 
-- Add public `match_key(value)` and `values_match(left, right)` functions to the
-  hand-written `groundx.extract` package.
-- For strings only, case-fold, remove whitespace, and map the approved classes
-  `{0, o}`, `{1, i, l}`, and `{8, b}`. Preserve punctuation, length, unmapped
-  characters, and current nonstring behavior.
+- Add public string-only `match_key(value: str) -> str` and
+  `values_match(left: str, right: str) -> bool` functions to the hand-written
+  `groundx.extract` package.
+- Case-fold strings, remove whitespace, and map the approved classes `{0, o}`,
+  `{1, i, l}`, and `{8, b}`. Preserve punctuation, length, and unmapped
+  characters. Reject nonstring helper inputs; production callers retain their
+  existing nonstring comparison behavior.
 - Route every string component of repeated-record identity keys and relationship
   comparisons through those functions.
 - Retire `identity_match.exact_attrs` as a runtime matching switch. Continue
@@ -49,8 +51,11 @@ case, whitespace, and approved OCR-confusable handling for both.
 - `tests/extract/`: adds function and production-entrypoint regressions.
 - `internal-arcadia-agents`: consumes the released functions under its separate
   `adopt-confusable-identifier-matcher` change and updates its SDK pin.
-- No dependency, Fern source, generated SDK, API, workflow YAML, Cashbot,
-  Harness, database, or stored-data change.
+- `eyelevel-fern-config`: a separate docs-only
+  `document-universal-identifier-matching` change updates the public workflow
+  contract before the SDK release.
+- No dependency, Fern API schema, generated SDK shape, API, workflow YAML,
+  Cashbot, Harness, database, or stored-data change.
 - All touched source, tests, and OpenSpec paths are protected by `.fernignore`.
 - Open design questions: none.
 

--- a/openspec/changes/add-confusable-identifier-matcher/proposal.md
+++ b/openspec/changes/add-confusable-identifier-matcher/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+Identity and relationship matching still treats OCR variants such as `I` and
+`1` as different values. In AGE-319, that can leave charges unattached unless a
+model happens to rewrite the identifier before final parent selection.
+
+GroundX Python also has separate string comparison branches for repeated-record
+identity and relationship selection. One small comparison function should own
+case, whitespace, and approved OCR-confusable handling for both.
+
+## What Changes
+
+- Add public `match_key(value)` and `values_match(left, right)` functions to the
+  hand-written `groundx.extract` package.
+- For strings only, case-fold, remove whitespace, and map the approved classes
+  `{0, o}`, `{1, i, l}`, and `{8, b}`. Preserve punctuation, length, unmapped
+  characters, and current nonstring behavior.
+- Route every string component of repeated-record identity keys and relationship
+  comparisons through those functions.
+- Retire `identity_match.exact_attrs` as a runtime matching switch. Continue
+  accepting existing metadata so old workflows remain readable.
+- Keep comparison values transient. Do not rewrite extracted values, conflicts,
+  provenance, X-Ray, diagnostics, or final output.
+- Add new regression coverage without changing an existing test, fixture,
+  expected output, or score. Any required existing-test change stops for human
+  review and approval.
+- **BREAKING**: repeated-record and relationship string equality becomes
+  universal, so previously distinct case, whitespace, or approved OCR variants
+  may merge or select the same parent.
+
+## Capabilities
+
+### New Capabilities
+
+- `identifier-comparison`: Defines the shared comparison functions, restricted
+  string transformation, exact-mode retirement, and raw-value preservation.
+
+### Modified Capabilities
+
+- `custom-output-readback`: Uses the shared comparison for repeated-record
+  identity and relationship parent selection.
+
+## Impact
+
+- `src/groundx/extract/comparison.py`: new hand-written comparison owner.
+- `src/groundx/extract/__init__.py`: exports both functions.
+- `src/groundx/extract/custom_outputs.py`: removes duplicate string transforms
+  from identity indexes, partitions, dedupe, thresholds, and parent selection.
+- `tests/extract/`: adds function and production-entrypoint regressions.
+- `internal-arcadia-agents`: consumes the released functions under its separate
+  `adopt-confusable-identifier-matcher` change and updates its SDK pin.
+- No dependency, Fern source, generated SDK, API, workflow YAML, Cashbot,
+  Harness, database, or stored-data change.
+- All touched source, tests, and OpenSpec paths are protected by `.fernignore`.
+- Open design questions: none.
+
+Rollback restores the prior GroundX Python release. No data repair is required
+because comparison values are never persisted.

--- a/openspec/changes/add-confusable-identifier-matcher/specs/custom-output-readback/spec.md
+++ b/openspec/changes/add-confusable-identifier-matcher/specs/custom-output-readback/spec.md
@@ -1,0 +1,215 @@
+## ADDED Requirements
+
+### Requirement: Repeated-record identity uses the shared comparison
+
+GroundX Python SHALL use `match_key` for every string component of a generated
+repeated-record identity key and `values_match` for every direct identity string
+comparison.
+
+#### Scenario: Identity indexes and dedupe share one string rule
+
+- **WHEN** repeated custom output is indexed, partitioned, threshold-matched, or
+  deduplicated by configured identity fields
+- **THEN** every string key component uses `match_key`
+- **AND** direct string equality uses `values_match`
+- **AND** existing missing, threshold, shortcut, type, merge, and stable-order
+  rules remain unchanged.
+
+#### Scenario: Raw repeated records are retained
+
+- **WHEN** two records merge through the shared comparison
+- **THEN** the existing first record and merge rules determine retained output
+- **AND** no comparison key appears in output or diagnostics.
+
+## MODIFIED Requirements
+
+### Requirement: Relationship metadata can create nested list output
+
+The SDK SHALL support generic parent/child list relationships through metadata
+rather than hardcoded final group names.
+
+#### Scenario: Child records attach to matching parent records
+
+- **GIVEN** a v1 workflow reassembles one parent final group and one child final
+  group as arrays
+- **AND** `workflow.output_relationships` declares the parent group, child group,
+  parent output field, and `match_attrs`
+- **WHEN** the SDK reassembles custom output
+- **THEN** child records whose present non-blank match fields equal the parent's
+  same present non-blank fields are placed in the parent output field
+- **AND** the behavior does not depend on final groups named `meters` or
+  `charges`.
+
+#### Scenario: Match semantics use the shared comparison
+
+- **GIVEN** relationship metadata declares multiple `match_attrs`
+- **AND** parent and child records include extracted-field wrappers, strings,
+  integers, floats, blanks, and missing values
+- **WHEN** the SDK applies relationship metadata
+- **THEN** extracted-field wrappers are compared by their `value`
+- **AND** string equality uses `values_match`
+- **AND** capitalization and all whitespace are ignored
+- **AND** only `{0, o}`, `{1, i, l}`, and `{8, b}` are treated as OCR-confusable
+- **AND** integers and floats retain numeric-value comparison
+- **AND** blank or missing fields do not participate
+- **AND** the parent and child only match when they have the same non-empty set
+  of present match fields
+- **AND** date-style strings receive no special normalization
+- **AND** the first matching parent in stable input order wins.
+
+#### Scenario: Match attrs without a present key do not match
+
+- **GIVEN** relationship metadata declares `match_attrs`
+- **AND** a child and parent both have no non-blank values for those fields
+- **WHEN** the SDK applies relationship metadata
+- **THEN** the child does not match that parent.
+
+#### Scenario: Unmatched child records are preserved
+
+- **GIVEN** relationship metadata declares `unmatched_child_group`
+- **AND** a child record does not match any parent record across all configured
+  `match_attrs`
+- **WHEN** the SDK applies relationship metadata
+- **THEN** the child record remains in the configured unmatched child group.
+
+#### Scenario: Missing relationship list groups become empty lists
+
+- **GIVEN** relationship metadata declares parent and child list groups
+- **AND** custom output produces no non-empty records for one or both groups
+- **WHEN** the SDK applies relationship metadata
+- **THEN** the absent relationship groups are treated as empty lists
+- **AND** no invalid relationship output diagnostic is emitted.
+
+#### Scenario: Undeclared ties attach to the first stable parent
+
+- **GIVEN** one child record matches more than one parent record
+- **AND** the relationship declares no `multiple_match_strategy`
+- **WHEN** the SDK applies relationship metadata
+- **THEN** the child attaches to the first matching parent in input order
+- **AND** no ambiguity diagnostic is emitted
+- **AND** the behavior equals a declared `multiple_match_strategy: first_stable`.
+
+#### Scenario: Runtime-only strategy metadata does not change selection
+
+- **GIVEN** one child record matches more than one parent record
+- **AND** the relationship explicitly declares a `multiple_match_strategy`
+  other than `first_stable`
+- **WHEN** the SDK applies relationship metadata
+- **THEN** the child still attaches to the first matching parent in input order
+- **AND** no ambiguity diagnostic is emitted
+- **AND** authoring validation remains responsible for rejecting the foreign
+  strategy before persistence.
+
+#### Scenario: A declared strategy resolves a tie
+
+- **GIVEN** one child record matches more than one parent record
+- **AND** the relationship declares `multiple_match_strategy: first_stable`
+- **WHEN** the SDK applies relationship metadata
+- **THEN** the child attaches to the first matching parent in input order
+- **AND** no ambiguity diagnostic is emitted.
+
+#### Scenario: Passthrough metadata does not weaken matching
+
+- **GIVEN** relationship metadata declares `parent_passthrough_attrs` that
+  overlap `match_attrs`
+- **AND** no parent matches the child on the full populated match-key shape
+- **WHEN** the SDK applies relationship metadata
+- **THEN** the SDK performs no fallback comparison
+- **AND** the child remains unmatched
+- **AND** `parent_passthrough_attrs` never changes parent selection.
+
+#### Scenario: Chained relationships create arrays inside arrays
+
+- **GIVEN** relationship metadata declares one child group nested under a parent
+  group
+- **AND** another relationship declares a grandchild group nested under that
+  child group
+- **WHEN** the SDK applies relationship metadata
+- **THEN** the final output can contain a list inside another list item.
+
+#### Scenario: Relationship view is the SDK final output
+
+- **GIVEN** a v1 workflow reassembles parent and child final groups as arrays
+- **AND** `workflow.output_relationships` declares how to nest child records
+- **WHEN** the SDK reassembles custom output
+- **THEN** `final_output` contains the nested relationship-applied view
+- **AND** `relationship_output` matches `final_output`
+- **AND** `workflow_output` preserves the pre-relationship route output for
+  diagnostics.
+
+#### Scenario: Relationship metadata selects the shared v1 output shape
+
+- **GIVEN** a v1 workflow has relationship metadata
+- **WHEN** the SDK reassembles custom output
+- **THEN** the SDK returns relationship-applied `final_output`
+- **AND** the SDK returns matching `relationship_output`
+- **AND** generic v1 and Arcadia v1 callers can consume the same SDK
+  `final_output` shape.
+
+### Requirement: Parent selection is one exported SDK primitive
+
+The SDK SHALL expose relationship parent selection as exactly one public
+primitive and SHALL use that same primitive for every workflow it reassembles.
+No caller and no workflow SHALL get a second matcher, a per-workflow variant, or
+a copied selection algorithm.
+
+The public surface is:
+
+```python
+from groundx.extract import select_relationship_parent, RelationshipParentSelection
+
+selection = select_relationship_parent(parents, child, relationship)
+```
+
+- `parents` is an ordered sequence of parent records, `child` is one child
+  record, and `relationship` is the relationship packet.
+- The packet accepts persisted snake_case or dispatched camelCase. Only
+  `match_attrs` or `matchAttrs` affects parent selection, and snake_case wins
+  when both are present.
+- The return value is the frozen dataclass
+  `RelationshipParentSelection(parent, ambiguous)`. `parent` is the selected
+  parent object or `None`. `ambiguous` is always `False` because multiple
+  matches select the first parent in stable input order.
+- The primitive is total and never raises for unsupported value types.
+- Both names are exported from `groundx.extract`.
+
+#### Scenario: Consumers call the selection primitive directly
+
+- **GIVEN** a consumer holds parent and child records and a relationship packet
+- **WHEN** it calls `select_relationship_parent(parents, child, relationship)`
+- **THEN** it receives a `RelationshipParentSelection`
+- **AND** `parent` is the selected parent object or `None`
+- **AND** `ambiguous` is `False`.
+
+#### Scenario: One primitive serves every workflow
+
+- **GIVEN** pure Arcadia legacy, Arcadia v1, renamed generic v1, or another
+  canonical v1 relationship packet
+- **WHEN** the SDK selects a parent
+- **THEN** every case uses the one exported primitive
+- **AND** reassembly delegates to it rather than matching inline
+- **AND** the outcome depends only on `match_attrs`, shared comparison results,
+  populated-key shape, and stable parent order.
+
+#### Scenario: Renamed generic workflows select identically
+
+- **GIVEN** two relationship packets differ only by one-to-one group and
+  match-attribute renames
+- **WHEN** the same records are selected under that rename
+- **THEN** the selected parent and ambiguity result are the same.
+
+#### Scenario: Retained parent conflicts do not change selection
+
+- **GIVEN** a parent record carries `<field>__conflicts` for a match field
+- **WHEN** the SDK selects a parent
+- **THEN** the conflict sibling does not affect comparison
+- **AND** selection uses only populated `match_attrs` values.
+
+#### Scenario: Empty routed values retain non-empty conflict siblings
+
+- **GIVEN** a repeated record has an empty routed field and a non-empty
+  `<field>__conflicts` sibling
+- **WHEN** the SDK reassembles custom output
+- **THEN** it omits the empty field value
+- **AND** retains the conflict sibling on the same record
+- **AND** parent selection ignores that sibling.

--- a/openspec/changes/add-confusable-identifier-matcher/specs/identifier-comparison/spec.md
+++ b/openspec/changes/add-confusable-identifier-matcher/specs/identifier-comparison/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: One function owns string comparison keys
+
+GroundX Python SHALL export `match_key(value)` from `groundx.extract`.
+For string input it SHALL return a transient comparison string. For nonstring
+input it SHALL return the input unchanged.
+
+#### Scenario: String extraction noise is ignored
+
+- **WHEN** two nonempty strings differ only by capitalization, whitespace, or
+  substitutions within `{0, o}`, `{1, i, l}`, and `{8, b}`
+- **THEN** `match_key` returns the same value for both strings
+- **AND** it runs in linear time relative to input length.
+
+#### Scenario: Unapproved differences remain significant
+
+- **WHEN** two strings differ by punctuation, length after whitespace removal,
+  or an unmapped character
+- **THEN** `match_key` returns different values.
+
+#### Scenario: Nonstrings are not transformed
+
+- **WHEN** `match_key` receives a missing, numeric, boolean, list, mapping, or
+  other nonstring value
+- **THEN** it returns that value unchanged
+- **AND** the caller retains its existing type, absence, and hashability rules.
+
+### Requirement: One equality wrapper delegates to the key function
+
+GroundX Python SHALL export `values_match(left, right)` from `groundx.extract`.
+It SHALL return `match_key(left) == match_key(right)` and SHALL contain no second
+case, whitespace, confusable, exact, profile, field, or workflow rule.
+
+#### Scenario: Direct comparison uses the same transformation
+
+- **WHEN** a production identity or relationship path directly compares two
+  string values
+- **THEN** it uses `values_match`
+- **AND** generated string key components use `match_key`.
+
+#### Scenario: Nonmatching equality is unchanged
+
+- **WHEN** code compares scalar candidate evidence, route or schema identity,
+  sorting values, rendered values, or transport values
+- **THEN** it retains its existing behavior
+- **AND** it does not use these functions merely because it compares values.
+
+### Requirement: Exact metadata cannot bypass universal matching
+
+Neither function SHALL accept an exact mode. Existing
+`identity_match.exact_attrs` metadata MAY remain accepted for compatibility but
+SHALL NOT change identity or relationship string equality.
+
+#### Scenario: Legacy exact metadata is present
+
+- **WHEN** a persisted workflow contains `identity_match.exact_attrs`
+- **THEN** matching still ignores capitalization, whitespace, and approved OCR
+  confusions
+- **AND** the metadata does not select raw string equality.
+
+### Requirement: Comparison never rewrites retained values
+
+Comparison values SHALL remain transient and SHALL NOT replace source or output
+values.
+
+#### Scenario: Records match through the comparison key
+
+- **WHEN** records match after case, whitespace, or OCR-confusable handling
+- **THEN** retained fields, conflicts, provenance, X-Ray, diagnostics, and final
+  output remain raw
+- **AND** no comparison key is serialized or displayed.
+
+### Requirement: Existing evidence changes require human approval
+
+An existing test, fixture, expected output, or score SHALL NOT change unless a
+human reviews and approves the specific behavioral difference.
+
+#### Scenario: Existing assertion conflicts with universal matching
+
+- **WHEN** implementation makes an existing evidence artifact fail
+- **THEN** work stops before modifying it
+- **AND** the review records the input, old result, new result, and downstream
+  effect.

--- a/openspec/changes/add-confusable-identifier-matcher/specs/identifier-comparison/spec.md
+++ b/openspec/changes/add-confusable-identifier-matcher/specs/identifier-comparison/spec.md
@@ -2,9 +2,9 @@
 
 ### Requirement: One function owns string comparison keys
 
-GroundX Python SHALL export `match_key(value)` from `groundx.extract`.
-For string input it SHALL return a transient comparison string. For nonstring
-input it SHALL return the input unchanged.
+GroundX Python SHALL export `match_key(value: str) -> str` from
+`groundx.extract`. It SHALL return a transient comparison string and reject
+nonstring input.
 
 #### Scenario: String extraction noise is ignored
 
@@ -19,18 +19,21 @@ input it SHALL return the input unchanged.
   or an unmapped character
 - **THEN** `match_key` returns different values.
 
-#### Scenario: Nonstrings are not transformed
+#### Scenario: The key function rejects nonstrings
 
 - **WHEN** `match_key` receives a missing, numeric, boolean, list, mapping, or
   other nonstring value
-- **THEN** it returns that value unchanged
-- **AND** the caller retains its existing type, absence, and hashability rules.
+- **THEN** it raises `TypeError`
+- **AND** production callers retain their existing type, absence, comparison,
+  and hashability rules without passing that value to `match_key`.
 
 ### Requirement: One equality wrapper delegates to the key function
 
-GroundX Python SHALL export `values_match(left, right)` from `groundx.extract`.
-It SHALL return `match_key(left) == match_key(right)` and SHALL contain no second
-case, whitespace, confusable, exact, profile, field, or workflow rule.
+GroundX Python SHALL export
+`values_match(left: str, right: str) -> bool` from `groundx.extract`. For two
+strings it SHALL return `match_key(left) == match_key(right)`. It SHALL reject
+nonstring input and contain no second case, whitespace, confusable, exact,
+profile, field, workflow, or nonstring rule.
 
 #### Scenario: Direct comparison uses the same transformation
 
@@ -45,6 +48,14 @@ case, whitespace, confusable, exact, profile, field, or workflow rule.
   sorting values, rendered values, or transport values
 - **THEN** it retains its existing behavior
 - **AND** it does not use these functions merely because it compares values.
+
+#### Scenario: Production callers compare nonstrings themselves
+
+- **WHEN** an identity or relationship caller compares a nonstring value
+- **THEN** it retains its existing typed comparison behavior
+- **AND** it does not pass that value to either public function
+- **AND** booleans do not become equal to numbers through Python's `bool` and
+  `int` equality.
 
 ### Requirement: Exact metadata cannot bypass universal matching
 

--- a/openspec/changes/add-confusable-identifier-matcher/specs/identifier-comparison/spec.md
+++ b/openspec/changes/add-confusable-identifier-matcher/specs/identifier-comparison/spec.md
@@ -52,10 +52,8 @@ profile, field, workflow, or nonstring rule.
 #### Scenario: Production callers compare nonstrings themselves
 
 - **WHEN** an identity or relationship caller compares a nonstring value
-- **THEN** it retains its existing typed comparison behavior
-- **AND** it does not pass that value to either public function
-- **AND** booleans do not become equal to numbers through Python's `bool` and
-  `int` equality.
+- **THEN** it does not pass that value to either public function
+- **AND** its existing behavior remains outside this matcher.
 
 ### Requirement: Exact metadata cannot bypass universal matching
 

--- a/openspec/changes/add-confusable-identifier-matcher/tasks.md
+++ b/openspec/changes/add-confusable-identifier-matcher/tasks.md
@@ -1,0 +1,47 @@
+## 1. Freeze Current Behavior
+
+- [ ] 1.1 Record the current GroundX Python ref, open PRs, and the exact
+  identity and relationship callers in `custom_outputs.py`.
+- [ ] 1.2 Run focused and full test baselines and keep every existing test,
+  fixture, expected output, and score unchanged.
+- [ ] 1.3 Add new failing tests for both public functions, every approved and
+  rejected string case, nonstring preservation, and raw-value preservation.
+- [ ] 1.4 Add new failing production-entrypoint tests for repeated-record
+  identity, advanced identity indexing, `exact_attrs` no-op behavior, populated
+  relationship key shape, and stable parent selection.
+
+## 2. Add The Shared Functions
+
+- [ ] 2.1 Add `src/groundx/extract/comparison.py` with `match_key(value)` and
+  `values_match(left, right)` and no matching modes or external dependency.
+- [ ] 2.2 Export both functions from `groundx.extract` without changing
+  generated top-level SDK files.
+- [ ] 2.3 Prove case folding, all `str.isspace()` characters, and only
+  `{0, o}`, `{1, i, l}`, and `{8, b}` affect string comparison.
+- [ ] 2.4 Prove nonstrings and all retained values remain unchanged.
+
+## 3. Route SDK Matching Through The Functions
+
+- [ ] 3.1 Route every repeated-record identity string key in indexes,
+  partitions, dedupe, thresholds, shortcuts, and direct comparisons through the
+  shared functions while preserving existing typed wrappers.
+- [ ] 3.2 Route relationship string equality through `values_match` while
+  preserving value unwrapping, absence rules, populated-key shape, and stable
+  parent order.
+- [ ] 3.3 Remove the runtime effect of `identity_match.exact_attrs` while
+  preserving metadata validation, preparation, persistence, and readback.
+- [ ] 3.4 Add a narrow routing check that fails if the listed production string
+  matching paths reintroduce a separate case, whitespace, confusable, or exact
+  transform.
+
+## 4. Verify And Release
+
+- [ ] 4.1 Run focused tests, the full pytest suite, mypy, changed-file Ruff,
+  build, line-ending checks, and strict OpenSpec validation.
+- [ ] 4.2 Exercise the Internal Arcadia consumer change against this branch and
+  complete its protected-case and collision gates before publishing.
+- [ ] 4.3 If any existing evidence fails, stop before editing it and obtain human
+  approval for the specific input and behavioral change.
+- [ ] 4.4 After collision approval, merge the implementation and prepare the
+  human release handoff with the merged commit, requested version, validation
+  evidence, and Internal Arcadia as the downstream consumer.

--- a/openspec/changes/add-confusable-identifier-matcher/tasks.md
+++ b/openspec/changes/add-confusable-identifier-matcher/tasks.md
@@ -5,8 +5,7 @@
 - [x] 1.2 Run focused and full test baselines and keep every existing test,
   fixture, expected output, and score unchanged.
 - [x] 1.3 Add new failing tests for both public functions, every approved and
-  rejected string case, nonstring helper rejection, caller-owned nonstring
-  behavior, and raw-value preservation.
+  rejected string case, nonstring helper rejection, and raw-value preservation.
 - [x] 1.4 Add new failing production-entrypoint tests for repeated-record
   identity, advanced identity indexing, `exact_attrs` no-op behavior, populated
   relationship key shape, and stable parent selection.
@@ -21,8 +20,8 @@
   generated top-level SDK files.
 - [x] 2.3 Prove case folding, all `str.isspace()` characters, and only
   `{0, o}`, `{1, i, l}`, and `{8, b}` affect string comparison.
-- [x] 2.4 Prove both helpers reject nonstrings and production callers preserve
-  their existing nonstring comparisons and retained values.
+- [x] 2.4 Prove both helpers reject nonstrings and production callers invoke
+  them only for strings.
 
 ## 3. Route SDK Matching Through The Functions
 
@@ -34,9 +33,9 @@
   parent order.
 - [x] 3.3 Remove the runtime effect of `identity_match.exact_attrs` while
   preserving metadata validation, preparation, persistence, and readback.
-- [ ] 3.4 Add a narrow routing check that fails if the listed production string
-  matching paths reintroduce a separate case, whitespace, confusable, or exact
-  transform.
+- [x] 3.4 Add narrow production-behavior checks that fail if repeated identity
+  or relationship matching reintroduces a separate case, whitespace,
+  confusable, or exact transform.
 
 ## 4. Verify And Release
 

--- a/openspec/changes/add-confusable-identifier-matcher/tasks.md
+++ b/openspec/changes/add-confusable-identifier-matcher/tasks.md
@@ -1,38 +1,38 @@
 ## 1. Freeze Current Behavior
 
-- [ ] 1.1 Record the current GroundX Python ref, open PRs, and the exact
+- [x] 1.1 Record the current GroundX Python ref, open PRs, and the exact
   identity and relationship callers in `custom_outputs.py`.
-- [ ] 1.2 Run focused and full test baselines and keep every existing test,
+- [x] 1.2 Run focused and full test baselines and keep every existing test,
   fixture, expected output, and score unchanged.
-- [ ] 1.3 Add new failing tests for both public functions, every approved and
+- [x] 1.3 Add new failing tests for both public functions, every approved and
   rejected string case, nonstring helper rejection, caller-owned nonstring
   behavior, and raw-value preservation.
-- [ ] 1.4 Add new failing production-entrypoint tests for repeated-record
+- [x] 1.4 Add new failing production-entrypoint tests for repeated-record
   identity, advanced identity indexing, `exact_attrs` no-op behavior, populated
   relationship key shape, and stable parent selection.
 
 ## 2. Add The Shared Functions
 
-- [ ] 2.1 Add `src/groundx/extract/comparison.py` with string-only
+- [x] 2.1 Add `src/groundx/extract/comparison.py` with string-only
   `match_key(value: str) -> str` and
   `values_match(left: str, right: str) -> bool`, explicit nonstring rejection,
   and no matching modes or external dependency.
-- [ ] 2.2 Export both functions from `groundx.extract` without changing
+- [x] 2.2 Export both functions from `groundx.extract` without changing
   generated top-level SDK files.
-- [ ] 2.3 Prove case folding, all `str.isspace()` characters, and only
+- [x] 2.3 Prove case folding, all `str.isspace()` characters, and only
   `{0, o}`, `{1, i, l}`, and `{8, b}` affect string comparison.
-- [ ] 2.4 Prove both helpers reject nonstrings and production callers preserve
+- [x] 2.4 Prove both helpers reject nonstrings and production callers preserve
   their existing nonstring comparisons and retained values.
 
 ## 3. Route SDK Matching Through The Functions
 
-- [ ] 3.1 Route every repeated-record identity string key in indexes,
+- [x] 3.1 Route every repeated-record identity string key in indexes,
   partitions, dedupe, thresholds, shortcuts, and direct comparisons through the
   shared functions while preserving existing typed wrappers.
-- [ ] 3.2 Route relationship string equality through `values_match` while
+- [x] 3.2 Route relationship string equality through `values_match` while
   preserving value unwrapping, absence rules, populated-key shape, and stable
   parent order.
-- [ ] 3.3 Remove the runtime effect of `identity_match.exact_attrs` while
+- [x] 3.3 Remove the runtime effect of `identity_match.exact_attrs` while
   preserving metadata validation, preparation, persistence, and readback.
 - [ ] 3.4 Add a narrow routing check that fails if the listed production string
   matching paths reintroduce a separate case, whitespace, confusable, or exact
@@ -40,11 +40,11 @@
 
 ## 4. Verify And Release
 
-- [ ] 4.1 Run focused tests, the full pytest suite, mypy, changed-file Ruff,
+- [x] 4.1 Run focused tests, the full pytest suite, mypy, changed-file Ruff,
   build, line-ending checks, and strict OpenSpec validation.
 - [ ] 4.2 Exercise the Internal Arcadia consumer change against this branch and
   complete its protected-case and collision gates before publishing.
-- [ ] 4.3 If any existing evidence fails, stop before editing it and obtain human
+- [x] 4.3 If any existing evidence fails, stop before editing it and obtain human
   approval for the specific input and behavioral change.
 - [ ] 4.4 Require the `eyelevel-fern-config`
   `document-universal-identifier-matching` public-docs change to merge before the

--- a/openspec/changes/add-confusable-identifier-matcher/tasks.md
+++ b/openspec/changes/add-confusable-identifier-matcher/tasks.md
@@ -5,20 +5,24 @@
 - [ ] 1.2 Run focused and full test baselines and keep every existing test,
   fixture, expected output, and score unchanged.
 - [ ] 1.3 Add new failing tests for both public functions, every approved and
-  rejected string case, nonstring preservation, and raw-value preservation.
+  rejected string case, nonstring helper rejection, caller-owned nonstring
+  behavior, and raw-value preservation.
 - [ ] 1.4 Add new failing production-entrypoint tests for repeated-record
   identity, advanced identity indexing, `exact_attrs` no-op behavior, populated
   relationship key shape, and stable parent selection.
 
 ## 2. Add The Shared Functions
 
-- [ ] 2.1 Add `src/groundx/extract/comparison.py` with `match_key(value)` and
-  `values_match(left, right)` and no matching modes or external dependency.
+- [ ] 2.1 Add `src/groundx/extract/comparison.py` with string-only
+  `match_key(value: str) -> str` and
+  `values_match(left: str, right: str) -> bool`, explicit nonstring rejection,
+  and no matching modes or external dependency.
 - [ ] 2.2 Export both functions from `groundx.extract` without changing
   generated top-level SDK files.
 - [ ] 2.3 Prove case folding, all `str.isspace()` characters, and only
   `{0, o}`, `{1, i, l}`, and `{8, b}` affect string comparison.
-- [ ] 2.4 Prove nonstrings and all retained values remain unchanged.
+- [ ] 2.4 Prove both helpers reject nonstrings and production callers preserve
+  their existing nonstring comparisons and retained values.
 
 ## 3. Route SDK Matching Through The Functions
 
@@ -42,6 +46,9 @@
   complete its protected-case and collision gates before publishing.
 - [ ] 4.3 If any existing evidence fails, stop before editing it and obtain human
   approval for the specific input and behavioral change.
-- [ ] 4.4 After collision approval, merge the implementation and prepare the
+- [ ] 4.4 Require the `eyelevel-fern-config`
+  `document-universal-identifier-matching` public-docs change to merge before the
+  SDK release.
+- [ ] 4.5 After collision approval, merge the implementation and prepare the
   human release handoff with the merged commit, requested version, validation
   evidence, and Internal Arcadia as the downstream consumer.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -78,8 +78,7 @@ rules:
     - State what the public package surface gains/changes and why; flag any breaking change
       to the published API (semver impact)
     - List downstream consumers (repos that import this package) affected
-    - For a Fern-generated repo: confirm the change targets the hand-written layer only
-      (paths on .fernignore). API-surface changes belong in the generation SOURCE repo, not here.
+    - "For a Fern-generated repo: confirm the change targets the hand-written layer only (paths on .fernignore). API-surface changes belong in the generation SOURCE repo, not here."
     - If open design questions remain after consulting AGENTS.md and existing specs, use the
       superpowers:brainstorming skill; otherwise note "none" in proposal.md
   specs:

--- a/openspec/specs/custom-output-readback/spec.md
+++ b/openspec/specs/custom-output-readback/spec.md
@@ -181,21 +181,19 @@ metadata rather than hardcoded final group names.
   integers, floats, blanks, and missing values
 - **WHEN** the SDK applies relationship metadata
 - **THEN** extracted-field wrappers are compared by their `value`
-- **AND** strings compare case-insensitively
-- **AND** leading and trailing string whitespace is removed before comparison
-- **AND** internal string whitespace remains significant
+- **AND** strings ignore capitalization and every whitespace character
+- **AND** only `{0, o}`, `{1, i, l}`, and `{8, b}` are OCR-equivalent
+- **AND** punctuation, unmapped characters, and remaining length stay significant
 - **AND** integers and floats compare by numeric value
 - **AND** blank or missing fields do not participate
 - **AND** the parent and child only match when they have the same non-empty set
   of present match fields
-- **AND** date-style strings are not normalized by the relationship matcher.
+- **AND** date-style strings receive no special normalization.
 
-Benjamin Fletcher resolved R25b on 2026-08-05: surrounding extraction
-whitespace is formatting noise, not identifier identity. The matcher trims only
-leading and trailing string whitespace. If trimming creates multiple parent
-matches, the tie resolves to the first parent in stable input order: the
-2026-08-17 ruling makes an absent `multiple_match_strategy` default to
-`first_stable`.
+Comparison keys are transient and never replace source or output values. Legacy
+`identity_match.exact_attrs` remains readable but has no runtime effect. If the
+shared comparison creates multiple parent matches, the tie resolves to the
+first parent in stable input order.
 
 #### Scenario: Match attrs without a present key do not match
 

--- a/src/groundx/extract/__init__.py
+++ b/src/groundx/extract/__init__.py
@@ -19,6 +19,7 @@ if typing.TYPE_CHECKING:
         TestXRay,
         XRayDocument,
     )
+    from .comparison import match_key, values_match
     from .custom_outputs import (
         CustomOutputDiagnostic,
         CustomOutputReassemblyResult,
@@ -70,6 +71,7 @@ __all__ = [
     "GroundXSettings",
     "Group",
     "Logger",
+    "match_key",
     "ObjectStore",
     "PreparedExtractionYaml",
     "ProcessResponse",
@@ -85,6 +87,7 @@ __all__ = [
     "TestField",
     "TestXRay",
     "Upload",
+    "values_match",
     "XRayDocument",
     "prepare_extraction_yaml",
     "reassemble_custom_outputs",
@@ -114,6 +117,7 @@ _EXPORT_MODULES = {
     "GroundXSettings": ".settings",
     "Group": ".classes",
     "Logger": ".services",
+    "match_key": ".comparison",
     "ObjectStore": ".prompt.object_store",
     "PreparedExtractionYaml": ".prompt.utility",
     "ProcessResponse": ".classes",
@@ -129,6 +133,7 @@ _EXPORT_MODULES = {
     "TestField": ".classes",
     "TestXRay": ".classes",
     "Upload": ".services",
+    "values_match": ".comparison",
     "XRayDocument": ".classes",
     "prepare_extraction_yaml": ".prompt.utility",
     "reassemble_custom_outputs": ".custom_outputs",

--- a/src/groundx/extract/comparison.py
+++ b/src/groundx/extract/comparison.py
@@ -1,0 +1,15 @@
+_CONFUSABLES = str.maketrans({"o": "0", "i": "1", "l": "1", "b": "8"})
+
+
+def match_key(value: str) -> str:
+    """Return a transient key for extraction identity comparisons."""
+    if not isinstance(value, str):
+        raise TypeError("match_key requires a string")
+    return "".join(character for character in value.casefold() if not character.isspace()).translate(_CONFUSABLES)
+
+
+def values_match(left: str, right: str) -> bool:
+    """Compare two extraction identity strings through :func:`match_key`."""
+    if not isinstance(left, str) or not isinstance(right, str):
+        raise TypeError("values_match requires two strings")
+    return match_key(left) == match_key(right)

--- a/src/groundx/extract/custom_outputs.py
+++ b/src/groundx/extract/custom_outputs.py
@@ -6,6 +6,7 @@ import json
 import numbers
 import typing
 
+from .comparison import match_key, values_match
 from .utility import clean_json
 
 
@@ -329,8 +330,8 @@ def select_relationship_parent(
       populates and every populated value compares equal. The first matching
       parent in stable input order wins.
     * Other relationship metadata does not affect parent selection.
-    * String comparison trims only leading and trailing whitespace before
-      case-insensitive comparison. Ints and floats remain number-normalized.
+    * String comparison ignores capitalization and whitespace and maps the
+      approved OCR-confusable classes. Ints and floats remain number-normalized.
     """
     no_selection = RelationshipParentSelection(parent=None, ambiguous=False)
     if not isinstance(relationship, typing.Mapping):
@@ -355,6 +356,12 @@ def select_relationship_parent(
             parent_value = parent.get(attr)
             if _relationship_value_absent(parent_value):
                 return False
+            parent_unwrapped = _unwrap_match_value(parent_value)
+            child_unwrapped = _unwrap_match_value(child_value)
+            if isinstance(parent_unwrapped, str) and isinstance(child_unwrapped, str):
+                if not values_match(parent_unwrapped, child_unwrapped):
+                    return False
+                continue
             if _relationship_comparison_value(parent_value) != _relationship_comparison_value(child_value):
                 return False
         return True
@@ -1744,6 +1751,10 @@ def _identity_values_match(
     second_absent = _match_value_absent(second)
     if first_absent or second_absent:
         return match_absent and first_absent and second_absent
+    first_unwrapped = _unwrap_match_value(first)
+    second_unwrapped = _unwrap_match_value(second)
+    if isinstance(first_unwrapped, str) and isinstance(second_unwrapped, str):
+        return values_match(first_unwrapped, second_unwrapped)
     return _identity_comparison_value(
         first,
         exact=exact,
@@ -1805,18 +1816,8 @@ def _hashable_identity_value(value: typing.Any, *, exact: bool = False) -> typin
 
 
 def _identity_comparison_value(value: typing.Any, *, exact: bool) -> typing.Any:
-    if not exact:
-        return _normalize_match_value(value)
-    unwrapped = _unwrap_match_value(value)
-    if isinstance(unwrapped, bool):
-        return ("bool", unwrapped)
-    if isinstance(unwrapped, int):
-        return ("number", unwrapped)
-    if isinstance(unwrapped, float):
-        if unwrapped.is_integer():
-            return ("number", int(unwrapped))
-        return ("float", unwrapped)
-    return unwrapped
+    del exact
+    return _normalize_match_value(value)
 
 
 def _identity_exact_attrs(
@@ -2004,8 +2005,7 @@ def _relationship_value_absent(value: typing.Any) -> bool:
 def _relationship_comparison_value(value: typing.Any) -> typing.Any:
     """Normalize a match value for relationship comparison.
 
-    Strings trim only their leading and trailing whitespace before
-    case-insensitive comparison. Ints and floats compare as numbers, and
+    Strings use the shared extraction identity key. Ints and floats compare as numbers, and
     differently-typed values never compare equal. Booleans stay distinct from
     numbers, and structured values compare structurally with the same string
     normalization.
@@ -2018,7 +2018,7 @@ def _relationship_comparison_value(value: typing.Any) -> typing.Any:
     if isinstance(unwrapped, numbers.Real):
         return ("number", float(unwrapped))
     if isinstance(unwrapped, str):
-        return ("string", unwrapped.strip().lower())
+        return ("string", match_key(unwrapped))
     if isinstance(unwrapped, typing.Mapping):
         mapping = typing.cast(typing.Mapping[typing.Any, typing.Any], unwrapped)
         return (
@@ -2044,7 +2044,7 @@ def _relationship_comparison_value(value: typing.Any) -> typing.Any:
 def _normalize_match_value(value: typing.Any) -> typing.Any:
     unwrapped = _unwrap_match_value(value)
     if isinstance(unwrapped, str):
-        return unwrapped.strip().casefold()
+        return match_key(unwrapped)
     if isinstance(unwrapped, bool):
         return ("boolean", unwrapped)
     if isinstance(unwrapped, numbers.Integral):

--- a/tests/extract/test_custom_output_reassembly.py
+++ b/tests/extract/test_custom_output_reassembly.py
@@ -535,7 +535,7 @@ def test_identity_normalization_preserves_large_integer_precision() -> None:
     ],
     ids=["fixed-partition", "threshold-index", "final-comparison"],
 )
-def test_missing_exact_attrs_preserves_exact_legacy_identity(
+def test_exact_attrs_cannot_bypass_universal_identity_matching(
     unique_attrs: list[str],
     identity_match: dict,
     force_final_comparison: bool,
@@ -595,8 +595,7 @@ def test_missing_exact_attrs_preserves_exact_legacy_identity(
             lambda self, record: (1 << len(self.records)) - 1,
         )
 
-    assert reassemble(None) == {"rows": rows}
-    assert reassemble([]) == {
+    expected = {
         "rows": [
             {
                 "fixed_identity": "GROUP-A",
@@ -606,6 +605,8 @@ def test_missing_exact_attrs_preserves_exact_legacy_identity(
             }
         ]
     }
+    assert reassemble(None) == expected
+    assert reassemble([]) == expected
 
 
 def test_advanced_identity_matching_bounds_candidate_comparisons(
@@ -3276,7 +3277,7 @@ def test_duplicate_parents_without_unique_attrs_are_not_collapsed() -> None:
     }
 
 
-def test_compiled_relationship_can_attach_ambiguous_child_to_first_parent() -> None:
+def test_compiled_relationship_dedupes_case_variant_parents_before_attachment() -> None:
     identity_attrs = (
         "record_key",
         "period_start",
@@ -3422,18 +3423,6 @@ def test_compiled_relationship_can_attach_ambiguous_child_to_first_parent() -> N
                         "value": 42,
                     }
                 ],
-            },
-            {
-                "record_key": "p-1",
-                "period_start": "2026-01-01",
-                "period_end": "2026-01-31",
-                "category": "primary",
-                "market_state": "combined",
-                "alternate_account": "A-1",
-                "alternate_provider": "Provider A",
-                "primary_provider": "Provider B",
-                "label": "second",
-                "children": [],
             },
         ],
         "children": [],

--- a/tests/extract/test_identifier_comparison.py
+++ b/tests/extract/test_identifier_comparison.py
@@ -1,0 +1,87 @@
+import pytest
+
+from groundx.extract import match_key, select_relationship_parent, values_match
+from groundx.extract.custom_outputs import _dedupe_repeated_records
+
+
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        ("Meter OIB", "meter018"),
+        ("A\tB\nC", "a8c"),
+        ("I L 1", "111"),
+        ("Straße", "STRASSE"),
+        ("A\u00a0B", "a8"),
+    ],
+)
+def test_match_key_ignores_only_approved_extraction_noise(left: str, right: str) -> None:
+    assert match_key(left) == match_key(right)
+    assert values_match(left, right)
+
+
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        ("AB-12", "AB12"),
+        ("S", "5"),
+        ("Z", "2"),
+        ("AB1", "AB11"),
+    ],
+)
+def test_match_key_preserves_unapproved_differences(left: str, right: str) -> None:
+    assert match_key(left) != match_key(right)
+    assert not values_match(left, right)
+
+
+@pytest.mark.parametrize("value", [None, 1, True, [], {}])
+def test_match_helpers_reject_nonstrings(value: object) -> None:
+    with pytest.raises(TypeError):
+        match_key(value)  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        values_match(value, "1")  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        values_match("1", value)  # type: ignore[arg-type]
+
+
+def test_relationship_parent_selection_uses_shared_string_match_without_rewriting() -> None:
+    first = {"meter_id": "M-OIB"}
+    second = {"meter_id": "M-019"}
+
+    selection = select_relationship_parent(
+        [first, second],
+        {"meter_id": " m-o 1 8 "},
+        {"match_attrs": ["meter_id"]},
+    )
+
+    assert selection.parent is first
+    assert selection.parent["meter_id"] == "M-OIB"
+
+
+def test_repeated_identity_uses_shared_match_even_when_exact_attrs_are_present() -> None:
+    first = {"meter_id": " M-OIB ", "label": "first"}
+    second = {"meter_id": "m-018", "description": "second"}
+
+    deduped = _dedupe_repeated_records(
+        [first, second],
+        ["meter_id"],
+        {
+            "exact_attrs": ["meter_id"],
+            "threshold_attrs": [],
+            "activate_threshold_at": 0,
+            "minimum_threshold_matches": 0,
+        },
+    )
+
+    assert deduped == [
+        {
+            "meter_id": " M-OIB ",
+            "label": "first",
+            "description": "second",
+        }
+    ]
+
+
+def test_repeated_identity_keeps_boolean_and_number_distinct() -> None:
+    records = [{"meter_id": True}, {"meter_id": 1}]
+
+    assert _dedupe_repeated_records(records, ["meter_id"]) == records

--- a/tests/extract/test_identifier_comparison.py
+++ b/tests/extract/test_identifier_comparison.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from groundx.extract import match_key, select_relationship_parent, values_match
@@ -82,6 +84,6 @@ def test_repeated_identity_uses_shared_match_even_when_exact_attrs_are_present()
 
 
 def test_repeated_identity_keeps_boolean_and_number_distinct() -> None:
-    records = [{"meter_id": True}, {"meter_id": 1}]
+    records: list[dict[str, Any]] = [{"meter_id": True}, {"meter_id": 1}]
 
     assert _dedupe_repeated_records(records, ["meter_id"]) == records

--- a/tests/extract/test_identifier_comparison.py
+++ b/tests/extract/test_identifier_comparison.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import pytest
 
 from groundx.extract import match_key, select_relationship_parent, values_match
@@ -81,9 +79,3 @@ def test_repeated_identity_uses_shared_match_even_when_exact_attrs_are_present()
             "description": "second",
         }
     ]
-
-
-def test_repeated_identity_keeps_boolean_and_number_distinct() -> None:
-    records: list[dict[str, Any]] = [{"meter_id": True}, {"meter_id": 1}]
-
-    assert _dedupe_repeated_records(records, ["meter_id"]) == records

--- a/tests/extract/test_relationship_parent_selection.py
+++ b/tests/extract/test_relationship_parent_selection.py
@@ -54,10 +54,18 @@ def test_matches_equal_populated_values(parents, child) -> None:
     assert _select(parents, child).parent is parents[0]
 
 
+def test_matches_internal_whitespace_variants_without_rewriting_parent() -> None:
+    parent = {"meter_number": "M 1"}
+
+    selection = _select([parent], {"meter_number": "M  1"})
+
+    assert selection.parent is parent
+    assert selection.parent["meter_number"] == "M 1"
+
+
 @pytest.mark.parametrize(
     ("parent_value", "child_value"),
     [
-        ("M 1", "M  1"),
         ("12", 12),
         (True, 1),
         ("2026-1-2", "2026-01-02"),


### PR DESCRIPTION
## Summary
- Add public match_key and values_match string helpers.
- Apply them to repeated-record identity and relationship selection.
- Make legacy identity_match.exact_attrs compatibility-only.
- Preserve raw values and caller-owned nonstring behavior.

## Verification
- 599 passed, 5 skipped.
- Ruff, mypy, package build, line endings, and strict OpenSpec passed.
- Internal Arcadia focused tests and the four protected consumer cases passed.

## Release
Merge eyelevelai/eyelevel-fern-config#58 first, then release GroundX Python 3.9.19. eyelevelai/internal-arcadia-agents#136 must pin that release before merge.