### PR TITLE
Bind fixtures to field comparison registry

### DIFF
--- a/tests/extract/fixtures/extraction-fixture-pack/fixture-pack.json
+++ b/tests/extract/fixtures/extraction-fixture-pack/fixture-pack.json
@@ -580,9 +580,9 @@
   },
   "owner": "groundx-python",
   "registry_binding": {
-    "method": "build",
-    "registry_digest": "2003245371a6a0f3be3d212756c01cc60c66200e212cc4a8ef1e9b5ce5fc7e8b",
-    "registry_sha256": "b181e780ca894e5de293ff95460a1c7e740a1e33e282bd9b58e7342c79d5d907",
+    "method": "guarded_migration",
+    "registry_digest": "4f0347b2f9057f9af65a41d557dc8be619a62c892621c9822c5a5f208e3832b9",
+    "registry_sha256": "888e77f51da9b331303ea080df118cdcf5d00d3e3263b8f54e8f62d629a7f659",
     "schema_version": "extraction_fixture_registry_binding_v1"
   },
   "review": {

--- a/tests/extract/fixtures/extraction-fixture-pack/fixture-pack.json
+++ b/tests/extract/fixtures/extraction-fixture-pack/fixture-pack.json
@@ -581,8 +581,8 @@
   "owner": "groundx-python",
   "registry_binding": {
     "method": "guarded_migration",
-    "registry_digest": "4f0347b2f9057f9af65a41d557dc8be619a62c892621c9822c5a5f208e3832b9",
-    "registry_sha256": "888e77f51da9b331303ea080df118cdcf5d00d3e3263b8f54e8f62d629a7f659",
+    "registry_digest": "7fc31e434f036e6c3735c72ba9741703e5ee2336f8aeaed44de2b069f5dc1e3b",
+    "registry_sha256": "c3bfab337f92347ae99924b036fd41ad379fd9026e734488abf6ac050bf39b3e",
     "schema_version": "extraction_fixture_registry_binding_v1"
   },
   "review": {


### PR DESCRIPTION
Bind the approved extraction fixture pack to the selection-list and field-comparison policy registry in [Harness PR217](https://github.com/EyeLevel-ai/groundx-studio-harness/pull/217).

The guarded migration changes only registry metadata. Payload hashes, cases, candidate identity and original review approval are unchanged. The owner's production-path fixture replay passed before and after migration. The final migration receipt is recorded in PR217 at `openspec/changes/restore-selection-list-scoring/receipts/comparison-profile-registry-migration.json`.

Review and merge with PR217 after its fresh certification gate passes.
