### PR TITLE
Preserve native boolean extraction fields

### DIFF
--- a/openspec/specs/extracted-value-coercion/spec.md
+++ b/openspec/specs/extracted-value-coercion/spec.md
@@ -8,9 +8,9 @@ hand-written extraction SDK.
 ### Requirement: The SDK provides one schema-driven coercion contract
 
 The hand-written extraction SDK SHALL expose one helper that accepts a JSON
-value and an optional declared type of `str`, `int`, `float`, `list`, `dict`, or
-a list of those types, and returns the selected value, match status, conversion
-status, and an optional content-free warning.
+value and an optional declared type of `str`, `int`, `float`, `bool`, `list`,
+`dict`, or a list of those types, and returns the selected value, match status,
+conversion status, and an optional content-free warning.
 
 #### Scenario: Value already matches the declared type
 
@@ -56,6 +56,17 @@ value.
 The helper SHALL convert scalar JSON values according to one shared matrix.
 Exact type checks SHALL prevent Python booleans from matching integer or float
 targets before conversion.
+
+#### Scenario: Native boolean targets bool
+
+- **WHEN** `true` or `false` is supplied for a `bool` target
+- **THEN** the helper returns the same native boolean without conversion.
+
+#### Scenario: Non-boolean targets bool
+
+- **WHEN** a string, number, list, or object is supplied for a `bool` target
+- **THEN** the helper returns null, marks it unmatched, and returns a warning
+- **AND** it does not guess truthiness.
 
 #### Scenario: Boolean targets a string
 
@@ -183,8 +194,8 @@ conversion logic. Existing date normalization SHALL remain separate.
 
 #### Scenario: Null remains null for every declared type
 
-- **WHEN** a field is missing or conversion to `str`, `int`, `float`, `list`, or
-  `dict` is impossible
+- **WHEN** a field is missing or conversion to `str`, `int`, `float`, `bool`,
+  `list`, or `dict` is impossible
 - **THEN** the field remains present with a null value through field readback and
   typed output serialization
 - **AND** the SDK does not replace null with an empty string, list, or dict.

--- a/src/groundx/extract/classes/field.py
+++ b/src/groundx/extract/classes/field.py
@@ -150,6 +150,8 @@ class ExtractedField(Element):
             elif isinstance(self.prompt.type, str):
                 if self.prompt.type == "int" or self.prompt.type == "float":
                     format = "number (float or int)"
+                elif self.prompt.type == "bool":
+                    format = "native JSON boolean"
                 elif self.prompt.type == "str":
                     format = "string"
             else:

--- a/src/groundx/extract/utility/utility.py
+++ b/src/groundx/extract/utility/utility.py
@@ -16,6 +16,7 @@ _SUPPORTED_TYPES: typing.Dict[str, typing.Type[typing.Any]] = {
     "str": str,
     "int": int,
     "float": float,
+    "bool": bool,
     "list": list,
     "dict": dict,
 }

--- a/tests/extract/classes/test_field.py
+++ b/tests/extract/classes/test_field.py
@@ -27,6 +27,8 @@ class TestExtractedField(unittest.TestCase):
     def test_supported_types_use_shared_coercion(self):
         cases = [
             ("str_field", "str", True, "true"),
+            ("bool_field", "bool", True, True),
+            ("false_bool_field", "bool", False, False),
             ("int_field", "int", "3.9", 3),
             ("float_field", "float", "1,234.5", 1234.5),
             ("list_field", "list", '[1,"two"]', [1, "two"]),
@@ -38,6 +40,11 @@ class TestExtractedField(unittest.TestCase):
                 self.assertEqual(field.get_value(), expected)
                 self.assertIs(type(field.get_value()), type(expected))
                 self.assertIsNone(field.coercion_warning)
+
+    def test_bool_render_requires_native_json_boolean(self):
+        field = typed_field("enabled", "bool", False)
+
+        self.assertIn("Format:                 native JSON boolean", field.render())
 
     def test_missing_and_impossible_values_remain_null(self):
         for target in ["str", "int", "float", "list", "dict"]:

--- a/tests/extract/classes/test_prompt.py
+++ b/tests/extract/classes/test_prompt.py
@@ -43,6 +43,13 @@ class TestPromptValidValue(unittest.TestCase):
         self.assertFalse(p.valid_value((1, 2, 3)))
         self.assertFalse(p.valid_value([1, 2, 3]))
 
+    def test_single_type_bool(self):
+        p = TestPrompt("field1", "bool")
+        self.assertTrue(p.valid_value(True))
+        self.assertTrue(p.valid_value(False))
+        self.assertFalse(p.valid_value(1))
+        self.assertFalse(p.valid_value("true"))
+
     def test_single_type_list(self):
         p = TestPrompt("field1", "list")
         self.assertFalse(p.valid_value("hello"))

--- a/tests/extract/utility/test_utility.py
+++ b/tests/extract/utility/test_utility.py
@@ -86,6 +86,8 @@ class TestUtilCoerceValue(unittest.TestCase):
     def test_exact_values_and_null_are_preserved(self) -> None:
         cases: typing.List[typing.Tuple[typing.Any, typing.Union[str, typing.List[str]]]] = [
             ("text", "str"),
+            (True, "bool"),
+            (False, "bool"),
             (7, "int"),
             (7.5, "float"),
             ([1], "list"),
@@ -99,6 +101,18 @@ class TestUtilCoerceValue(unittest.TestCase):
         self.assert_result(coerce_value(None, "str"), None, type(None), True, False)
         self.assert_result(coerce_value(None, ["int", "float"]), None, type(None), True, False)
         self.assert_result(coerce_value({"a": 1}), {"a": 1}, dict, True, False)
+
+    def test_bool_accepts_only_native_booleans(self) -> None:
+        values: typing.Tuple[typing.Any, ...] = ("true", "false", 0, 1, [], {})
+        for value in values:
+            with self.subTest(value=value):
+                self.assert_result(
+                    coerce_value(value, "bool"),
+                    None,
+                    type(None),
+                    False,
+                    False,
+                )
 
     def test_null_in_declared_type_unions(self) -> None:
         cases: typing.List[typing.Tuple[typing.Any, typing.List[str]]] = [


### PR DESCRIPTION
## Summary

- add exact native bool support to the hand-written extraction coercer
- reject string, numeric, and container truthiness conversions
- render bool fields as native JSON booleans
- update the coercion contract and focused regressions

## Verification

- 520 extraction tests passed, 1 skipped
- mypy: no issues in 261 source files
- Ruff, line endings, strict OpenSpec, and diff checks passed

## Release handoff

After merge, the human release owner should publish groundx 4.0.1 from commit 994d6c0105db3f8d9b50074c76c6fcdab698e558. Internal Arcadia must pin and deploy that release before Cashbot advertises the bool authoring type.

AGE-326