### PR TITLE
Fix typed JSON agent response parsing

### DIFF
--- a/src/groundx/extract/agents/agent.py
+++ b/src/groundx/extract/agents/agent.py
@@ -202,6 +202,19 @@ def _unwrap_response(
     value: typing.Any,
     expected_types: typing.Union[type, typing.Tuple[type, ...]],
 ) -> typing.Any:
+    if type(value) is dict and set(value) == {"answer"}:
+        answer = value["answer"]
+        if (
+            type(answer) is dict
+            and set(answer) == {"type", "description"}
+            and answer["type"] in {"array", "object"}
+            and isinstance(answer["description"], str)
+        ):
+            decoded = json.loads(clean_json(answer["description"]))
+            labeled_type = list if answer["type"] == "array" else dict
+            if type(decoded) is not labeled_type:
+                _raise_response_type_error(decoded, labeled_type)
+            return decoded
     if (
         type(value) is list
         and not _matches_expected_type(value, expected_types)
@@ -227,7 +240,9 @@ def process_response(
 ) -> typing.Any:
     candidate = res
     if not _matches_expected_type(candidate, expected_types):
-        if type(candidate) is list and _expects_dict(expected_types) and len(candidate) == 1:
+        if type(candidate) is dict:
+            pass
+        elif type(candidate) is list and _expects_dict(expected_types) and len(candidate) == 1:
             pass
         elif isinstance(candidate, str):
             candidate = json.loads(clean_json(candidate))

--- a/tests/extract/agents/test_agent_response_reliability.py
+++ b/tests/extract/agents/test_agent_response_reliability.py
@@ -71,6 +71,65 @@ def test_process_response_parses_agent_text_string_subclass() -> None:
     assert process_response(response, dict) == {"ok": True}
 
 
+@pytest.mark.parametrize(
+    ("response_type", "description", "expected_type", "expected"),
+    [
+        ("array", '[{"meter_number":"M-1"}]', list, [{"meter_number": "M-1"}]),
+        ("object", '{"amount_due":12.34}', dict, {"amount_due": 12.34}),
+    ],
+)
+def test_process_response_decodes_exact_typed_description_envelope(
+    response_type: str,
+    description: str,
+    expected_type: type,
+    expected: typing.Any,
+) -> None:
+    response = {
+        "answer": {
+            "type": response_type,
+            "description": description,
+        }
+    }
+
+    assert process_response(response, expected_type) == expected
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"answer": {"type": "array", "description": '{"ok":true}'}},
+        {"answer": {"type": "object", "description": "[]"}},
+        {"answer": {"type": "array", "description": "not json"}},
+        {
+            "answer": {
+                "type": "array",
+                "description": "[]",
+                "unexpected": True,
+            }
+        },
+        {
+            "answer": {
+                "type": "array",
+                "description": "[]",
+            },
+            "unexpected": True,
+        },
+    ],
+)
+def test_process_response_rejects_ambiguous_typed_description_envelope(
+    response: typing.Dict[str, typing.Any],
+) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        process_response(response, (dict, list))
+
+
+def test_process_response_rejects_typed_description_value_of_unexpected_type() -> None:
+    response = {"answer": {"type": "array", "description": "[]"}}
+
+    with pytest.raises(TypeError):
+        process_response(response, dict)
+
+
 def test_agent_tool_retries_one_parser_failure_without_ordinary_output(
     monkeypatch,
     capsys,


### PR DESCRIPTION
## Summary

Accept the exact typed-description response envelope observed from a supported Bedrock model, then pass its decoded JSON value to the existing caller validation. Reject malformed, mislabeled, extra-key, and wrong-type variants. Raw responses and existing envelopes are unchanged.

## Tests

- `PYTHONPATH=$PWD/src poetry run pytest -q`, 614 passed, 2 skipped
- `poetry run mypy src/groundx/extract/agents/agent.py tests/extract/agents/test_agent_response_reliability.py`
- `poetry run ruff check src/groundx/extract/agents/agent.py tests/extract/agents/test_agent_response_reliability.py`
- `poetry run ruff format --check src/groundx/extract/agents/agent.py tests/extract/agents/test_agent_response_reliability.py`
- `scripts/check-line-endings.sh --all`