### PR TITLE
fix(extract): preserve final record evidence lineage

### DIFF
--- a/src/groundx/extract/__init__.py
+++ b/src/groundx/extract/__init__.py
@@ -22,6 +22,7 @@ if typing.TYPE_CHECKING:
     from .comparison import match_key, values_match
     from .custom_outputs import (
         CustomOutputDiagnostic,
+        CustomOutputFinalRecordProvenance,
         CustomOutputReassemblyResult,
         CustomOutputScalarCandidate,
         CustomOutputScalarCandidateSet,
@@ -57,6 +58,7 @@ __all__ = [
     "ContainerSettings",
     "ContainerUploadSettings",
     "CustomOutputDiagnostic",
+    "CustomOutputFinalRecordProvenance",
     "CustomOutputReassemblyResult",
     "CustomOutputScalarCandidate",
     "CustomOutputScalarCandidateSet",
@@ -103,6 +105,7 @@ _EXPORT_MODULES = {
     "ContainerSettings": ".settings",
     "ContainerUploadSettings": ".settings",
     "CustomOutputDiagnostic": ".custom_outputs",
+    "CustomOutputFinalRecordProvenance": ".custom_outputs",
     "CustomOutputReassemblyResult": ".custom_outputs",
     "CustomOutputScalarCandidate": ".custom_outputs",
     "CustomOutputScalarCandidateSet": ".custom_outputs",

--- a/src/groundx/extract/custom_outputs.py
+++ b/src/groundx/extract/custom_outputs.py
@@ -33,6 +33,12 @@ class CustomOutputSourceProvenance:
 
 
 @dataclasses.dataclass(frozen=True)
+class CustomOutputFinalRecordProvenance:
+    final_path: str
+    page_numbers: typing.Tuple[int, ...] = ()
+
+
+@dataclasses.dataclass(frozen=True)
 class CustomOutputScalarCandidate:
     value: typing.Any
     page_numbers: typing.Tuple[int, ...] = ()
@@ -68,6 +74,7 @@ class CustomOutputReassemblyResult:
     diagnostics: typing.List[CustomOutputDiagnostic]
     workflow_output: typing.Dict[str, typing.Any] = dataclasses.field(default_factory=dict)
     source_provenance: typing.List[CustomOutputSourceProvenance] = dataclasses.field(default_factory=list)
+    final_record_provenance: typing.List[CustomOutputFinalRecordProvenance] = dataclasses.field(default_factory=list)
     scalar_candidate_sets: typing.List[CustomOutputScalarCandidateSet] = dataclasses.field(default_factory=list)
 
 
@@ -97,6 +104,14 @@ class _RouteContainer:
     identity: typing.Tuple[typing.Any, ...]
     value: typing.Any
     page_numbers: typing.Tuple[int, ...] = ()
+
+
+class _LineagedRecord(dict[str, typing.Any]):
+    page_numbers: typing.Tuple[int, ...]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.page_numbers = ()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -285,12 +300,27 @@ def reassemble_custom_outputs_from_xray(
             )
         )
 
+    final_record_provenance = _final_record_provenance(final_output)
+    plain_final_output = typing.cast(
+        typing.Dict[str, typing.Any],
+        _plain_output(final_output),
+    )
+    plain_relationship_output = (
+        typing.cast(
+            typing.Dict[str, typing.Any],
+            _plain_output(relationship_output),
+        )
+        if relationship_output is not None
+        else None
+    )
+
     return CustomOutputReassemblyResult(
-        final_output=final_output,
-        relationship_output=relationship_output,
+        final_output=plain_final_output,
+        relationship_output=plain_relationship_output,
         diagnostics=diagnostics,
         workflow_output=workflow_output,
         source_provenance=source_provenance,
+        final_record_provenance=final_record_provenance,
         scalar_candidate_sets=_public_scalar_candidate_sets(scalar_candidates),
     )
 
@@ -832,9 +862,10 @@ def _set_pointer(
         item_key = (tuple(list_path), record_key)
         record = repeated_records.get(item_key)
         if record is None:
-            record = {}
+            record = _LineagedRecord()
             repeated_records[item_key] = record
             records.append(record)
+        _add_record_pages(record, page_numbers)
 
         field_path = parts[star_index + 1 :]
         if field_path:
@@ -848,9 +879,10 @@ def _set_pointer(
         item_key = ((parts[0],), record_key)
         record = repeated_records.get(item_key)
         if record is None:
-            record = {}
+            record = _LineagedRecord()
             repeated_records[item_key] = record
             records.append(record)
+        _add_record_pages(record, page_numbers)
         if len(parts) > 1:
             _set_nested_value(record, parts[1:], value)
         return
@@ -916,6 +948,51 @@ def _merge_page_numbers(
     second: typing.Sequence[int],
 ) -> typing.Tuple[int, ...]:
     return tuple(dict.fromkeys((*first, *second)))
+
+
+def _add_record_pages(
+    record: typing.MutableMapping[str, typing.Any],
+    page_numbers: typing.Sequence[int],
+) -> None:
+    if isinstance(record, _LineagedRecord):
+        record.page_numbers = _merge_page_numbers(
+            record.page_numbers,
+            page_numbers,
+        )
+
+
+def _final_record_provenance(
+    output: typing.Mapping[str, typing.Any],
+) -> typing.List[CustomOutputFinalRecordProvenance]:
+    provenance: typing.List[CustomOutputFinalRecordProvenance] = []
+
+    def visit(value: typing.Any, parts: typing.Tuple[str, ...]) -> None:
+        if isinstance(value, list):
+            for index, item in enumerate(value):
+                item_parts = (*parts, str(index))
+                if isinstance(item, _LineagedRecord):
+                    provenance.append(
+                        CustomOutputFinalRecordProvenance(
+                            final_path=_encode_pointer(item_parts),
+                            page_numbers=item.page_numbers,
+                        )
+                    )
+                visit(item, item_parts)
+            return
+        if isinstance(value, typing.Mapping):
+            for key, item in value.items():
+                visit(item, (*parts, str(key)))
+
+    visit(output, ())
+    return provenance
+
+
+def _plain_output(value: typing.Any) -> typing.Any:
+    if isinstance(value, typing.Mapping):
+        return {key: _plain_output(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_plain_output(item) for item in value]
+    return copy.deepcopy(value)
 
 
 def _public_scalar_candidate_sets(
@@ -1889,6 +1966,11 @@ def _merge_identity_record(
     target: typing.Dict[str, typing.Any],
     source: typing.Mapping[str, typing.Any],
 ) -> None:
+    if isinstance(target, _LineagedRecord) and isinstance(source, _LineagedRecord):
+        target.page_numbers = _merge_page_numbers(
+            target.page_numbers,
+            source.page_numbers,
+        )
     for key, value in source.items():
         if key not in target or _match_value_absent(target.get(key)):
             target[key] = copy.deepcopy(value)

--- a/tests/extract/test_custom_output_reassembly.py
+++ b/tests/extract/test_custom_output_reassembly.py
@@ -1098,6 +1098,114 @@ def test_relationship_places_rows_deduped_by_explicit_unique_attrs() -> None:
     assert result.relationship_output == result.final_output
 
 
+def test_final_record_provenance_follows_dedupe_and_relationship_placement() -> None:
+    workflow_extract = {
+        "_groundx_persisted_extract": {
+            "charges": {
+                "match_attrs": ["meter_number"],
+                "unique_attrs": ["description", "amount"],
+            }
+        },
+        "workflow": {
+            "custom_steps": [
+                {"name": "meter_rows", "level": "chunk", "kind": "keys"},
+                {"name": "charge_rows", "level": "chunk", "kind": "keys"},
+            ],
+            "output_routes": [
+                {
+                    "workflow_group": "meters",
+                    "workflow_field": "meter_number",
+                    "final_path": "/meters/*/meter_number",
+                    "step_name": "meter_rows",
+                    "level": "chunk",
+                    "output_map": "customChunkOutputs",
+                    "output_key": "meter_number",
+                },
+                *[
+                    {
+                        "workflow_group": "charges",
+                        "workflow_field": field,
+                        "final_path": f"/charges/*/{field}",
+                        "step_name": "charge_rows",
+                        "level": "chunk",
+                        "output_map": "customChunkOutputs",
+                        "output_key": field,
+                    }
+                    for field in ("meter_number", "description", "amount")
+                ],
+            ],
+            "output_relationships": [
+                {
+                    "parent_group": "meters",
+                    "child_group": "charges",
+                    "parent_output_field": "charges",
+                    "match_attrs": ["meter_number"],
+                    "unmatched_child_group": "charges",
+                }
+            ],
+        },
+    }
+    xray = {
+        "chunks": [
+            {
+                "chunkId": "meter",
+                "pageNumbers": [1],
+                "customChunkOutputs": {"meter_rows": {"_records": [{"meter_number": "M-1"}]}},
+            },
+            *[
+                {
+                    "chunkId": f"charge-{page_number}",
+                    "pageNumbers": [page_number],
+                    "customChunkOutputs": {"charge_rows": {"_records": [charge]}},
+                }
+                for page_number, charge in (
+                    (
+                        2,
+                        {
+                            "meter_number": "M-1",
+                            "description": "Energy",
+                            "amount": 10,
+                        },
+                    ),
+                    (
+                        3,
+                        {
+                            "meter_number": "M-1",
+                            "description": "Energy",
+                            "amount": 10,
+                        },
+                    ),
+                    (
+                        4,
+                        {
+                            "meter_number": "M-1",
+                            "description": "Demand",
+                            "amount": 20,
+                        },
+                    ),
+                )
+            ],
+        ]
+    }
+
+    result = reassemble_custom_outputs_from_xray(
+        xray,
+        workflow_extract=workflow_extract,
+    )
+
+    assert [
+        {
+            "final_path": provenance.final_path,
+            "page_numbers": provenance.page_numbers,
+        }
+        for provenance in getattr(result, "final_record_provenance", [])
+    ] == [
+        {"final_path": "/meters/0", "page_numbers": (1,)},
+        {"final_path": "/meters/0/charges/0", "page_numbers": (2, 3)},
+        {"final_path": "/meters/0/charges/1", "page_numbers": (4,)},
+    ]
+
+
 def test_relationship_roles_support_the_same_declared_value_types() -> None:
     parent_group = "generic_parent_records"
     child_group = "generic_child_records"
@@ -2072,6 +2180,17 @@ def test_identical_section_payloads_on_different_pages_are_not_collapsed() -> No
         ],
     }
     assert [provenance.page_numbers for provenance in result.source_provenance] == [(1,), (2,)]
+    assert [provenance.record_index for provenance in result.source_provenance] == [0, 0]
+    assert [
+        {
+            "final_path": provenance.final_path,
+            "page_numbers": provenance.page_numbers,
+        }
+        for provenance in getattr(result, "final_record_provenance", [])
+    ] == [
+        {"final_path": "/sections/0", "page_numbers": (1,)},
+        {"final_path": "/sections/1", "page_numbers": (2,)},
+    ]
 
 
 def test_singular_section_route_preserves_candidates_and_pages_across_shared_section_id() -> None:
@@ -3079,8 +3198,10 @@ def test_duplicate_scalar_observations_merge_pages_for_selected_and_every_altern
 
 
 def test_scalar_candidate_sidecar_types_are_public_exports() -> None:
+    assert "CustomOutputFinalRecordProvenance" in extract.__all__
     assert "CustomOutputScalarCandidate" in extract.__all__
     assert "CustomOutputScalarCandidateSet" in extract.__all__
+    assert extract.CustomOutputFinalRecordProvenance is custom_outputs.CustomOutputFinalRecordProvenance
     assert extract.CustomOutputScalarCandidate is custom_outputs.CustomOutputScalarCandidate
     assert extract.CustomOutputScalarCandidateSet is custom_outputs.CustomOutputScalarCandidateSet
 


### PR DESCRIPTION
## Summary

Add an extraction-only `final_record_provenance` sidecar that maps each final repeated-record JSON pointer to its source pages after existing deduplication and relationship placement. Extracted values, final output shape, matching, deduplication, and relationship behavior remain unchanged.

This fixes consumers treating page-local source record indexes as final record positions.

## Validation

- 77 custom-output reassembly tests pass
- Reused page-local indexes produce distinct final record paths
- Deduped records union source pages
- Child lineage follows relationship placement
- Ruff and formatting checks pass
- Line-ending check passes

## Release handoff

After merge, release as GroundX Python 4.0.2. Internal Arcadia PR #149 must pin that exact version before certification.